### PR TITLE
88 level node add temporal level constraint to constants

### DIFF
--- a/tlatools/src/tla2sany/explorer/ExploreNode.java
+++ b/tlatools/src/tla2sany/explorer/ExploreNode.java
@@ -21,7 +21,8 @@ public interface ExploreNode {
     * descendant foo.                                                      *
     ***********************************************************************/
   public String levelDataToString();
-  public void   walkGraph(Hashtable semNodesTable);
+
+  public void   walkGraph(Hashtable<Integer, ExploreNode> semNodesTable);
     /***********************************************************************
     * This method is apparently supposed to insert an entry in             *
     * semNodesTable for itself and every descendant in the semantic tree   *

--- a/tlatools/src/tla2sany/semantic/AnyDefNode.java
+++ b/tlatools/src/tla2sany/semantic/AnyDefNode.java
@@ -39,14 +39,14 @@ public interface AnyDefNode {
     public boolean getOpLevelCond(int i, int j, int k) ;
     public int getLevel() ;
     public int getWeight(int i) ;
-    public HashSet getLevelParams() ;
-    public HashSet getAllParams() ;
-    public HashSet getNonLeibnizParams() ;
+    public HashSet<SymbolNode> getLevelParams() ;
+    public HashSet<SymbolNode> getAllParams() ;
+    public HashSet<SymbolNode> getNonLeibnizParams() ;
     public int getArity() ;
     public boolean[] getIsLeibnizArg() ;
     public boolean getIsLeibniz() ;
     public SetOfLevelConstraints getLevelConstraints() ;
-    public HashSet getArgLevelParams() ;
+    public HashSet<ArgLevelParam> getArgLevelParams() ;
     public SetOfArgLevelConstraints getArgLevelConstraints() ;
     public FormalParamNode[] getParams() ;
 }

--- a/tlatools/src/tla2sany/semantic/AssumeNode.java
+++ b/tlatools/src/tla2sany/semantic/AssumeNode.java
@@ -5,11 +5,10 @@ package tla2sany.semantic;
 import java.util.HashSet;
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
-
-import tla2sany.xml.XMLExportable;
-import org.w3c.dom.Attr;
+import tla2sany.xml.SymbolContext;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -81,6 +80,7 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
 
   /* Level checking */
   int levelChecked = 0 ;
+  @Override
   public final boolean levelCheck(int iter) {
     if (levelChecked >= iter) {return true ;} ;
     levelChecked = iter;
@@ -103,33 +103,40 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
     return res;
   }
 
+  @Override
   public final int getLevel() {
     return this.assumeExpr.getLevel();
   }
 
-  public final HashSet getLevelParams() {
+  @Override
+  public final HashSet<SymbolNode> getLevelParams() {
     return this.assumeExpr.getLevelParams();
   }
 
-  public final HashSet getAllParams() {
+  @Override
+  public final HashSet<SymbolNode> getAllParams() {
     return this.assumeExpr.getAllParams();
   }
 
+  @Override
   public final SetOfLevelConstraints getLevelConstraints() {
     return this.assumeExpr.getLevelConstraints();
   }
 
+  @Override
   public final SetOfArgLevelConstraints getArgLevelConstraints() {
     return this.assumeExpr.getArgLevelConstraints();
   }
 
-  public final HashSet getArgLevelParams() {
+  @Override
+  public final HashSet<ArgLevelParam> getArgLevelParams() {
     return this.assumeExpr.getArgLevelParams();
   }
 
   /**
    * toString(), levelDataToString(), and walkGraph() methods
    */
+  @Override
   public final String levelDataToString() {
     return "Level: "               + getLevel()               + "\n" +
            "LevelParameters: "     + getLevelParams()         + "\n" +
@@ -143,6 +150,7 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
    * interface; depth parameter is a bound on the depth of the portion
    * of the tree that is displayed.
    */
+  @Override
   public final String toString (int depth) {
     if (depth <= 0) return "";
     String res =
@@ -165,6 +173,7 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
    * The assume expression is the node's only child.
    */
 
+  @Override
   public SemanticNode[] getChildren() {
     return new SemanticNode[] {this.assumeExpr};
   }
@@ -174,7 +183,8 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
    * inserts them in the Hashtable semNodesTable for use by the
    * Explorer tool.
    */
-  public final void walkGraph (Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph (Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
 
     if (semNodesTable.get(uid) != null) return;
@@ -185,7 +195,7 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
 
   /* MR: This is the same as SymbolNode.exportDefinition. Exports the actual theorem content, not only a reference.
    */
-  public Element exportDefinition(Document doc, tla2sany.xml.SymbolContext context) {
+  public Element exportDefinition(Document doc, SymbolContext context) {
     if (!context.isTop_level_entry())
       throw new IllegalArgumentException("Exporting theorem ref "+getNodeRef()+" twice!");
     context.resetTop_level_entry();
@@ -226,7 +236,8 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
 //      return getDef().export(doc,context);
 //  }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("AssumeNode");
     if (def != null) {
       //if there is a definition, export it too
@@ -242,7 +253,8 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
   }
 
   /* overrides LevelNode.export and exports a UID reference instad of the full version*/
-  public Element export(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  public Element export(Document doc, SymbolContext context) {
     // first add symbol to context
     context.put(this, doc);
     Element e = doc.createElement(getNodeRef());

--- a/tlatools/src/tla2sany/semantic/AssumeProveNode.java
+++ b/tlatools/src/tla2sany/semantic/AssumeProveNode.java
@@ -6,8 +6,10 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -191,6 +193,7 @@ public class AssumeProveNode extends LevelNode {
   * compute the level-related fields for an OpApplNode.  This seems        *
   * reasonable, but I don't know if it's really correct.  -   LL           *
   *************************************************************************/
+  @Override
   public boolean levelCheck(int iter) {
     /***********************************************************************
     * Return immediately if this this.levelCheck(i) has already been       *
@@ -337,6 +340,7 @@ public class AssumeProveNode extends LevelNode {
   /**
    * The children of this node are the assumes and prove expressions.
    */
+  @Override
   public SemanticNode[] getChildren() {
      SemanticNode[] res = new SemanticNode[this.assumes.length + 1];
      res[assumes.length] = this.prove;
@@ -346,7 +350,8 @@ public class AssumeProveNode extends LevelNode {
      return res;
   }
 
-  public final void walkGraph(Hashtable h) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> h) {
     Integer uid = new Integer(myUID);
     if (h.get(uid) != null) return;
     h.put(uid, this);
@@ -363,6 +368,7 @@ public class AssumeProveNode extends LevelNode {
    * Displays this node as a String, implementing ExploreNode interface; depth
    * parameter is a bound on the depth of the portion of the tree that is displayed.
    */
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     String assumeStr = "" ;
@@ -385,7 +391,8 @@ public class AssumeProveNode extends LevelNode {
   * End fields and methods implementing the ExplorerNode interface:        *
   *************************************************************************/
 
-  public Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  public Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("AssumeProveNode");
     Element antecedent = doc.createElement("assumes");
     Element succedent = doc.createElement("prove");

--- a/tlatools/src/tla2sany/semantic/AtNode.java
+++ b/tlatools/src/tla2sany/semantic/AtNode.java
@@ -4,7 +4,9 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -72,6 +74,7 @@ public class AtNode extends ExprNode {
 //  private SetOfArgLevelConstraints argLevelConstraints;
 //  private HashSet argLevelParams;
 
+  @Override
   public final boolean levelCheck(int iter) {
     if (this.levelChecked >= iter) return true;
     this.levelChecked = iter;
@@ -147,7 +150,8 @@ public class AtNode extends ExprNode {
    * walkGraph finds all reachable nodes in the semantic graph
    * and inserts them in the Hashtable semNodesTable for use by the Explorer tool.
    */
-  public final void walkGraph(Hashtable h) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> h) {
   // Empty because there are no nodes reachable through an AtNode that are not
   // reachable by other paths through the semantic graph.
   } // end walkGraph()
@@ -157,6 +161,7 @@ public class AtNode extends ExprNode {
    * Displays this node as a String, implementing ExploreNode interface; depth
    * parameter is a bound on the depth of the portion of the tree that is displayed.
    */
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     return "\n*AtNode: " + super.toString(depth) +
@@ -164,7 +169,8 @@ public class AtNode extends ExprNode {
                              "\nExceptComponent: " + exceptComponentRef.getUid());
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("AtNode");
     SemanticNode exceptObj = exceptRef.getArgs()[0];
     SemanticNode exceptComponents = exceptComponentRef.getArgs()[0];

--- a/tlatools/src/tla2sany/semantic/Context.java
+++ b/tlatools/src/tla2sany/semantic/Context.java
@@ -506,11 +506,11 @@ public class Context implements ExploreNode {
     return ctxtEntries;
   }
 
-  public void walkGraph(Hashtable semNodesTable) {
+  public void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     UniqueString key;
-    Enumeration  Enum = table.keys();
+    Enumeration<?>  e = table.keys();
 
-    while (Enum.hasMoreElements()) {
+    while (e.hasMoreElements()) {
       /*********************************************************************
       * Bug fix attempted by LL on 19 Apr 2007.                            *
       *                                                                    *
@@ -524,7 +524,7 @@ public class Context implements ExploreNode {
       * getContextEntryStringVector later on.  I decided to stop wasting   *
       * time on this.                                                      *
       *********************************************************************/
-      Object next = Enum.nextElement();
+      Object next = e.nextElement();
       if (next instanceof SymbolTable.ModuleName) {
          key = ((SymbolTable.ModuleName) next).name ;
          System.out.println("Bug in debugging caused by inner module " +

--- a/tlatools/src/tla2sany/semantic/DecimalNode.java
+++ b/tlatools/src/tla2sany/semantic/DecimalNode.java
@@ -5,7 +5,9 @@ package tla2sany.semantic;
 import java.math.BigDecimal;
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -67,9 +69,11 @@ public class DecimalNode extends ExprNode {
    * Returns the value as a string, exactly the way the user typed it--e.g.,
    * without any normalization, removal of leading or trailing zero's, etc.
    */
+  @Override
   public final String toString() { return this.image; }
 
   /* Level checking */
+  @Override
   public final boolean levelCheck(int iter) {
     levelChecked = iter;
       /*********************************************************************
@@ -109,11 +113,12 @@ public class DecimalNode extends ExprNode {
    * inserts them in the Hashtable semNodesTable for use by the
    * Explorer tool.
    */
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
   }
 
   /**
@@ -121,6 +126,7 @@ public class DecimalNode extends ExprNode {
    * interface; depth parameter is a bound on the depth of the portion
    * of the tree that is displayed.
    */
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     return( "\n*DecimalNode" + super.toString(depth) + "Mantissa: "
@@ -130,7 +136,8 @@ public class DecimalNode extends ExprNode {
           );
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("DecimalNode");
     if (bigVal != null) {
       e.appendChild(appendText(doc,"mantissa",bigVal.unscaledValue().toString()));

--- a/tlatools/src/tla2sany/semantic/DefStepNode.java
+++ b/tlatools/src/tla2sany/semantic/DefStepNode.java
@@ -3,8 +3,10 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -47,6 +49,7 @@ public class DefStepNode extends LevelNode {
   public UniqueString getStepNumber() {return stepNumber ;}
   public OpDefNode[] getDefs() {return defs;}
 
+  @Override
   public boolean levelCheck(int iter) {
     /***********************************************************************
     * Level check the steps and the instantiated modules coming from       *
@@ -55,15 +58,17 @@ public class DefStepNode extends LevelNode {
     return this.levelCheckSubnodes(iter, defs) ;
    }
 
-  public void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     for (int  i = 0; i < defs.length; i++) {
       defs[i].walkGraph(semNodesTable);
       } ;
    }
 
+  @Override
   public SemanticNode[] getChildren() {
       SemanticNode[] res = new SemanticNode[defs.length];
       for (int i = 0; i < defs.length; i++) {
@@ -71,6 +76,8 @@ public class DefStepNode extends LevelNode {
       }
       return res;
    }
+  
+  @Override
   public String toString(int depth) {
     if (depth <= 0) return "";
     String ret = "\n*DefStepNode:\n"
@@ -82,7 +89,8 @@ public class DefStepNode extends LevelNode {
     return ret;
    }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
       Element e = doc.createElement("DefStepNode");
       for (int i=0; i<defs.length;i++) {
         e.appendChild(defs[i].export(doc,context));

--- a/tlatools/src/tla2sany/semantic/ExternalModuleTable.java
+++ b/tlatools/src/tla2sany/semantic/ExternalModuleTable.java
@@ -49,7 +49,7 @@ public class ExternalModuleTable implements ExploreNode {
      */
     public String levelDataToString() { return "Dummy level string"; }
 
-    public void walkGraph(Hashtable moduleNodesTable) {
+    public void walkGraph(Hashtable<Integer, ExploreNode> moduleNodesTable) {
       if (moduleNode != null)   moduleNode.walkGraph(moduleNodesTable);
       if (ctxt != null)      ctxt.walkGraph(moduleNodesTable);
     } // end walkGraph()
@@ -137,6 +137,7 @@ public class ExternalModuleTable implements ExploreNode {
     }
   }
 
+  @Override
   public String toString() {
     Enumeration Enum = moduleHashTable.elements();
     String ret = "";
@@ -186,7 +187,7 @@ public class ExternalModuleTable implements ExploreNode {
     return ret;
   }
 
-  public void walkGraph(Hashtable moduleNodesTable) {
+  public void walkGraph(Hashtable<Integer, ExploreNode> moduleNodesTable) {
     Enumeration Enum = moduleHashTable.elements();
 
     while ( Enum.hasMoreElements() ) {

--- a/tlatools/src/tla2sany/semantic/FormalParamNode.java
+++ b/tlatools/src/tla2sany/semantic/FormalParamNode.java
@@ -4,7 +4,9 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -67,6 +69,7 @@ public class FormalParamNode extends SymbolNode {
   /* Level checking */
 //  private HashSet levelParams;
 
+  @Override
   public final boolean levelCheck(int iter) {
     if (levelChecked == 0) {
       /*********************************************************************
@@ -111,13 +114,15 @@ public class FormalParamNode extends SymbolNode {
 //           "ArgLevelParams: "      + this.getArgLevelParams()      + "\n" ;
 //  }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     return ("\n*FormalParamNode: " + this.getName().toString() +
@@ -128,7 +133,7 @@ public class FormalParamNode extends SymbolNode {
     return "FormalParamNodeRef";
   }
 
-  protected Element getSymbolElement(Document doc, tla2sany.xml.SymbolContext context) {
+  protected Element getSymbolElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("FormalParamNode");
     e.appendChild(appendText(doc,"uniquename",getName().toString()));
     e.appendChild(appendText(doc,"arity",Integer.toString(getArity())));

--- a/tlatools/src/tla2sany/semantic/LabelNode.java
+++ b/tlatools/src/tla2sany/semantic/LabelNode.java
@@ -46,6 +46,7 @@ import tla2sany.parser.SyntaxTreeNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 import util.WrongInvocationException;
 
@@ -214,6 +215,7 @@ public class LabelNode extends ExprNode
   /*************************************************************************
   * Level-Checking.                                                        *
   *************************************************************************/
+  @Override
   public final boolean levelCheck(int iter) {
     if (levelChecked >= iter) {return true ;} ;
     levelChecked = iter;
@@ -224,37 +226,43 @@ public class LabelNode extends ExprNode
     return this.body.levelCheck(iter) && retVal ;
   }
 
+  @Override
   public final int getLevel() {
     if (levelChecked == 0)
       {throw new WrongInvocationException("getLevel called for TheoremNode before levelCheck");};
     return this.body.getLevel();
   }
 
-  public final HashSet getLevelParams() {
+  @Override
+  public final HashSet<SymbolNode> getLevelParams() {
     if (levelChecked == 0)
       {throw new WrongInvocationException("getLevelParams called for ThmNode before levelCheck");};
     return this.body.getLevelParams();
   }
 
-  public final HashSet getAllParams() {
+  @Override
+  public final HashSet<SymbolNode> getAllParams() {
     if (levelChecked == 0)
       {throw new WrongInvocationException("getAllParams called for ThmNode before levelCheck");};
     return this.body.getAllParams();
   }
 
+  @Override
   public final SetOfLevelConstraints getLevelConstraints() {
     if (levelChecked == 0)
        {throw new WrongInvocationException("getLevelConstraints called for ThmNode before levelCheck");};
     return this.body.getLevelConstraints();
   }
 
+  @Override
   public final SetOfArgLevelConstraints getArgLevelConstraints() {
     if (levelChecked == 0)
       {throw new WrongInvocationException("getArgLevelConstraints called for ThmNode before levelCheck");};
     return this.body.getArgLevelConstraints();
   }
 
-  public final HashSet getArgLevelParams() {
+  @Override
+  public final HashSet<ArgLevelParam> getArgLevelParams() {
     if (levelChecked == 0)
       {throw new WrongInvocationException("getArgLevelParams called for ThmNode before levelCheck");};
     return this.body.getArgLevelParams();
@@ -266,22 +274,25 @@ public class LabelNode extends ExprNode
    *
    * @see tla2sany.semantic.SemanticNode#getChildren()
    */
+  @Override
   public SemanticNode[] getChildren() {
       return new SemanticNode[] { this.body };
   }
   /*************************************************************************
   * The methods for implementing the ExploreNode interface.                *
   *************************************************************************/
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     if (body != null) body.walkGraph(semNodesTable);
     for (int i = 0 ; i < params.length; i++) {
       params[i].walkGraph(semNodesTable);
      } ;
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     String ret = "\n*LabelNode: " + super.toString(depth);
@@ -319,7 +330,8 @@ public class LabelNode extends ExprNode
     return ret;
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
       Element ret = doc.createElement("LabelNode");
       ret.appendChild(appendText(doc,"uniquename",getName().toString()));
       ret.appendChild(appendText(doc,"arity",Integer.toString(getArity())));

--- a/tlatools/src/tla2sany/semantic/LeafProofNode.java
+++ b/tlatools/src/tla2sany/semantic/LeafProofNode.java
@@ -3,8 +3,10 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -70,6 +72,7 @@ public class LeafProofNode extends ProofNode {
   public boolean getOmitted() {return omitted ;} ;
   public boolean getOnlyFlag() {return isOnly ;} ;
 
+  @Override
   public boolean levelCheck(int iter) {
     /***********************************************************************
     * Level checking is performed by level-checking the facts.  Since the  *
@@ -84,6 +87,7 @@ public class LeafProofNode extends ProofNode {
    * The children are the facts.
    * @see tla2sany.semantic.SemanticNode#getChildren()
    */
+  @Override
   public SemanticNode[] getChildren() {
       if (this.facts == null || this.facts.length == 0) {
           return null;
@@ -95,10 +99,11 @@ public class LeafProofNode extends ProofNode {
       return res;
    }
 
-  public void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     for (int  i = 0; i < facts.length; i++) {
       facts[i].walkGraph(semNodesTable);
       } ;
@@ -108,6 +113,7 @@ public class LeafProofNode extends ProofNode {
     ***********************************************************************/
    }
 
+  @Override
   public String toString(int depth) {
     if (depth <= 0) return "";
     String ret = "\n*LeafProofNode:\n"
@@ -125,7 +131,8 @@ public class LeafProofNode extends ProofNode {
     return ret;
    }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e;
 
     if (getOmitted()) {

--- a/tlatools/src/tla2sany/semantic/LetInNode.java
+++ b/tlatools/src/tla2sany/semantic/LetInNode.java
@@ -10,6 +10,7 @@ import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -106,6 +107,8 @@ implements ExploreNode, LevelConstants {
 //  private SetOfArgLevelConstraints argLevelConstraints;
 //  private HashSet argLevelParams;
 
+  @Override
+  @SuppressWarnings("unchecked")
   public final boolean levelCheck(int itr) {
     if (this.levelChecked >= itr) return this.levelCorrect;
     levelChecked = itr ;
@@ -141,8 +144,8 @@ implements ExploreNode, LevelConstants {
     * the aliasing of the levelParams and allParams fields of this node    *
     * and its body to the same HashSets, but it doesn't hurt to be safe.   *
     ***********************************************************************/
-    this.levelParams = (HashSet) this.body.getLevelParams().clone();
-    this.allParams   = (HashSet) this.body.getAllParams().clone();
+    this.levelParams = (HashSet<SymbolNode>)this.body.getLevelParams().clone();
+    this.allParams   = (HashSet<SymbolNode>) this.body.getAllParams().clone();
 
 //    this.levelConstraints = new SetOfLevelConstraints();
     this.levelConstraints.putAll(this.body.getLevelConstraints());
@@ -173,9 +176,9 @@ implements ExploreNode, LevelConstants {
         if (this.opDefs[i].getKind() != ThmOrAssumpDefKind){
           params = ((OpDefNode) this.opDefs[i]).getParams();
           } ;
-        Iterator iter = this.opDefs[i].getArgLevelParams().iterator();
+        Iterator<ArgLevelParam> iter = this.opDefs[i].getArgLevelParams().iterator();
         while (iter.hasNext()) {
-          ArgLevelParam alp = (ArgLevelParam)iter.next();
+          ArgLevelParam alp = iter.next();
           if (!alp.occur(params)) {
             this.argLevelParams.add(alp);
           }
@@ -219,6 +222,7 @@ implements ExploreNode, LevelConstants {
 //           "ArgLevelParams: "      + this.argLevelParams      + "\n" ;
 //  }
 
+  @Override
   public SemanticNode[] getChildren() {
       SemanticNode[] res =
          new SemanticNode[this.opDefs.length + this.insts.length + 1];
@@ -233,12 +237,13 @@ implements ExploreNode, LevelConstants {
       return res;
    }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
 
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
 
     /***********************************************************************
     * Can now walk LET nodes from context, don't need to use opDefs        *
@@ -253,6 +258,7 @@ implements ExploreNode, LevelConstants {
     if (body != null) body.walkGraph(semNodesTable);
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
 
@@ -286,8 +292,8 @@ implements ExploreNode, LevelConstants {
     return ret;
   }
 
-
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element ret = doc.createElement("LetInNode");
     ret.appendChild(appendElement(doc,"body",body.export(doc,context)));
     Element arguments = doc.createElement("opDefs");

--- a/tlatools/src/tla2sany/semantic/LevelNode.java
+++ b/tlatools/src/tla2sany/semantic/LevelNode.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 import util.WrongInvocationException;
 
 import org.w3c.dom.Document;
@@ -63,10 +64,10 @@ public class LevelNode extends SemanticNode {
 ***************************************************************************/
 public boolean                   levelCorrect        = true ;
 public int                       level               = ConstantLevel ;
-public HashSet                   levelParams         = new HashSet() ;
+public HashSet<SymbolNode>       levelParams         = new HashSet<>() ;
 public SetOfLevelConstraints     levelConstraints    = new SetOfLevelConstraints();
 public SetOfArgLevelConstraints  argLevelConstraints = new SetOfArgLevelConstraints();
-public HashSet                   argLevelParams      = new HashSet() ;
+public HashSet<ArgLevelParam>    argLevelParams      = new HashSet<>() ;
 
 /***************************************************************************
 * The following HashSets are used in computing Leibnizity.                 *
@@ -80,8 +81,8 @@ public HashSet                   argLevelParams      = new HashSet() ;
 * See the file leibniz-checking.txt, appended below, for an explanation    *
 * of Leibnizity and Leibniz checking.                                      *
 ***************************************************************************/
-public HashSet                   allParams           = new HashSet() ;
-public HashSet                   nonLeibnizParams    = new HashSet() ;
+public HashSet<SymbolNode>       allParams           = new HashSet<>() ;
+public HashSet<SymbolNode>       nonLeibnizParams    = new HashSet<>() ;
 
 public int levelChecked   = 0 ;
   /*************************************************************************
@@ -178,11 +179,11 @@ public int levelChecked   = 0 ;
   * instantiated by a temporal formula.  Added by LL on 1 Mar 2009         *
   *************************************************************************/
   static void addTemporalLevelConstraintToConstants(
-                 HashSet params,
+                 HashSet<SymbolNode> params,
                  SetOfLevelConstraints constrs ) {
-      Iterator iter = params.iterator();
+      Iterator<SymbolNode> iter = params.iterator();
       while (iter.hasNext()) {
-        LevelNode node = (LevelNode) iter.next() ;
+        SymbolNode node = iter.next() ;
         if (node.getKind() == ConstantDeclKind) {
           constrs.put(node, Levels[ActionLevel]);
          };
@@ -198,7 +199,7 @@ public int levelChecked   = 0 ;
     return this.level;
   }
 
-  public HashSet getLevelParams(){
+  public HashSet<SymbolNode> getLevelParams(){
     /***********************************************************************
     * Seems to return a HashSet of OpDeclNode objects.  Presumably, these  *
     * are the parameters from the local context that contribute to the     *
@@ -209,7 +210,7 @@ public int levelChecked   = 0 ;
     return this.levelParams;
    }
 
-  public HashSet getAllParams(){
+  public HashSet<SymbolNode> getAllParams(){
     /***********************************************************************
     * Returns a HashSet of OpDeclNode objects, which are the parameters    *
     * from the local context that appear within the object.                *
@@ -219,7 +220,7 @@ public int levelChecked   = 0 ;
     return this.allParams;
    }
 
-  public HashSet getNonLeibnizParams(){
+  public HashSet<SymbolNode> getNonLeibnizParams(){
     /***********************************************************************
     * Returns a HashSet of OpDeclNode objects, which is the subset of      *
     * parameters returned by getAllParams() that appear within a           *
@@ -254,7 +255,7 @@ public int levelChecked   = 0 ;
     return this.argLevelConstraints;
    }
 
-  public HashSet getArgLevelParams(){
+  public HashSet<ArgLevelParam> getArgLevelParams(){
     /***********************************************************************
     * Seems to return a HashSet of ArgLevelParam objects.  (See            *
     * ArgLevelParam.java for an explanation of those objects.)             *
@@ -278,32 +279,32 @@ public int levelChecked   = 0 ;
        "NonLeibnizParams: "    + HashSetToString(this.getNonLeibnizParams()) ;
     }
 
-  public static String HashSetToString(HashSet hs) {
+  public static String HashSetToString(HashSet<SymbolNode> hs) {
     /***********************************************************************
     * Converts a HashSet of SymbolNodes to a printable string.             *
     ***********************************************************************/
     String rval = "{" ;
     boolean first = true ;
-    Iterator iter = hs.iterator();
+    Iterator<SymbolNode> iter = hs.iterator();
     while (iter.hasNext()) {
       if (! first) {rval = rval + ", ";} ;
-      rval = rval + ((SymbolNode) iter.next()).getName() ;
+      rval = rval + iter.next().getName() ;
       first = false ;
      } ;
     rval = rval + "}" ;
     return rval ;
    }
 
-  public static String ALPHashSetToString(HashSet hs) {
+  public static String ALPHashSetToString(HashSet<ArgLevelParam> hs) {
     /***********************************************************************
     * Converts a HashSet of ArgLevelParam objects to a printable string.   *
     ***********************************************************************/
     String rval = "{" ;
     boolean first = true ;
-    Iterator iter = hs.iterator();
+    Iterator<ArgLevelParam> iter = hs.iterator();
     while (iter.hasNext()) {
       if (! first) {rval = rval + ", ";} ;
-      ArgLevelParam alp = (ArgLevelParam) iter.next();
+      ArgLevelParam alp = iter.next();
       rval = rval + "<" + alp.op.getName() + ", " + alp.i + ", " +
                      alp.param.getName() + ">" ;
       first = false;
@@ -322,7 +323,8 @@ public int levelChecked   = 0 ;
     return this.defaultLevelDataToString() ;}
 
 
-  protected Element getSemanticElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getSemanticElement(Document doc, SymbolContext context) {
       // T.L. abstract method used to add data from subclasses
       Element e = getLevelElement(doc, context); //SymbolElement.getLevelElement is not supposed to be called
       try {
@@ -338,7 +340,7 @@ public int levelChecked   = 0 ;
      * T.L. October 2014
      * Abstract method for subclasses of LevelNode to add their information
      * */
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  protected Element getLevelElement(Document doc, SymbolContext context) {
       throw new UnsupportedOperationException("xml export is not yet supported for: " + getClass() + " with toString: " + toString(100));
     }
 

--- a/tlatools/src/tla2sany/semantic/ModuleNode.java
+++ b/tlatools/src/tla2sany/semantic/ModuleNode.java
@@ -16,9 +16,11 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 import util.WrongInvocationException;
 
@@ -680,6 +682,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
 //  private SetOfArgLevelConstraints argLevelConstraints;
 //  private HashSet argLevelParams;
 
+  @Override
   public final boolean levelCheck(int itr) {
 
     if (levelChecked >= itr) return this.levelCorrect;
@@ -948,6 +951,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     return this.levelCorrect;
   }
 
+  @Override
   public final int getLevel() {
       throw new WrongInvocationException("Internal Error: Should never call ModuleNode.getLevel()");
   }
@@ -1023,6 +1027,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
    * walkGraph, levelDataToString, and toString methods to implement
    * ExploreNode interface
    */
+  @Override
   public final String levelDataToString() {
     return "LevelParams: "         + getLevelParams()         + "\n" +
            "LevelConstraints: "    + getLevelConstraints()    + "\n" +
@@ -1031,6 +1036,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
   }
 
   private SemanticNode[] children = null;
+  @Override
   public SemanticNode[] getChildren() {
       if (children != null) {
           return children;
@@ -1047,7 +1053,8 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
       return children;
    }
 
-  public final void walkGraph (Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph (Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
 
     if (semNodesTable.get(uid) != null) return;
@@ -1087,6 +1094,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     }
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
 
@@ -1149,7 +1157,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     return "ModuleNodeRef";
   }
 
-  protected Element getSymbolElement(Document doc, tla2sany.xml.SymbolContext context) {
+  protected Element getSymbolElement(Document doc, SymbolContext context) {
     Element ret = doc.createElement("ModuleNode");
     ret.appendChild(appendText(doc, "uniquename", getName().toString()));
 

--- a/tlatools/src/tla2sany/semantic/NewSymbNode.java
+++ b/tlatools/src/tla2sany/semantic/NewSymbNode.java
@@ -21,8 +21,10 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -84,6 +86,7 @@ public class NewSymbNode extends LevelNode {
   * level of the `set' expression, if it's non-null.  Any other level      *
   * information comes from the `set' expression.                           *
   *************************************************************************/
+  @Override
   public boolean levelCheck(int iter)       {
 
     if (levelChecked < iter) {
@@ -157,6 +160,7 @@ public class NewSymbNode extends LevelNode {
    * The body is the node's only child.
    */
 
+  @Override
   public SemanticNode[] getChildren() {
     if (this.set == null) {
         return null;
@@ -165,13 +169,15 @@ public class NewSymbNode extends LevelNode {
     }
   }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     if (set != null) { set.walkGraph(semNodesTable); } ;
    }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     String setString = "" ;
@@ -187,7 +193,8 @@ public class NewSymbNode extends LevelNode {
              setString);
    }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("NewSymbNode");
     e.appendChild(getOpDeclNode().export(doc,context));
     if (getSet() != null) {

--- a/tlatools/src/tla2sany/semantic/NonLeafProofNode.java
+++ b/tlatools/src/tla2sany/semantic/NonLeafProofNode.java
@@ -3,9 +3,11 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -141,6 +143,7 @@ public class NonLeafProofNode extends ProofNode {
   public LevelNode[] getSteps()   {return steps ;}
   public Context     getContext() {return context ;}
 
+  @Override
   public boolean levelCheck(int iter) {
     /***********************************************************************
     * Level check the steps and the instantiated modules coming from       *
@@ -157,6 +160,7 @@ public class NonLeafProofNode extends ProofNode {
    * The children are the steps.
    * @see tla2sany.semantic.SemanticNode#getChildren()
    */
+  @Override
   public SemanticNode[] getChildren() {
       if (this.steps == null || this.steps.length == 0) {
           return null;
@@ -168,10 +172,11 @@ public class NonLeafProofNode extends ProofNode {
       return res;
    }
 
-  public void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     for (int  i = 0; i < steps.length; i++) {
       steps[i].walkGraph(semNodesTable);
       } ;
@@ -186,6 +191,7 @@ public class NonLeafProofNode extends ProofNode {
       *********************************************************************/
    }
 
+  @Override
   public String toString(int depth) {
     if (depth <= 0) return "";
     String ret = "\n*ProofNode:\n"
@@ -211,7 +217,8 @@ public class NonLeafProofNode extends ProofNode {
     return ret;
    }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("steps");
 
     for (int i=0; i< steps.length; i++) {

--- a/tlatools/src/tla2sany/semantic/NumeralNode.java
+++ b/tlatools/src/tla2sany/semantic/NumeralNode.java
@@ -5,7 +5,9 @@ package tla2sany.semantic;
 import java.math.BigInteger;
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -70,9 +72,11 @@ public class NumeralNode extends ExprNode {
    * reflects how the value appeared in the input, so it should be
    * "\O7777" if that's what appears in the source.
    */
+  @Override
   public final String toString() { return this.image; }
 
   /* Level Checking */
+  @Override
   public final boolean levelCheck(int iter) {
     levelChecked = iter;
       /*********************************************************************
@@ -107,13 +111,15 @@ public class NumeralNode extends ExprNode {
 //           "ArgLevelParams: "      + this.getArgLevelParams()      + "\n" ;
 //  }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
 
@@ -122,7 +128,8 @@ public class NumeralNode extends ExprNode {
 	   "; image: " + image);
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
       String v = (bigValue != null) ? bigValue.toString() : (Integer.toString(value));
       Element e = doc.createElement("IntValue");
       Node n = doc.createTextNode(v);

--- a/tlatools/src/tla2sany/semantic/OpArgNode.java
+++ b/tlatools/src/tla2sany/semantic/OpArgNode.java
@@ -7,13 +7,14 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.parser.SyntaxTreeNode;
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 
 /**
  * This class represents operators of arity > 0 used as arguments to
@@ -66,6 +67,7 @@ public class OpArgNode extends ExprOrOpArgNode {
   public final ModuleNode   getModule()    { return this.mn; }
 
   /* Level check */
+  @Override
   public final boolean levelCheck(int iter) {
     if (levelChecked >= iter) {return this.levelCorrect; } ;
     levelChecked = iter ;
@@ -109,11 +111,12 @@ public class OpArgNode extends ExprOrOpArgNode {
 //           "ArgLevelParams: "      + this.getArgLevelParams()      + "\n" ;
 //  }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
 
     /***********************************************************************
     * Modified on 28 Mar 2007 by LL to walk the operator node of the       *
@@ -126,6 +129,7 @@ public class OpArgNode extends ExprOrOpArgNode {
     if (op != null) {op.walkGraph(semNodesTable) ;} ;
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
 
@@ -135,7 +139,8 @@ public class OpArgNode extends ExprOrOpArgNode {
       "  op: " + (op != null ? "" + ((SemanticNode)op).getUid() : "null" );
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("OpArgNode");
     Element n = doc.createElement("argument");
     //Element ope = op.getSymbolElement(doc, context);

--- a/tlatools/src/tla2sany/semantic/OpDeclNode.java
+++ b/tlatools/src/tla2sany/semantic/OpDeclNode.java
@@ -7,7 +7,9 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -85,6 +87,7 @@ public class OpDeclNode extends OpDefOrDeclNode {
 
 //  private HashSet levelParams;
 
+  @Override
   public final boolean levelCheck(int iter) {
     /***********************************************************************
     * Level information set by constructor.                                *
@@ -136,12 +139,14 @@ public class OpDeclNode extends OpDefOrDeclNode {
 //           "ArgLevelParams: "      + this.getArgLevelParams()      + "\n";
 //  }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
   }
 
+  @Override
   public final String toString (int depth) {
     if (depth <= 0) return "";
     return "\n*OpDeclNode: " + this.getName() + "  " + super.toString(depth)
@@ -156,7 +161,7 @@ public class OpDeclNode extends OpDefOrDeclNode {
     return "OpDeclNodeRef";
   }
 
-  protected Element getSymbolElement(Document doc, tla2sany.xml.SymbolContext context) {
+  protected Element getSymbolElement(Document doc, SymbolContext context) {
     Element e = doc.createElement("OpDeclNode");
     e.appendChild(appendText(doc,"uniquename",getName().toString()));
     e.appendChild(appendText(doc,"arity",Integer.toString(getArity())));

--- a/tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -35,11 +35,13 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.parser.SyntaxTreeNode;
 import tla2sany.st.Location;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 import util.WrongInvocationException;
 
@@ -945,6 +947,7 @@ public class OpDefNode extends OpDefOrDeclNode
 //    this.argLevelParams      = EmptySet;
   }
 
+  @Override
   public final boolean levelCheck(int itr) {
     if (   (this.levelChecked >= itr)
         || (    (! inRecursiveSection)
@@ -1144,6 +1147,7 @@ public class OpDefNode extends OpDefOrDeclNode
    * toString, levelDataToString, and walkGraph methods to implement
    * ExploreNode interface
    */
+  @Override
   public final String levelDataToString() {
     if (   (this.getKind() == ModuleInstanceKind)
         || (this.getKind() == NumberedProofStepKind)) {return "";} ;
@@ -1210,6 +1214,7 @@ public class OpDefNode extends OpDefOrDeclNode
    * The body is the node's only child.
    */
 
+  @Override
   public SemanticNode[] getChildren() {
     return new SemanticNode[] {this.body};
   }
@@ -1219,7 +1224,8 @@ public class OpDefNode extends OpDefOrDeclNode
    * and inserts them in the Hashtable semNodesTable for use by
    * the Explorer tool.
    */
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
     semNodesTable.put(uid, this);
@@ -1237,6 +1243,7 @@ public class OpDefNode extends OpDefOrDeclNode
    * interface; depth parameter is a bound on the depth of the portion
    * of the tree that is displayed.
    */
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
 
@@ -1323,7 +1330,7 @@ public class OpDefNode extends OpDefOrDeclNode
     }
   }
 
-  protected Element getSymbolElement(Document doc, tla2sany.xml.SymbolContext context) {
+  protected Element getSymbolElement(Document doc, SymbolContext context) {
     Element ret = null;
     switch (getKind()) {
       case UserDefinedOpKind:

--- a/tlatools/src/tla2sany/semantic/SemanticNode.java
+++ b/tlatools/src/tla2sany/semantic/SemanticNode.java
@@ -25,7 +25,7 @@ import util.ToolIO;
  * used to check for equality.
  */
 public abstract class SemanticNode
- implements ASTConstants, ExploreNode, LevelConstants, Comparable, XMLExportable /* interface for exporting into XML */ {
+ implements ASTConstants, ExploreNode, LevelConstants, Comparable<SemanticNode>, XMLExportable /* interface for exporting into XML */ {
 
   private static final Object[] EmptyArr = new Object[0];
 
@@ -176,10 +176,10 @@ public abstract class SemanticNode
    * of walkgraph is to find all reachable nodes in the semantic graph
    * and insert them in a Hashtable for use by the Explorer tool.
    */
-  public void walkGraph(Hashtable semNodesTable) {
+  public void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
   }
 
   /**
@@ -211,9 +211,9 @@ public abstract class SemanticNode
    * @param s2
    * @return
    */
-  public int compareTo(Object s) {
+  public int compareTo(SemanticNode s) {
        Location loc1 = this.stn.getLocation();
-       Location loc2 = ((SemanticNode) s).stn.getLocation();
+       Location loc2 = s.stn.getLocation();
        if (loc1.beginLine() < loc2.beginLine())
         {
            return -1;
@@ -242,6 +242,7 @@ public abstract class SemanticNode
 	  }
   }
 
+  @Override
   public String toString() {
 	  TreeNode treeNode = getTreeNode();
 		if (treeNode instanceof SyntaxTreeNode

--- a/tlatools/src/tla2sany/semantic/SetOfArgLevelConstraints.java
+++ b/tlatools/src/tla2sany/semantic/SetOfArgLevelConstraints.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-class SetOfArgLevelConstraints extends HashMap implements LevelConstants {
+class SetOfArgLevelConstraints extends HashMap<ParamAndPosition, Integer> implements LevelConstants {
   // Implements a map mapping arg-level parameters (ParamAndPosition)
   // to levels (Integer). An entry <pap,x> means that the argument
   // pap.position of the operator pap.param must have a level >= x.
@@ -18,21 +18,25 @@ class SetOfArgLevelConstraints extends HashMap implements LevelConstants {
   * k.position.                                                            *
   *************************************************************************/
   
+  static private final long serialVersionUID = -7784778621001953833L;
+
+  
   /**
    * This method adds <pap, level> into this set, and "subsumes"
    * it with another one for the same parameter if one is there, or
    * ignoring the constraint if it is vacuous.
    */
-  public final Object put(Object pap, Object level) {
-    int newLevel = ((Integer)level).intValue();
-    Object old = this.get(pap);
+  @Override
+  public final Integer put(ParamAndPosition pap, Integer level) {
+    int newLevel = level.intValue();
+    Integer old = this.get(pap);
 
-    int oldLevel = (old == null) ? MinLevel : ((Integer)old).intValue();
+    int oldLevel = (old == null) ? MinLevel : old.intValue();
     super.put(pap, new Integer(Math.max(newLevel, oldLevel)));
     return old;
   }
 
-  public final Object put(SymbolNode param, int position, int level) {
+  public final Integer put(SymbolNode param, int position, int level) {
     ParamAndPosition pap = new ParamAndPosition(param, position);
     return this.put(pap, new Integer(level));
   }
@@ -42,17 +46,19 @@ class SetOfArgLevelConstraints extends HashMap implements LevelConstants {
    * map, in each case "subsuming" it with any constraint already
    * present for the same parameter if one is there.
    */
-  public final void putAll(Map s) {
-    for (Iterator iter = s.keySet().iterator(); iter.hasNext(); ) {
-      Object key = iter.next();
-      put(key, s.get(key));
+  @Override
+  public final void putAll(Map<? extends ParamAndPosition, ? extends Integer> s) {
+    for (Iterator<? extends ParamAndPosition> iter = s.keySet().iterator(); iter.hasNext(); ) {
+    	  ParamAndPosition key = iter.next();
+      this.put(key, s.get(key));
     }
   }
 
+  @Override
   public final String toString() {
     StringBuffer sb = new StringBuffer("{ ");
-    for (Iterator iter = this.keySet().iterator(); iter.hasNext(); ) {
-      Object pap = iter.next();
+    for (Iterator<ParamAndPosition> iter = this.keySet().iterator(); iter.hasNext(); ) {
+      ParamAndPosition pap = iter.next();
       sb.append(pap.toString() + " -> " + this.get(pap));
       if (iter.hasNext()) sb.append(", ");
     }

--- a/tlatools/src/tla2sany/semantic/SetOfLevelConstraints.java
+++ b/tlatools/src/tla2sany/semantic/SetOfLevelConstraints.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-class SetOfLevelConstraints extends HashMap implements LevelConstants {
+class SetOfLevelConstraints extends HashMap<SymbolNode, Integer> implements LevelConstants {
   // Implements a map mapping parameters to levels. An entry <p,x> in
   // the set means that p must have a level <= x.
   /*************************************************************************
@@ -15,17 +15,19 @@ class SetOfLevelConstraints extends HashMap implements LevelConstants {
   * that the key/parameter must have a level <= the value/int.             *
   *************************************************************************/
   
+  static private final long serialVersionUID = -770627695426802007L;
 
-
+  
   /**
    * This method adds <param, level> into this map. It subsumes
    * any existing one. 
    */
-  public final Object put(Object param, Object level) {
-    int newLevel = ((Integer)level).intValue();
-    Object old = this.get(param);
+  @Override
+  public final Integer put(SymbolNode param, Integer level) {
+    int newLevel = level.intValue();
+    Integer old = this.get(param);
 
-    int oldLevel = (old == null) ? MaxLevel : ((Integer)old).intValue();
+    int oldLevel = (old == null) ? MaxLevel : old.intValue();
     super.put(param, new Integer(Math.min(newLevel, oldLevel)));
     return old;
   }
@@ -35,17 +37,19 @@ class SetOfLevelConstraints extends HashMap implements LevelConstants {
    * map, in each case "subsuming" it with any constraint already
    * present for the same parameter if one is there.
    */
-  public final void putAll(Map s) {
-    for (Iterator iter = s.keySet().iterator(); iter.hasNext(); ) {
-      Object key = iter.next();
+  @Override
+  public final void putAll(Map<? extends SymbolNode, ? extends Integer> s) {
+    for (Iterator<? extends SymbolNode> iter = s.keySet().iterator(); iter.hasNext(); ) {
+      SymbolNode key = iter.next();
       this.put(key, s.get(key));
     }
   }
   
+  @Override
   public final String toString() {
     StringBuffer sb = new StringBuffer("{ ");
-    for (Iterator iter = this.keySet().iterator(); iter.hasNext(); ) {
-      SymbolNode param = (SymbolNode)iter.next();
+    for (Iterator<SymbolNode> iter = this.keySet().iterator(); iter.hasNext(); ) {
+      SymbolNode param = iter.next();
       sb.append(param.getName() + " -> " + this.get(param));
       if (iter.hasNext()) sb.append(", ");
     }

--- a/tlatools/src/tla2sany/semantic/StringNode.java
+++ b/tlatools/src/tla2sany/semantic/StringNode.java
@@ -6,6 +6,7 @@ import java.util.Hashtable;
 
 import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -47,6 +48,7 @@ public class StringNode extends ExprNode implements ExploreNode {
   public final UniqueString getRep() { return this.value; }
 
   /* Level Checking */
+  @Override
   public final boolean levelCheck(int iter) {
     levelChecked = iter;
       /*********************************************************************
@@ -81,11 +83,12 @@ public class StringNode extends ExprNode implements ExploreNode {
 //           "ArgLevelParams: "      + this.getArgLevelParams()      + "\n" ;
 //  }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
   }
 
   final String PrintVersion(String str) {
@@ -118,6 +121,7 @@ public class StringNode extends ExprNode implements ExploreNode {
     return buf.toString();
    }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     return "\n*StringNode: " + super.toString(depth)
@@ -125,7 +129,8 @@ public class StringNode extends ExprNode implements ExploreNode {
                              "'" + " Length: " + value.length();
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
       Element e = doc.createElement("StringValue");
       Node n = doc.createTextNode(value.toString());
       e.appendChild(n);

--- a/tlatools/src/tla2sany/semantic/Subst.java
+++ b/tlatools/src/tla2sany/semantic/Subst.java
@@ -9,7 +9,7 @@ import java.util.Iterator;
 import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
-
+import tla2sany.xml.SymbolContext;
 import tla2sany.xml.XMLExportable;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -59,7 +59,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
     return null;
   }
 
-  public static HashSet paramSet(Object param, Subst[] subs) {
+  public static HashSet<SymbolNode> paramSet(SymbolNode param, Subst[] subs) {
     /***********************************************************************
     * If subs[i] is of the form `parm <- expr', then it returns the        *
     * expr.levelParams.  Otherwise, it returns the HashSet containing      *
@@ -76,12 +76,12 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
       return subs[idx].getExpr().getLevelParams();
     }
 
-    HashSet res = new HashSet();
+    HashSet<SymbolNode> res = new HashSet<>();
     res.add(param);
     return res;
   }
 
-  public static HashSet allParamSet(Object param, Subst[] subs) {
+  public static HashSet<SymbolNode> allParamSet(SymbolNode param, Subst[] subs) {
     /***********************************************************************
     * This is exactly like paramSet, except it returns the allParams       *
     * HashSet instead of levelParams.                                      *
@@ -94,7 +94,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
       return subs[idx].getExpr().getAllParams();
     }
 
-    HashSet res = new HashSet();
+    HashSet<SymbolNode> res = new HashSet<>();
     res.add(param);
     return res;
   }
@@ -110,10 +110,10 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
     ***********************************************************************/
     SetOfLevelConstraints res = new SetOfLevelConstraints();
     SetOfLevelConstraints lcSet = body.getLevelConstraints();
-    Iterator iter = lcSet.keySet().iterator();
+    Iterator<SymbolNode> iter = lcSet.keySet().iterator();
     while (iter.hasNext()) {
-      SymbolNode param = (SymbolNode)iter.next();
-      Object plevel = lcSet.get(param);
+      SymbolNode param = iter.next();
+      Integer plevel = lcSet.get(param);
       if (!isConstant) {
 	if (param.getKind() == ConstantDeclKind) {
 	  plevel = Levels[ConstantLevel];
@@ -122,15 +122,15 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
 	  plevel = Levels[VariableLevel];
 	}
       }
-      Iterator iter1 = paramSet(param, subs).iterator();
+      Iterator<SymbolNode> iter1 = paramSet(param, subs).iterator();
       while (iter1.hasNext()) {
 	res.put(iter1.next(), plevel);
       }
     }
-    HashSet alpSet = body.getArgLevelParams();
-    iter = alpSet.iterator();
-    while (iter.hasNext()) {
-      ArgLevelParam alp = (ArgLevelParam)iter.next();
+    HashSet<ArgLevelParam> alpSet = body.getArgLevelParams();
+    Iterator<ArgLevelParam> alpIter = alpSet.iterator();
+    while (alpIter.hasNext()) {
+      ArgLevelParam alp = alpIter.next();
       OpArgNode sub = (OpArgNode)getSub(alp.op, subs);
       if (sub != null &&
 	  sub.getOp() instanceof OpDefNode) {
@@ -145,7 +145,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
           * argument of this method.                                       *
           *****************************************************************/
 	Integer mlevel = new Integer(subDef.getMaxLevel(alp.i));
-	Iterator iter1 = paramSet(alp.param, subs).iterator();
+	Iterator<SymbolNode> iter1 = paramSet(alp.param, subs).iterator();
 	while (iter1.hasNext()) {
 	  res.put(iter1.next(), mlevel);
 	}
@@ -162,10 +162,10 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
     ***********************************************************************/
     SetOfArgLevelConstraints res = new SetOfArgLevelConstraints();
     SetOfArgLevelConstraints alcSet = body.getArgLevelConstraints();
-    Iterator iter = alcSet.keySet().iterator();
+    Iterator<ParamAndPosition> iter = alcSet.keySet().iterator();
     while (iter.hasNext()) {
-      ParamAndPosition pap = (ParamAndPosition)iter.next();
-      Object plevel = alcSet.get(pap);
+      ParamAndPosition pap = iter.next();
+      Integer plevel = alcSet.get(pap);
       ExprOrOpArgNode sub = getSub(pap.param, subs);
       if (sub == null) {
 	res.put(pap, plevel);
@@ -178,10 +178,10 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
 	}
       }
     }
-    HashSet alpSet = body.getArgLevelParams();
-    iter = alpSet.iterator();
-    while (iter.hasNext()) {
-      ArgLevelParam alp = (ArgLevelParam)iter.next();
+    HashSet<ArgLevelParam> alpSet = body.getArgLevelParams();
+    Iterator<ArgLevelParam> alpIter = alpSet.iterator();
+    while (alpIter.hasNext()) {
+      ArgLevelParam alp = alpIter.next();
       ExprOrOpArgNode subParam = getSub(alp.param, subs);
       if (subParam != null) {
 	ExprOrOpArgNode subOp = getSub(alp.op, subs);
@@ -200,16 +200,16 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
     return res;
   }
 
-  public static HashSet getSubALPSet(LevelNode body, Subst[] subs) {
+  public static HashSet<ArgLevelParam> getSubALPSet(LevelNode body, Subst[] subs) {
     /***********************************************************************
     * This should only be called after level checking has been called on   *
     * body and on all subs[i].getExpr().                                   *
     ***********************************************************************/
-    HashSet res = new HashSet();
-    HashSet alpSet = body.getArgLevelParams();
-    Iterator iter = alpSet.iterator();
+    HashSet<ArgLevelParam> res = new HashSet<>();
+    HashSet<ArgLevelParam> alpSet = body.getArgLevelParams();
+    Iterator<ArgLevelParam> iter = alpSet.iterator();
     while (iter.hasNext()) {
-      ArgLevelParam alp = (ArgLevelParam)iter.next();
+      ArgLevelParam alp = iter.next();
       ExprOrOpArgNode sub = getSub(alp.op, subs);
       if (sub == null) {
 	res.add(alp);
@@ -217,9 +217,9 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
       else {
 	SymbolNode subOp = ((OpArgNode)sub).getOp();
 	if (subOp.isParam()) {
-	  Iterator iter1 = paramSet(alp.param, subs).iterator();
+	  Iterator<SymbolNode> iter1 = paramSet(alp.param, subs).iterator();
 	  while (iter1.hasNext()) {
-	    res.add(new ArgLevelParam(subOp, alp.i, (SymbolNode)iter1.next()));
+	    res.add(new ArgLevelParam(subOp, alp.i, iter1.next()));
 	  }
 	}
       }
@@ -229,7 +229,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
 
   public final String levelDataToString() { return "Dummy level string"; }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     if (op != null) op.walkGraph(semNodesTable);
     if (expr != null) expr.walkGraph(semNodesTable);
   }
@@ -240,7 +240,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
            "\nExpr: " + Strings.indent(2,(expr!=null ? expr.toString(depth-1) : "<null>"));
   }
 
-  public Element export(Document doc, tla2sany.xml.SymbolContext context) {
+  public Element export(Document doc, SymbolContext context) {
       Element ret = doc.createElement("Subst");
       ret.appendChild(op.export(doc,context));
       ret.appendChild(expr.export(doc,context));

--- a/tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -24,9 +24,11 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -196,7 +198,8 @@ public class SubstInNode extends ExprNode {
    * to this method can contain a mixture of explicit and implicit
    * substitutions
    */
-  final void addExplicitSubstitute(Context instanceeCtxt, UniqueString lhs,
+  @SuppressWarnings("unused")	// TODO final else block is dead code 
+  final void addExplicitSubstitute(Context instanceCtxt, UniqueString lhs,
                                    TreeNode stn, ExprOrOpArgNode sub) {
     int index;
     for (index = 0; index < this.substs.length; index++) {
@@ -224,7 +227,7 @@ public class SubstInNode extends ExprNode {
       // the instancee context
 
       // look up the lhs symbol in the instancee context
-      SymbolNode lhsSymbol = instanceeCtxt.getSymbol(lhs);
+      SymbolNode lhsSymbol = instanceCtxt.getSymbol(lhs);
 
       // lhs must be an OpDeclNode; if not just return, as this error
       // will have been earlier, though semantic analysis was allowed
@@ -291,6 +294,8 @@ public class SubstInNode extends ExprNode {
 //  private SetOfArgLevelConstraints argLevelConstraints;
 //  private HashSet argLevelParams;
 
+  @Override
+  @SuppressWarnings("unchecked")
   public final boolean levelCheck(int itr) {
     if (this.levelChecked >= itr) return this.levelCorrect;
     this.levelChecked = itr ;
@@ -311,7 +316,7 @@ public class SubstInNode extends ExprNode {
 
     // Calculate the level information
     this.level = this.body.getLevel();
-    HashSet lpSet = this.body.getLevelParams();
+    HashSet<SymbolNode> lpSet = this.body.getLevelParams();
     for (int i = 0; i < this.substs.length; i++) {
       if (lpSet.contains(this.getSubFor(i))) {
 	this.level = Math.max(level, this.getSubWith(i).getLevel());
@@ -319,10 +324,9 @@ public class SubstInNode extends ExprNode {
     }
 
 //    this.levelParams = new HashSet();
-    Iterator iter = lpSet.iterator();
+    Iterator<SymbolNode> iter = lpSet.iterator();
     while (iter.hasNext()) {
-      Object param = iter.next();
-      this.levelParams.addAll(Subst.paramSet(param, this.substs));
+      this.levelParams.addAll(Subst.paramSet(iter.next(), this.substs));
         /*******************************************************************
         * At this point, levelCheck(itr) has been invoked on              *
         * this.substs[i].getExpr() (which equals this.getSubWith(i)).      *
@@ -353,8 +357,8 @@ public class SubstInNode extends ExprNode {
     * 23 February 2009: Added ".clone" to the following statements to fix  *
     * bug.                                                                 *
     ***********************************************************************/
-    this.allParams        = (HashSet) this.body.getAllParams().clone() ;
-    this.nonLeibnizParams = (HashSet) this.body.getNonLeibnizParams().clone() ;
+    this.allParams        = (HashSet<SymbolNode>)this.body.getAllParams().clone() ;
+    this.nonLeibnizParams = (HashSet<SymbolNode>)this.body.getNonLeibnizParams().clone() ;
     for (int i = 0 ; i < this.substs.length ; i++) {
       OpDeclNode param = substs[i].getOp() ;
       if (this.allParams.contains(param)) {
@@ -460,6 +464,7 @@ public class SubstInNode extends ExprNode {
 //           "ArgLevelParams: "      + this.argLevelParams      + "\n" ;
 //  }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
 
@@ -489,6 +494,7 @@ public class SubstInNode extends ExprNode {
    * The children of this node are the body and the expressions
    * being substituted for symbols.
    */
+  @Override
   public SemanticNode[] getChildren() {
      SemanticNode[] res = new SemanticNode[this.substs.length + 1];
      res[0] = this.body;
@@ -498,11 +504,12 @@ public class SubstInNode extends ExprNode {
      return res;
   }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
 
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
 
     if (this.substs != null) {
       for (int i = 0; i < this.substs.length; i++) {
@@ -513,7 +520,8 @@ public class SubstInNode extends ExprNode {
     return;
   }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
       Element sbts = doc.createElement("substs");
       for (int i=0; i<substs.length; i++) {
         sbts.appendChild(substs[i].export(doc,context));

--- a/tlatools/src/tla2sany/semantic/TheoremNode.java
+++ b/tlatools/src/tla2sany/semantic/TheoremNode.java
@@ -15,8 +15,10 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -112,7 +114,8 @@ public class TheoremNode extends LevelNode {
   /* (non-Javadoc)
  * @see tla2sany.semantic.LevelNode#levelCheck(int)
  */
-public final boolean levelCheck(int iter) {
+  @Override
+  public final boolean levelCheck(int iter) {
     if (levelChecked >= iter) {return true ;} ;
     levelChecked = iter;
     LevelNode sub[] ;
@@ -318,6 +321,7 @@ public final boolean levelCheck(int iter) {
    * toString, levelDataToString, and walkGraph methods to implement
    * ExploreNode interface
    */
+  @Override
   public final String levelDataToString() {
     return "Level: "               + this.getLevel()               + "\n" +
            "LevelParameters: "     + this.getLevelParams()         + "\n" +
@@ -326,6 +330,7 @@ public final boolean levelCheck(int iter) {
            "ArgLevelParams: "      + this.getArgLevelParams()      + "\n";
   }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     String res =
@@ -358,6 +363,7 @@ public final boolean levelCheck(int iter) {
    * The children are the statement and the proof (if there is one).
    */
 
+  @Override
   public SemanticNode[] getChildren() {
     if (this.proof == null) {
     return new SemanticNode[] {this.theoremExprOrAssumeProve};
@@ -366,7 +372,8 @@ public final boolean levelCheck(int iter) {
                                this.proof};
   }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
     semNodesTable.put(uid, this);
@@ -384,7 +391,7 @@ public final boolean levelCheck(int iter) {
 
   /* MR: This is the same as SymbolNode.exportDefinition. Exports the actual theorem content, not only a reference.
    */
-  public Element exportDefinition(Document doc, tla2sany.xml.SymbolContext context) {
+  public Element exportDefinition(Document doc, SymbolContext context) {
     //makes sure that the we are creating an entry in the database
     if (!context.isTop_level_entry())
       throw new IllegalArgumentException("Exporting theorem ref "+getNodeRef()+" twice!");
@@ -440,7 +447,8 @@ public final boolean levelCheck(int iter) {
   }
 
   /* overrides LevelNode.export and exports a UID reference instad of the full version*/
-  public Element export(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  public Element export(Document doc, SymbolContext context) {
     // first add symbol to context
     context.put(this, doc);
     Element e = doc.createElement(getNodeRef());

--- a/tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
+++ b/tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
@@ -27,9 +27,11 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
 import tla2sany.utilities.Vector;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 import util.WrongInvocationException;
 
@@ -417,6 +419,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
     * parameter of the definition of op appears within the k-th argument   *
     * of opArg.                                                            *
     ***********************************************************************/
+  @Override
   public final boolean levelCheck(int itr) {
       if (this.levelChecked >= itr) { return this.levelCorrect; }
       this.levelChecked = itr ;
@@ -573,17 +576,20 @@ public class ThmOrAssumpDefNode extends SymbolNode
   /**
    *  The body is the node's only child.
    */
+  @Override
   public SemanticNode[] getChildren() {
     return new SemanticNode[] {this.body};
   }
 
-  public final void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public final void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     if(this.body != null) {this.body.walkGraph(semNodesTable) ;} ;
    }
 
+  @Override
   public final String toString(int depth) {
     if (depth <= 0) return "";
     String ret =
@@ -657,7 +663,8 @@ public class ThmOrAssumpDefNode extends SymbolNode
   }
 
   /* overrides LevelNode.export and exports a UID reference instad of the full version*/
-  public Element export(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  public Element export(Document doc, SymbolContext context) {
     // first add symbol to context
     context.put(this, doc);
     Element e = doc.createElement(getNodeRef());

--- a/tlatools/src/tla2sany/semantic/UseOrHideNode.java
+++ b/tlatools/src/tla2sany/semantic/UseOrHideNode.java
@@ -4,8 +4,10 @@ package tla2sany.semantic;
 
 import java.util.Hashtable;
 
+import tla2sany.explorer.ExploreNode;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Strings;
+import tla2sany.xml.SymbolContext;
 import util.UniqueString;
 
 import org.w3c.dom.Document;
@@ -101,6 +103,7 @@ public class UseOrHideNode extends LevelNode {
     } // for
   }
 
+  @Override
   public boolean levelCheck(int iter) {
     /***********************************************************************
     * Level checking is performed by level-checking the facts.  Since the  *
@@ -111,10 +114,11 @@ public class UseOrHideNode extends LevelNode {
     return this.levelCheckSubnodes(iter, facts) ;
    }
 
-  public void walkGraph(Hashtable semNodesTable) {
+  @Override
+  public void walkGraph(Hashtable<Integer, ExploreNode> semNodesTable) {
     Integer uid = new Integer(myUID);
     if (semNodesTable.get(uid) != null) return;
-    semNodesTable.put(new Integer(myUID), this);
+    semNodesTable.put(uid, this);
     for (int  i = 0; i < facts.length; i++) {
       facts[i].walkGraph(semNodesTable);
       } ;
@@ -128,6 +132,7 @@ public class UseOrHideNode extends LevelNode {
    * The children are the facts.
    * @see tla2sany.semantic.SemanticNode#getChildren()
    */
+  @Override
   public SemanticNode[] getChildren() {
       if (this.facts == null || this.facts.length == 0) {
           return null;
@@ -139,6 +144,7 @@ public class UseOrHideNode extends LevelNode {
       return res;
    }
 
+  @Override
   public String toString(int depth) {
     if (depth <= 0) return "";
     String ret = "\n*UseOrHideNode:\n"
@@ -155,7 +161,8 @@ public class UseOrHideNode extends LevelNode {
     return ret;
    }
 
-  protected Element getLevelElement(Document doc, tla2sany.xml.SymbolContext context) {
+  @Override
+  protected Element getLevelElement(Document doc, SymbolContext context) {
     //SemanticNode.SymbolContext context = new SemanticNode.SymbolContext(context2);
     Element e = doc.createElement("UseOrHideNode");
 


### PR DESCRIPTION
Code addressing #88 as well as adding typing and annotations, fixing the odd misspelling and moving fully-qualified-class-in-method-signature to an import.