### PR TITLE
Permit PlusCal "call" statement to be followed directly by "goto" without intervening label

### DIFF
--- a/tlatools/src/pcal/AST.java
+++ b/tlatools/src/pcal/AST.java
@@ -17,7 +17,7 @@
 * However, there are the following classes that do not represent explicit  *
 * non-terminals of the +CAL grammar.                                       *
 *                                                                          *
-*     Uniprocess   MultiProcess   SingleAssign   CallReturn                *
+* Uniprocess   MultiProcess   SingleAssign   CallReturn   CallGoto         *
 *                                                                          *
 * Every AST has col and line fields that contain the position of the       *
 * first character of the corresponding portion of the algorithm text (as   *
@@ -100,6 +100,7 @@ public class AST
     public static AST.Call         CallObj         ;
     public static AST.Return       ReturnObj       ;
     public static AST.CallReturn   CallReturnObj   ;
+    public static AST.CallGoto     CallGotoObj     ;
     public static AST.Goto         GotoObj         ;
     public static AST.Macro        MacroObj        ;
     public static AST.MacroCall    MacroCallObj    ;
@@ -214,6 +215,7 @@ public class AST
         CallObj         = new AST.Call() ;
         ReturnObj       = new AST.Return() ;
         CallReturnObj   = new AST.CallReturn() ;
+        CallGotoObj     = new AST.CallGoto() ;
         GotoObj         = new AST.Goto() ;
         MacroObj        = new AST.Macro() ;
         MacroCallObj    = new AST.MacroCall() ;
@@ -839,6 +841,24 @@ public class AST
                " from     |-> \"" + from + "\"," + NewLine() +
                " to       |-> \"" + to + "\"," + NewLine() +
                Indent("args     |-> ") + VectorToSeqString(args) 
+                                             + "]" + NewLine() +
+               EndIndent() +
+             EndIndent() ;
+          }
+      }
+
+    public static class CallGoto extends AST
+      { public String    after    = "" ;
+        public String    to       = "" ;
+        public Vector    args     = null ; // of TLAExpr
+        public CallGoto() { };
+        public String toString()
+          { return
+             Indent(lineCol()) +
+               "[type     |-> \"callGoto\"," + NewLine() +
+               " after    |-> \"" + after + "\"," + NewLine() +
+               " to       |-> \"" + to + "\"," + NewLine() +
+               Indent("args     |-> ") + VectorToSeqString(args)
                                              + "]" + NewLine() +
                EndIndent() +
              EndIndent() ;

--- a/tlatools/src/pcal/ParseAlgorithm.java
+++ b/tlatools/src/pcal/ParseAlgorithm.java
@@ -49,9 +49,10 @@
 *    holds the label (the absence of a label represented by                *
 *    a lbl field equal to the empty string "").  The only difference       *
 *    from the simple grammar is that a <Call> followed by an unlabeled     *
-*    <Return> is converted into a single AST.CallReturn object.  This      *
-*    pass does not produce any AST.If or AST.Either objects, and any       *
-*    AST.While object it produces has an empty labDo field.                *
+*    <Return> or <Goto> is converted into a single AST.CallReturn or       *
+*    AST.CallGoto object, respectively.  This pass does not produce any    *
+*    AST.If or AST.Either objects, and any AST.While object it produces    *
+*    has an empty labDo field.                                             *
 *                                                                          *
 *  - It calls the procedure AddLabelsToStmtSeq to check for missing        *
 *    labels and either add them or report an error if it finds one,        *
@@ -1077,7 +1078,7 @@ public class ParseAlgorithm
        if (nextTok.equals("print"))  { return GetPrintS() ; } ;
        if (nextTok.equals("assert")) { return GetAssert() ; } ;
        if (nextTok.equals("skip"))   { return GetSkip() ; }   ;
-       if (nextTok.equals("call"))   { return GetCallOrCallReturn() ; }   ;
+       if (nextTok.equals("call"))   { return GetCallOrCallReturnOrCallGoto() ; } ;
        if (nextTok.equals("return")) { return GetReturn() ; }   ;
        if (nextTok.equals("goto"))   { return GetGoto() ; }   ;
        if (nextTok.equals("while"))  { return GetWhile() ; } ;
@@ -1585,7 +1586,7 @@ public class ParseAlgorithm
        return result ;
      }
 
-   public static AST GetCallOrCallReturn() throws ParseAlgorithmException 
+   public static AST GetCallOrCallReturnOrCallGoto() throws ParseAlgorithmException
      /**********************************************************************
      * Note: should not complain if it finds a return that is not inside   *
      * a procedure because it could be in a macro that is called only      *
@@ -1603,6 +1604,23 @@ public class ParseAlgorithm
            result.from = currentProcedure ;
            result.args = theCall.args ;
            result.setOrigin(new Region(theCall.getOrigin().getBegin(), end)) ;
+           return result ;
+         }
+       else if (PeekAtAlgToken(1).equals("goto"))
+         { MustGobbleThis("goto") ;
+           AST.CallGoto result = new AST.CallGoto();
+           result.col   = theCall.col ;
+           result.line  = theCall.line ;
+           result.to    = theCall.to ;
+           result.after = GetAlgToken() ;
+           result.args  = theCall.args ;
+           PCalLocation end = new PCalLocation(lastTokLine-1, lastTokCol-1+result.to.length());
+           result.setOrigin(new Region(theCall.getOrigin().getBegin(), end)) ;
+           gotoUsed = true ;
+           if (result.to.equals("Done") || result.to.equals("\"Done\"")) {
+               gotoDoneUsed = true;
+           }
+           GobbleThis(";") ;
            return result ;
          }
        else 
@@ -2020,15 +2038,16 @@ public class ParseAlgorithm
                * set assignedVbls to the set of variables being assigned   *
                * by this statement.  Should set nextStepNeedsLabel to      *
                * true and set assignedVbls to a non-empty set iff this is  *
-               * a call, return, or callReturn.                            *
+               * a call, return, callReturn, or callGoto.                  *
                ************************************************************/
                nextStepNeedsLabel = false ;
                Vector assignedVbls = new Vector() ;
 
                /************************************************************
-               * Set isCallOrReturn true iff this is a call, return, or    *
-               * callReturn.  Will set setsPrcdVbls true iff this is a     *
-               * return or callReturn or a call of currentProcedure.       *
+               * Set isCallOrReturn true iff this is a call, return,       *
+               * callReturn, or callGoto.  Will set setsPrcdVbls true iff  *
+               * this is a return or callReturn or a call of               *
+               * currentProcedure.                                         *
                ************************************************************/
                boolean isCallOrReturn = false ;
                boolean setsPrcdVbls   = false ;
@@ -2037,6 +2056,12 @@ public class ParseAlgorithm
                      /******************************************************
                      * Sets obj to an alias of stmt of the right type.     *
                      ******************************************************/
+                   isCallOrReturn = true ;
+                   if (obj.to.equals(currentProcedure))
+                     { setsPrcdVbls = true ; } ;
+                 }
+               else if (stmt.getClass().equals(AST.CallGotoObj.getClass()))
+                 { AST.CallGoto obj = (AST.CallGoto) stmt ;
                    isCallOrReturn = true ;
                    if (obj.to.equals(currentProcedure))
                      { setsPrcdVbls = true ; } ;
@@ -2493,8 +2518,10 @@ public class ParseAlgorithm
                    } ;
                  result = 1 ;
                }
-             else if (node.getClass().equals(
-                           AST.GotoObj.getClass())  
+             else if (   node.getClass().equals(
+                           AST.GotoObj.getClass())
+                      || node.getClass().equals(
+                           AST.CallGotoObj.getClass())
                      )
                { result = 1 ;
                }
@@ -3157,6 +3184,25 @@ public class ParseAlgorithm
             result.to   = tstmt.to ;
             result.from = tstmt.from ;
             result.args = 
+               TLAExpr.SeqSubstituteForAll(tstmt.args, args, params) ;
+            return result;
+          } ;
+
+        if (stmt.getClass().equals( AST.CallGotoObj.getClass()))
+          { AST.CallGoto tstmt = (AST.CallGoto) stmt ;
+            AST.CallGoto result = new AST.CallGoto() ;
+            result.col  = tstmt.col ;
+            result.line = tstmt.line ;
+            result.macroCol  = tstmt.macroCol ;
+            result.macroLine = tstmt.macroLine ;
+            result.setOrigin(tstmt.getOrigin()) ;
+            if (macroLine > 0)
+              { result.macroLine = macroLine ;
+                result.macroCol  = macroCol ;
+              } ;
+            result.to    = tstmt.to ;
+            result.after = tstmt.after ;
+            result.args  =
                TLAExpr.SeqSubstituteForAll(tstmt.args, args, params) ;
             return result;
           } ;

--- a/tlatools/src/pcal/PcalFixIDs.java
+++ b/tlatools/src/pcal/PcalFixIDs.java
@@ -73,6 +73,8 @@ public class PcalFixIDs {
             FixReturn((AST.Return) ast, context);
         else if (ast.getClass().equals(AST.CallReturnObj.getClass()))
             FixCallReturn((AST.CallReturn) ast, context);
+        else if (ast.getClass().equals(AST.CallGotoObj.getClass()))
+            FixCallGoto((AST.CallGoto) ast, context);
         else if (ast.getClass().equals(AST.GotoObj.getClass()))
             FixGoto((AST.Goto) ast, context);
 
@@ -390,6 +392,13 @@ public class PcalFixIDs {
 
     private static void FixCallReturn(AST.CallReturn ast, String context) throws PcalFixIDException {
         ast.from = st.UseThis(PcalSymTab.PROCEDURE, ast.from, context);
+        ast.to = st.UseThis(PcalSymTab.PROCEDURE, ast.to, context);
+        for (int i = 0; i < ast.args.size(); i++)
+            FixExpr((TLAExpr) ast.args.elementAt(i), context);
+    }
+
+    private static void FixCallGoto(AST.CallGoto ast, String context) throws PcalFixIDException {
+        ast.after = st.UseThis(PcalSymTab.PROCEDURE, ast.after, context);
         ast.to = st.UseThis(PcalSymTab.PROCEDURE, ast.to, context);
         for (int i = 0; i < ast.args.size(); i++)
             FixExpr((TLAExpr) ast.args.elementAt(i), context);

--- a/tlatools/src/pcal/PcalSymTab.java
+++ b/tlatools/src/pcal/PcalSymTab.java
@@ -484,6 +484,8 @@ public class PcalSymTab {
             ExtractReturn((AST.Return) ast, context, cType);
         else if (ast.getClass().equals(AST.CallReturnObj.getClass()))
             ExtractCallReturn((AST.CallReturn) ast, context, cType);
+        else if (ast.getClass().equals(AST.CallGotoObj.getClass()))
+            ExtractCallGoto((AST.CallGoto) ast, context, cType);
         else if (ast.getClass().equals(AST.GotoObj.getClass()))
             ExtractGoto((AST.Goto) ast, context, cType);
 
@@ -667,6 +669,11 @@ public class PcalSymTab {
     private void ExtractCallReturn(AST.CallReturn ast,
                                    String context,
                                    String cType) {
+    }
+
+    private void ExtractCallGoto(AST.CallGoto ast,
+                                 String context,
+                                 String cType) {
     }
 
     private void ExtractGoto(AST.Goto ast, String context, String cType) {

--- a/tlatools/src/pcal/PcalTranslate.java
+++ b/tlatools/src/pcal/PcalTranslate.java
@@ -556,6 +556,10 @@ public class PcalTranslate {
                 result1.removeElementAt(result1.size()-1);
                 result1.addAll(ExplodeCallReturn((AST.CallReturn) last, next));
             }
+            else if (last.getClass().equals(AST.CallGotoObj.getClass())) {
+                result1.removeElementAt(result1.size()-1);
+                result1.addAll(ExplodeCallGoto((AST.CallGoto) last, next));
+            }
             else if (last.getClass().equals(AST.IfObj.getClass())) {
                 AST.If If = (AST.If) last;
                 Vector p1 = CopyAndExplodeLastStmt(If.Then, next);
@@ -1478,5 +1482,19 @@ public class PcalTranslate {
          *********************************************************/
         result.addElement(UpdatePC(peTo.iPC));
         return result;
+    }
+
+    /***********************************************************************
+    * Generate sequence of statements corresponding to call followed by a  *
+    * goto.                                                                *
+    ***********************************************************************/
+    private static Vector ExplodeCallGoto(AST.CallGoto ast, String next) throws PcalTranslateException {
+      AST.Call call = new AST.Call();
+      call.to = ast.to;
+      call.args = ast.args;
+      call.line = ast.line;
+      call.col = ast.col;
+      call.setOrigin(ast.getOrigin());
+      return ExplodeCall(call, ast.after);
     }
 }


### PR DESCRIPTION
As discussed here: https://groups.google.com/d/topic/tlaplus/6M1oFOtN-5k/discussion

If a call is followed directly by a goto, we can simply use the goto's target as the return label for the call, thus negating the requirement for the call to be followed by a label.  This helps eliminate dummy labels/states for certain cases.

The implementation is simply an adaptation of the existing machinery for a call followed directly by return.  Manual tests produce the desired output.