### PR TITLE
Fix TLC help msg: gzip is off by default

### DIFF
--- a/tlatools/src/tlc2/TLC.java
+++ b/tlatools/src/tlc2/TLC.java
@@ -179,7 +179,7 @@ public class TLC
      *    stored in the class FP64.
      *  o -view: apply VIEW (if provided) when printing out states.
      *  o -gzip: control if gzip is applied to value input/output stream.
-     *    Defaults to use gzip.
+     *    Defaults to off if not specified
      *  o -debug: debbuging information (non-production use)
      *  o -tool: tool mode (put output codes on console)
      *  o -checkpoint num: interval for check pointing (in minutes)

--- a/tlatools/src/tlc2/output/messages.properties
+++ b/tlatools/src/tlc2/output/messages.properties
@@ -22,7 +22,7 @@ and the optional GENERAL-SWITCHES are:\n\
  -fp num: use the num'th irreducible polynomial from the list \n\
  \tstored in the class FP64.\n\
  -gzip: control if gzip is applied to value input/output stream.\n\
- \tDefaults to use gzip.\n\
+ \tDefaults to off if not specified\n\
  -metadir path: store metadata in the directory at path\n\
  \tDefaults to SPEC-directory/states if not specified\n\
  -recover id: recover from the checkpoint with id\n\


### PR DESCRIPTION
The GZIP default is defined to be `false` here:
https://github.com/tlaplus/tlaplus/blob/master/tlatools/src/tlc2/TLCGlobals.java#L163