### PR TITLE
Fix reporting of liveness violations in the Simulator

### DIFF
--- a/tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/src/tlc2/tool/SimulationWorker.java
@@ -366,7 +366,7 @@ public class SimulationWorker extends Thread {
 					}
 				} catch (final Exception e) {
 					return Optional.of(new SimulationWorkerError(EC.TLC_INVARIANT_EVALUATION_FAILED,
-							new String[] { tool.getInvNames()[idx], e.getMessage() }, state, stateTrace, e));
+							new String[] { tool.getInvNames()[idx], e.getMessage() }, state, stateTrace, null));
 				}
 
 				// Check action properties.
@@ -380,7 +380,7 @@ public class SimulationWorker extends Thread {
 					}
 				} catch (final Exception e) {
 					return Optional.of(new SimulationWorkerError(EC.TLC_ACTION_PROPERTY_EVALUATION_FAILED,
-							new String[] { tool.getImpliedActNames()[idx], e.getMessage() }, state, stateTrace, e));
+							new String[] { tool.getImpliedActNames()[idx], e.getMessage() }, state, stateTrace, null));
 				}
 
 			}

--- a/tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/src/tlc2/tool/Simulator.java
@@ -270,17 +270,24 @@ public class Simulator implements Cancelable {
 			// If the result is an error, print it.
 			if (result.isError()) {
 				SimulationWorkerError error = result.error();
-				printBehavior(error);
 				
-				if(error.exception != null) {
-					// Print a summary in case of a liveness error.
+				// We assume that if a worker threw an unexpected exception, there is a bug
+				// somewhere, so we print out the exception and terminate. In the case of a
+				// liveness error, which is reported as an exception, we also terminate.
+				if (error.exception != null) {
 					if (error.exception instanceof LiveException) {
+						// In case of a liveness error, there is no need to print out
+						// the behavior since the liveness checker should take care of that itself.
 						this.printSummary();
 					} else {
-						printBehavior(EC.GENERAL, new String[] { MP.ECGeneralMsg("", error.exception) },
-								error.state, error.stateTrace);
+						printBehavior(EC.GENERAL, new String[] { MP.ECGeneralMsg("", error.exception) }, error.state,
+								error.stateTrace);
 					}
+					break;
 				}
+				
+				// Print the trace for all other errors.
+				printBehavior(error);
 				
 				// For certain, "fatal" errors, we shut down all workers and terminate,
 				// regardless of the "continue" parameter, since these errors likely indicate a bug in the spec.

--- a/tlatools/test-model/simulation/BasicMultiTrace/BasicMultiTrace.tla
+++ b/tlatools/test-model/simulation/BasicMultiTrace/BasicMultiTrace.tla
@@ -56,9 +56,8 @@ StateConstraint == depth < 4
 ActionConstraint == ~(depth' = 4 /\ depth = 3)
 InvConstraint   == depth <= 4
 
-
-
-\*TemporalProp == <>(branch = 15)
+\* A liveness property that should be violated.
+LivenessProp == <>(branch = -1)
 
 
 =============================================================================

--- a/tlatools/test-model/simulation/BasicMultiTrace/MCLivenessProp.cfg
+++ b/tlatools/test-model/simulation/BasicMultiTrace/MCLivenessProp.cfg
@@ -1,0 +1,4 @@
+SPECIFICATION
+Spec
+PROPERTY
+LivenessProp

--- a/tlatools/test/tlc2/tool/simulation/SimulatorTest.java
+++ b/tlatools/test/tlc2/tool/simulation/SimulatorTest.java
@@ -14,6 +14,7 @@ import tlc2.output.EC;
 import tlc2.output.MP;
 import tlc2.tool.CommonTestCase;
 import tlc2.tool.Simulator;
+import tlc2.util.FP64;
 import tlc2.util.RandomGenerator;
 import util.FileUtil;
 import util.SimpleFilenameToStream;
@@ -121,6 +122,27 @@ public class SimulatorTest extends CommonTestCase {
 		runSimulatorTest("BasicMultiTrace", "MCBadInvNonInitState", false, 100, Long.MAX_VALUE);
 		assertTrue(recorder.recordedWithStringValue(EC.TLC_COMPUTING_INIT_PROGRESS, "1"));
 		assertTrue(recorder.recordedWithStringValue(EC.TLC_INVARIANT_EVALUATION_FAILED, "InvBadEvalNonInitState"));
+	}
+	
+	@Test
+	public void testLivenessViolation() {	
+		FP64.Init();
+		runSimulatorTest("BasicMultiTrace", "MCLivenessProp", false, 100, 100);
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_COMPUTING_INIT_PROGRESS, "1"));
+		assertTrue(recorder.recorded(EC.TLC_TEMPORAL_PROPERTY_VIOLATED));
+		assertTrue(recorder.recorded(EC.TLC_COUNTER_EXAMPLE));
+	}
+	
+	@Test
+	public void testLivenessViolationIgnoresContinue() {	
+		FP64.Init();
+		TLCGlobals.continuation = true;
+		// We should always terminate after the first liveness violation, regardless of
+		// the "continue" parameter.
+		runSimulatorTest("BasicMultiTrace", "MCLivenessProp", false, 100, Long.MAX_VALUE);
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_COMPUTING_INIT_PROGRESS, "1"));
+		assertTrue(recorder.recorded(EC.TLC_TEMPORAL_PROPERTY_VIOLATED));
+		assertTrue(recorder.recorded(EC.TLC_COUNTER_EXAMPLE));
 	}
 	
 


### PR DESCRIPTION
@lemmy This is a follow up fix for issue #147. It addresses the bug in how we reported liveness violations in the Simulator introduced by [8355920](https://github.com/tlaplus/tlaplus/commit/83559207381b08472f1d1dcf8bb07d08a7f9b089). I updated the logic so that we don't print out a behavior trace twice in case of a liveness exception being thrown by a worker. The liveness checker itself already prints the error message, so the Simulator doesn't need to do so again.