### PR TITLE
Do not set queue size to distinct states

### DIFF
--- a/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/output/data/StateSpaceInformationItem.java
+++ b/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/output/data/StateSpaceInformationItem.java
@@ -56,7 +56,7 @@ public class StateSpaceInformationItem
 	}
 	
 	private StateSpaceInformationItem(Date time, long foundStates, long distinctStates) {
-		this(time, 0, foundStates, distinctStates, distinctStates, 0, 0);
+		this(time, 0, foundStates, distinctStates, -1, 0, 0);
 	}
 
 	private StateSpaceInformationItem(Date time, long distinctStates) {
@@ -64,7 +64,7 @@ public class StateSpaceInformationItem
 	}
 	
 	private StateSpaceInformationItem(long foundStates, long distinctStates) {
-		this(new Date(), 0, foundStates, distinctStates, distinctStates, 0, 0);
+		this(new Date(), 0, foundStates, distinctStates, -1, 0, 0);
 	}
 
 	private StateSpaceInformationItem(long distinctStates) {


### PR DESCRIPTION
This is confusing and plain wrong.

The Toolbox already has support for rendering negative numbers as "--".