### PR TITLE
Javacc4 config input file

### DIFF
--- a/tlatools/javacc/config.jj
+++ b/tlatools/javacc/config.jj
@@ -131,12 +131,12 @@ TOKEN : {
 }
 
 void
-ConfigurationUnit() : { }{
+ConfigurationUnit() throws AbortException : { }{
   (OpDefinition()) *
 }
 
 void
-OpDefinition() : {
+OpDefinition() throws AbortException : {
   Token t; }{
   ( <OPERATOR> (t = <OPID>) { /* System.out.println( t.image ); */ } ( OpBody(t.image) | OpNull(t.image) ) )
   | OpSynonym()
@@ -185,7 +185,7 @@ OpNull( String s ) : {
 }
 
 void
-OpBuiltin() : {
+OpBuiltin() throws AbortException : {
   Token t;
   String external, internal;
   UniqueString us;

--- a/tlatools/javacc/config.jj
+++ b/tlatools/javacc/config.jj
@@ -49,42 +49,47 @@ import util.UniqueString;
 
 public final class Configuration implements ConfigConstants {
 
-public static void displayDefinitions() {
-  System.out.println( defaultConfig );
-}
+  private static Errors         errors;
+  private static java.io.Reader input;
 
-public static void load ( ) {
-  Configuration Parser;
-  try {
-    File source = new File( "config.src" );
-    java.io.InputStream input;
-    String origin;
-
-    if ( source.exists() ) {
-//      java.io.OutputStream output;
-      input = new java.io.FileInputStream( source );
-      origin = " from local config.src file.";
-    } else {
-      input = new java.io.StringBufferInputStream( defaultConfig );
-      origin = " from defaults.";
-    }
-    Parser = new Configuration( input );
-
-    try {
-      Parser.ConfigurationUnit();
-//      Operators.printTable();
-    } catch (ParseException e) {
-      System.err.println(e.getMessage());
-      System.err.println("Configuration Parser:  Encountered errors during parse.");
-      System.exit(0);
-    }
-
-  } catch (java.io.FileNotFoundException e) {
-    System.err.println("File not found.");
-    System.exit(0);
+  public static void displayDefinitions() {
+    ToolIO.out.println( defaultConfig );
   }
-}
 
+  public static void load (Errors errs ) throws AbortException {
+    /***********************************************************************
+    * Called from drivers/SANY.java                                        *
+    ***********************************************************************/
+    Configuration Parser;
+    try {
+      errors = errs;
+      File source = new File( "config.src" );
+      String origin;
+
+      if ( source.exists() ) {
+//      java.io.OutputStream output;
+        input = new java.io.FileReader( source );
+        origin = " from local config.src file.";
+      } else {
+        input = new java.io.StringReader( defaultConfig );
+        origin = " from defaults.";
+      }
+      Parser = new Configuration( input );
+
+      try {
+        Parser.ConfigurationUnit();
+//      Operators.printTable();
+      } catch (ParseException e) {
+        errors.addAbort(Location.nullLoc,"\nConfiguration Parser:  Encountered errors during parse.  "
+                        + e.getMessage(),true );
+      }
+
+    } catch (java.io.FileNotFoundException e) {
+      errors.addAbort(Location.nullLoc,"File not found.\n" + e,true);
+    }
+
+
+  }
 }
 PARSER_END(Configuration)
 

--- a/tlatools/javacc/config.jj
+++ b/tlatools/javacc/config.jj
@@ -27,6 +27,7 @@ options {
   DEBUG_LOOKAHEAD = false;
   DEBUG_TOKEN_MANAGER = false;
   STATIC = true;
+  JDK_VERSION = "1.8";
 }
 
 PARSER_BEGIN(Configuration)

--- a/tlatools/javacc/config.jj
+++ b/tlatools/javacc/config.jj
@@ -31,17 +31,21 @@ options {
 
 PARSER_BEGIN(Configuration)
 
-package tlatk.configuration;
+package tla2sany.configuration;
+
 import java.io.File;
-import tlatk.parser.Operator;
-import tlatk.parser.Operators;
-import tlatk.parser.SyntaxTreeNode;
 
-import tlatk.utilities.UniqueString;
-
-import tlatk.semantic.OpDefNode;
-import tlatk.semantic.FormalParamNode;
-import tlatk.semantic.Context;
+import tla2sany.parser.Operator;
+import tla2sany.parser.Operators;
+import tla2sany.parser.SyntaxTreeNode;
+import tla2sany.semantic.AbortException;
+import tla2sany.semantic.Context;
+import tla2sany.semantic.Errors;
+import tla2sany.semantic.FormalParamNode;
+import tla2sany.semantic.OpDefNode;
+import tla2sany.st.Location;
+import util.ToolIO;
+import util.UniqueString;
 
 public final class Configuration implements ConfigConstants {
 
@@ -186,22 +190,22 @@ OpBuiltin() : {
   t = <OPID> { external = t.image; us = UniqueString.uniqueStringOf( external ); }
   t = <RESTRICTED> { internal = t.image; }
 //  sig = Signature()
- (    <INFIX> {Context.addGlobalSymbol( us, new OpDefNode( tlatk.semantic.ASTConstants.BuiltInKind, new FormalParamNode[2], false, null, null, new SyntaxTreeNode( us ) ));}
- |   <PREFIX> {Context.addGlobalSymbol( us, new OpDefNode( tlatk.semantic.ASTConstants.BuiltInKind, new FormalParamNode[1], false, null, null, new SyntaxTreeNode( us ) ));}
- |  <POSTFIX> {Context.addGlobalSymbol( us, new OpDefNode( tlatk.semantic.ASTConstants.BuiltInKind, new FormalParamNode[1], false, null, null, new SyntaxTreeNode( us ) ));}
- | <CONSTANT> {Context.addGlobalSymbol( us, new OpDefNode( tlatk.semantic.ASTConstants.BuiltInKind, new FormalParamNode[0], false, null, null, new SyntaxTreeNode( us ) ));}
+ (    <INFIX> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[2], false, null, null, new SyntaxTreeNode( us ) ));}
+ |   <PREFIX> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[1], false, null, null, new SyntaxTreeNode( us ) ));}
+ |  <POSTFIX> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[1], false, null, null, new SyntaxTreeNode( us ) ));}
+ | <CONSTANT> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[0], false, null, null, new SyntaxTreeNode( us ) ));}
  | t = <NUMBER> {
      int n = Integer.parseInt( t.image );
      FormalParamNode fpn[] = null;
      if ( n != -1 ) fpn = new FormalParamNode[ n ];
-     Context.addGlobalSymbol( us, new OpDefNode( tlatk.semantic.ASTConstants.BuiltInKind, fpn, false, null, null, new SyntaxTreeNode( us ) ));
+     Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, fpn, false, null, null, new SyntaxTreeNode( us ) ));
    }
  )
   { }
 }
 
 /*
-new OpDefNode( tlatk.semantic.ASTConstants.BuiltInKind, {null,null}, false );
+new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, {null,null}, false );
 
 Signature
 Signature() : {

--- a/tlatools/javacc/config.jj
+++ b/tlatools/javacc/config.jj
@@ -175,12 +175,13 @@ void
 OpSynonym() : {
   Token t1, t2; }{
   <SYNONYM> t1 = <OPID> t2 = <OPID>
-  { Operators.addSynonym( UniqueString.uniqueStringOf(t1.image), UniqueString.uniqueStringOf(t2.image) ); }
+  { Operators.addSynonym( UniqueString.uniqueStringOf(t1.image),
+                          UniqueString.uniqueStringOf(t2.image) ); }
 }
 
 void
 OpNull( String s ) : {
- Token t; }{
+    Token t; }{
   <NOTOP>
 }
 
@@ -192,8 +193,12 @@ OpBuiltin() throws AbortException : {
 //  Signature sig;
 }{
   <BUILTIN>
-  t = <OPID> { external = t.image; us = UniqueString.uniqueStringOf( external ); }
-  t = <RESTRICTED> { internal = t.image; }
+  t = <OPID> {
+    external = t.image; us = UniqueString.uniqueStringOf( external );
+  }
+  t = <RESTRICTED> {
+    internal = t.image;
+  }
 //  sig = Signature()
  (    <INFIX> {
       Context.addGlobalSymbol( us, new OpDefNode( us, tla2sany.semantic.ASTConstants.BuiltInKind, 2,

--- a/tlatools/javacc/config.jj
+++ b/tlatools/javacc/config.jj
@@ -195,15 +195,30 @@ OpBuiltin() throws AbortException : {
   t = <OPID> { external = t.image; us = UniqueString.uniqueStringOf( external ); }
   t = <RESTRICTED> { internal = t.image; }
 //  sig = Signature()
- (    <INFIX> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[2], false, null, null, new SyntaxTreeNode( us ) ));}
- |   <PREFIX> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[1], false, null, null, new SyntaxTreeNode( us ) ));}
- |  <POSTFIX> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[1], false, null, null, new SyntaxTreeNode( us ) ));}
- | <CONSTANT> {Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, new FormalParamNode[0], false, null, null, new SyntaxTreeNode( us ) ));}
+ (    <INFIX> {
+      Context.addGlobalSymbol( us, new OpDefNode( us, tla2sany.semantic.ASTConstants.BuiltInKind, 2,
+                        new FormalParamNode[2], false, null, null, null, new SyntaxTreeNode( us ) ),
+                        errors);}
+ |   <PREFIX> {
+      Context.addGlobalSymbol( us, new OpDefNode( us, tla2sany.semantic.ASTConstants.BuiltInKind, 1,
+                        new FormalParamNode[1], false, null, null, null, new SyntaxTreeNode( us ) ),
+                        errors);}
+ |  <POSTFIX> {
+      Context.addGlobalSymbol( us, new OpDefNode( us, tla2sany.semantic.ASTConstants.BuiltInKind, 1,
+                        new FormalParamNode[1], false, null, null, null, new SyntaxTreeNode( us ) ),
+                        errors);}
+ | <CONSTANT> {
+      Context.addGlobalSymbol( us, new OpDefNode( us, tla2sany.semantic.ASTConstants.BuiltInKind, 0,
+                        new FormalParamNode[0], false, null, null, null, new SyntaxTreeNode( us ) ),
+                        errors);}
  | t = <NUMBER> {
-     int n = Integer.parseInt( t.image );
-     FormalParamNode fpn[] = null;
-     if ( n != -1 ) fpn = new FormalParamNode[ n ];
-     Context.addGlobalSymbol( us, new OpDefNode( tla2sany.semantic.ASTConstants.BuiltInKind, fpn, false, null, null, new SyntaxTreeNode( us ) ));
+      int n = Integer.parseInt( t.image );
+      FormalParamNode fpn[] = null;
+      if ( n != -1 ) fpn = new FormalParamNode[ n ];
+      Context.addGlobalSymbol( us,
+                        new OpDefNode( us, tla2sany.semantic.ASTConstants.BuiltInKind, n,
+                                       fpn, false, null, null, null, new SyntaxTreeNode( us ) ),
+                                       errors);
    }
  )
   { }


### PR DESCRIPTION
This patchset applies the code from Configuration.java to the input file config.jj which is used to generate a fresh parser.
**Only config.jj is changed** in this patchset, so **nothing can break**.

A generated parser by JavaCC V4.0 from this config.jj has still differences to the currently used code,
but they are either trivial or unmodifiable by editing config.jj.

This is the diffstat of a patch from the current Configuration.java to a fresh one from JavaCC 4.0:

Configuration.java |   95 +++++++++++++++++++++--------------------------------
 1 file changed, 38 insertions(+), 57 deletions(-)

Best regards.

P.S.: I fully understand and agree with your arguments and I'm not discouraged by your rejection.
Also I understand that my initial pull request [#248](https://github.com/tlaplus/tlaplus/pull/248) was too ambitious and could have been made more comprehensible.


Sadly I could not reproduce the failed JUnit-Tests you mentioned in [#254](https://github.com/tlaplus/tlaplus/pull/254#issuecomment-473422610), since I ran them also on my machine where they did not fail. I'm using:
openjdk version "1.8.0_191"
OpenJDK Runtime Environment (build 1.8.0_191-8u191-b12-2ubuntu0.18.04.1-b12)
OpenJDK 64-Bit Server VM (build 25.191-b12, mixed mode)