### PR TITLE
Adding ErrorProne as a Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,26 @@
 					</environments>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>8</source>
+					<target>8</target>
+					<compilerArgs>
+						<arg>-XDcompilePolicy=simple</arg>
+						<arg>-Xplugin:ErrorProne</arg>
+					</compilerArgs>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>com.google.errorprone</groupId>
+							<artifactId>error_prone_core</artifactId>
+							<version>2.3.3</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
ErrorProne (https://errorprone.info) performs static analysis and issues warnings for Java code likely to cause errors.

See https://errorprone.info/docs/installation for information about the configuration of the Maven plugin.