### PR TITLE
Configuration Parser: use the static parser the right way

### DIFF
--- a/tlatools/src/tla2sany/configuration/ASCII_CharStream.java
+++ b/tlatools/src/tla2sany/configuration/ASCII_CharStream.java
@@ -257,9 +257,7 @@ public final class ASCII_CharStream
   static public void ReInit(java.io.Reader dstream, int startline,
   int startcolumn, int buffersize)
   {
-    // Bug: The following line used to read "inputStream = dstream;" but this bug was
-    // corrected by DRJ.  The correction should be in the .jcc copy, but isn't.
-    inputStream = null;
+    inputStream = dstream;
     line = startline;
     column = startcolumn - 1;
 

--- a/tlatools/src/tla2sany/configuration/Configuration.java
+++ b/tlatools/src/tla2sany/configuration/Configuration.java
@@ -4,8 +4,7 @@
 /***************************************************************************
 * This file was originally created by running javacc on the grammar file   *
 * config.jj that specifies the parsing of the string                       *
-* ConfigConstants.defaultConfig.  The current file has since been          *
-* modified by DRJ (David Jefferson).                                       *
+* ConfigConstants.defaultConfig.                                           *
 *                                                                          *
 * This file was modified by LL on 13 May 2008 to replace calls to          *
 * System.out and System.err by calls to ToolIO.out and ToolIO.err.         *
@@ -42,7 +41,7 @@ public final class Configuration implements ConfigConstants {
     /***********************************************************************
     * Called from drivers/SANY.java                                        *
     ***********************************************************************/
-    Configuration Parser;
+
     try {
       errors = errs;
       File source = new File( "config.src" );
@@ -56,10 +55,10 @@ public final class Configuration implements ConfigConstants {
         input = new java.io.StringReader( defaultConfig );
         origin = " from defaults.";
       }
-      Parser = new Configuration( input );
+     Configuration.ReInit(input);
 
       try {
-        Parser.ConfigurationUnit();
+        Configuration.ConfigurationUnit();
 //      Operators.printTable();
       } catch (ParseException e) {
         errors.addAbort(Location.nullLoc,"\nConfiguration Parser:  Encountered errors during parse.  " 
@@ -318,18 +317,6 @@ public final class Configuration implements ConfigConstants {
     jj_gen = 0;
     for (int i = 0; i < 7; i++) jj_la1[i] = -1;
   }
-
-  // The following method added by DRJ.  It should be in the .jcc version of this file
-  static public void ReInit() {
-    jj_initialized_once = false;
-    jj_input_stream.ReInit(input, 1, 1);
-    token_source.ReInit(jj_input_stream);
-    token = new Token();
-    jj_ntk = -1;
-    jj_gen = 0;
-    for (int i = 0; i < 7; i++) jj_la1[i] = -1;
-  }
-
 
   public Configuration(ConfigurationTokenManager tm) {
     if (jj_initialized_once) {

--- a/tlatools/src/tla2sany/configuration/ConfigurationTokenManager.java
+++ b/tlatools/src/tla2sany/configuration/ConfigurationTokenManager.java
@@ -3,8 +3,7 @@
 /***************************************************************************
 * This file was originally created by running javacc the grammar file      *
 * config.jj that specifies the parsing of the string                       *
-* ConfigConstants.defaultConfig.  The current file has since been          *
-* modified by DRJ (David Jefferson).                                       *
+* ConfigConstants.defaultConfig.                                           *
 ***************************************************************************/
 
 package tla2sany.configuration;
@@ -1024,9 +1023,7 @@ static public void ReInit(ASCII_CharStream stream)
 {
    jjmatchedPos = jjnewStateCnt = 0;
    curLexState = defaultLexState;
-   // Bug: The following line used to read "input_stream = stream; but this bug was corrected
-   // by DRJ.  The bug should also be corrected in the .jcc file, but isn't.
-   input_stream = null;
+   input_stream = stream;
    ReInitRounds();
 }
 static private final void ReInitRounds()

--- a/tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/src/tla2sany/drivers/SANY.java
@@ -156,9 +156,6 @@ public class SANY {
     try {
       // Read & initialize config file for each specification
 
-      // Set Configuration class to (re)start
-      Configuration.ReInit();
-
       // (Re)create an empty Context object
       Context.reInit();
 


### PR DESCRIPTION
Remove a missuse of the static configuration parser.
Before the parser is called the source of the input must
be specified and passed to the ReInit() method to
(re-)initialize the internal members of the parser.
Thats the way how the JavaCC devs want us to use the parser
in the static version.

This patch removes the handwritten ReInit() method
which was used to do the reinitialization without
knowledge of the input and the two resulting
bugfixes which made that ReInit() method work,
but broke the way it should be used.

The code is now restored the way it is generated by JavaCC.

[Refactor][SANY]