### PR TITLE
Make it easier to run TLC standalone.

### DIFF
--- a/tlatools/src/tlc2/TLC.java
+++ b/tlatools/src/tlc2/TLC.java
@@ -220,9 +220,24 @@ public class TLC
 
         // Setup how spec files will be resolved in the filesystem.
         if (MODEL_PART_OF_JAR) {
+            // There was not spec file given, it instead exists in the
+            // .jar file being executed. So we need to use a special file
+            // resolver to parse it.
         		tlc.setResolver(new InJarFilenameToStream(ModelInJar.PATH));
         } else {
-        		tlc.setResolver(new SimpleFilenameToStream());
+            // The user passed us a spec file directly. To ensure we can
+            // recover it during semantic parsing, we must include its
+            // parent directory as a library path in the file resolver.
+            //
+            // If the spec file has no parent directory, use the "standard"
+            // library paths provided by SimpleFilenameToStream.
+            String[] libraryPaths = {};
+
+            String dir = FileUtil.parseDirname(tlc.getMainFile());
+            if (!dir.isEmpty()) {
+                libraryPaths = new String[]{dir};
+            }
+            tlc.setResolver(new SimpleFilenameToStream(libraryPaths));
         }
 
         // Execute TLC.
@@ -1079,6 +1094,10 @@ public class TLC
 
     FPSetConfiguration getFPSetConfiguration() {
     	return fpSetConfiguration;
+    }
+
+    public String getMainFile() {
+        return mainFile;
     }
 
 	public String getModelName() {

--- a/tlatools/src/util/FileUtil.java
+++ b/tlatools/src/util/FileUtil.java
@@ -40,6 +40,19 @@ public class FileUtil
     public static final String pathSeparator = File.pathSeparator;
 
     /**
+     * Parses the directory path from a filename. If the filename
+     * is already a basename, returns the empty string.
+     */
+    public static String parseDirname(String filename) {
+        int lastSep = filename.lastIndexOf(separatorChar);
+        if (lastSep == -1) {
+            // No parent directory.
+            return "";
+        }
+        return filename.substring(0, lastSep + 1);
+    }
+
+    /**
      * Deletes the file or directory. Returns true iff the deletion
      * succeeds. The argument recurse forces the deletion of non-empty
      * directory.


### PR DESCRIPTION
Note: The "flowpayau" identity is a Github.com bug and should (hopefully) be resolved shortly. The committer is "edahlgren".

--- From commit message:

TLC terminates with a filesystem lookup error in SANY parsing code when
given a path to an arbitrary spec file on the user's local filesystem.

TLC is fully capable of being an easy to use, standalone tool. This change
fixes these filesystem lookup errors so that users of TLC can intuitively
use any spec file that exists on their filesystem.

---

Background:

* When a spec file is given to TLC explicitly (not part of a .jar file),
  a SimpleFilenameToStream resolver is used to lookup files on a filesystem
  (see tool/SpecObj.java).

* Code paths like tool/Simulator.java -> tool/Tool.java -> tool/Spec.java
  tool/SpecObj.java parse the spec directory from the spec file, but then
  subsequently ignore it (see specDir as dead code in tool/Spec.java).

* As a result, tool/SpecObj.java can only lookup specs from paths included
  in the filesystem resolver. It also means that in many cases the specDir
  is passed to Tool invocations for no reason.

Change details:

* This change parses the spec directory from the spec file and adds it as
  a library path in the resolver before TLC.process() is called. This means
  that SpecObj.java will look for the spec file in the spec directory first,
  before trying the "standard" module directories built into the resolver.
  This is what we want.

* The change leaves the dead code in tool/Spec.java to remain minimal. A
  follow-up change will remove the dead code and clean up initializers.

Testing:

I don't know how to create an automated integration test for this change. It
was minimally validated by running:

  $ cd tlatools
  $ ant -f customBuild.xml compile dist
  $ java -cp dist/tla2tools.jar tlc2.TLC -deadlock -simulate -config test-model/DieHard.cfg test-model/DieHard.tla

Categories: Bug, TLC, Standalone, Interface