### PR TITLE
Detect empty while body while parsing

### DIFF
--- a/tlatools/src/pcal/ParseAlgorithm.java
+++ b/tlatools/src/pcal/ParseAlgorithm.java
@@ -954,6 +954,8 @@ public class ParseAlgorithm
          }
        else
          { result.unlabDo = GetCStmt() ; } ;
+       if (result.unlabDo.size() == 0)
+         { ParsingError("Empty while body") ;} ;
        result.labDo = new Vector() ;
          /******************************************************************
          * For historical reasons, some methods expect a labDo field to    *


### PR DESCRIPTION
Per the PlusCal spec, `while` should have `Stmt` as its body, which is `[Id :] (UnlabeledStmt | CompoundStmt)`, where `CompoundStmt ` is `{ Stmt [; Stmt]∗ [;] }`.

Either way, the body of `while` should not be empty, and should trigger a parsing error.

However, the current implementation accepts empty `while` body, and thus results in the following exception later when setting `labDo`
```
pcal.trans Version 1.8 of 16 May 2016
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: -1
	at java.util.Vector.elementData(Vector.java:737)
	at java.util.Vector.elementAt(Vector.java:480)
	at pcal.ParseAlgorithm.GetWhile(ParseAlgorithm.java:964)
	at pcal.ParseAlgorithm.GetStmt(ParseAlgorithm.java:1084)
	at pcal.ParseAlgorithm.GetStmtSeq(ParseAlgorithm.java:1053)
	at pcal.ParseAlgorithm.GetProcedure(ParseAlgorithm.java:701)
	at pcal.ParseAlgorithm.getAlgorithm(ParseAlgorithm.java:351)
	at pcal.trans.runMe(trans.java:896)
	at pcal.trans.runMe(trans.java:375)
	at pcal.trans.main(trans.java:287)
```

The patch throws a parsing error, which prevents the above behaviour and make the parser conform to the spec.