### PR TITLE
add space after `\A, \E` for use by humans, translate accordingly in TLATeX

### DIFF
--- a/tlatools/src/pcal/PcalBuiltInSymbols.java
+++ b/tlatools/src/pcal/PcalBuiltInSymbols.java
@@ -166,9 +166,9 @@ public final class PcalBuiltInSymbols
         add("]",   "]",           Symbol.RIGHT_PAREN, 0);
         add(">>",  "{\\rangle}",  Symbol.RIGHT_PAREN, 0);
 
-        add("\\A",         "\\A\\,",          Symbol.PREFIX, 0);
+        add("\\A",         "\\forall\\,",     Symbol.PREFIX, 0);
         add("\\forall",    "\\forall\\,",     Symbol.PREFIX, 0);
-        add("\\E",         "\\E\\,",          Symbol.PREFIX, 0);
+        add("\\E",         "\\exists\\,",     Symbol.PREFIX, 0);
         add("\\exists",    "\\exists\\,",     Symbol.PREFIX, 0);
         add("\\AA",        "{\\AA}",         Symbol.PREFIX, 0);
         add("\\EE",        "{\\EE}",         Symbol.PREFIX, 0);

--- a/tlatools/src/tla2tex/BuiltInSymbols.java
+++ b/tlatools/src/tla2tex/BuiltInSymbols.java
@@ -282,9 +282,9 @@ public final class BuiltInSymbols
         add("]",   "]",           Symbol.RIGHT_PAREN, 0);
         add(">>",  "{\\rangle}",  Symbol.RIGHT_PAREN, 0);
 
-        add("\\A",         "\\A\\,",          Symbol.PREFIX, 0);
+        add("\\A",         "\\forall\\,",     Symbol.PREFIX, 0);
         add("\\forall",    "\\forall\\,",     Symbol.PREFIX, 0);
-        add("\\E",         "\\E\\,",          Symbol.PREFIX, 0);
+        add("\\E",         "\\exists\\,",     Symbol.PREFIX, 0);
         add("\\exists",    "\\exists\\,",     Symbol.PREFIX, 0);
         add("\\AA",        "{\\AA}",         Symbol.PREFIX, 0);
         add("\\EE",        "{\\EE}",         Symbol.PREFIX, 0);

--- a/tlatools/src/tla2tex/tlatex.sty
+++ b/tlatools/src/tla2tex/tlatex.sty
@@ -47,8 +47,8 @@
 \newcommand{\stst}{*\!*}
 \newcommand{\slsl}{/\!/}
 \newcommand{\ct}{\hat{\hspace{.4em}}}
-\newcommand{\A}{\forall}
-\newcommand{\E}{\exists}
+\newcommand{\A}{\forall\,}
+\newcommand{\E}{\exists\,}
 \renewcommand{\AA}{\makebox{$\raisebox{.05em}{\makebox[0pt][l]{%
    $\forall\hspace{-.517em}\forall\hspace{-.517em}\forall$}}%
    \forall\hspace{-.517em}\forall \hspace{-.517em}\forall\,$}}


### PR DESCRIPTION
TLATeX translates:

``` tla
\A -> \A\,
\forall -> \forall\,
```

and `tlatex.sty` defines:

`\A` as `\forall`

However, a human using `tlatex.sty` to write TLA+ directly in LaTeX  (without calling TLATeX, for example loading `tlatex.sty` via `tla2texplus-book.sty`) gets quantifiers that are very close to the bound variables.
One could redefine `\A` in the preamble, but that won't work for using both TLATeX and human-written TLA+ math in the same LaTeX document.
(The patches to `tla2texplus-book.sty` that I considered won't work for both humans and TLATeX.)

Instead, I would like to suggest the TLATeX translation:

``` tla
\A -> \forall\,
\forall -> \forall\,
```

and the `tlatex.sty` definition:

`\A` as `\forall\,` (same as in `tla2.sty`)

This works for both humans (who can type the "high level" `\A`) and TLATeX (which generates the "low level" `\forall`). Moreover, anyone who wants greater control over spacing can still define custom operators using `\forall` (or redefine `\A`).

Similar changes have been made for `\E`.

### A slightly different approach

I considered the alternative:

```latex
\usepackage{amsopn}
\DeclareMathOperator{\A}{\forall}
\DeclareMathOperator{\E}{\exists}
```

This introduces the same amount of horizontal space after each operator as `\,`.
However, it introduces also some space before each operator, so the typeset document would change. Besides, it depends on the `amsopn` package.