### PR TITLE
Add ant target that allows for the execution of a single unit test class

### DIFF
--- a/tlatools/customBuild.xml
+++ b/tlatools/customBuild.xml
@@ -451,6 +451,49 @@
 		<delete dir="${ws.class.dir}" deleteonexit="true"/>
 	</target>
 
+	<!-- Executes a single unit test. -->
+	<target name="test-single" unless="test.skip">
+		<!-- run junit test -->
+		<junit printsummary="yes" haltonfailure="true" showoutput="no" haltonerror="true" forkmode="perTest" fork="yes">
+			<!-- enable all assertions -->
+			<jvmarg value="-ea"/>
+			<jvmarg value="-XX:MaxDirectMemorySize=512k"/>
+			<jvmarg value="-XX:+UseParallelGC"/>
+			<!-- Uncomment to open a debug port in each forked VM to remote attach your Eclipse at port 1044.
+            <jvmarg value="-Xdebug" />
+	        <jvmarg value="-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=1044" />
+			-->
+			<classpath refid="project.classpath" />
+			<classpath>
+				<pathelement location="lib/junit-4.12.jar" />
+				<pathelement location="lib/hamcrest-core-1.3.jar" />
+				<pathelement location="lib/cglib-nodep-3.1.jar" />
+				<pathelement location="lib/objenesis-2.1.jar" />
+				<pathelement location="lib/easymock-3.3.1.jar" />
+				<pathelement location="lib/javax.mail/mailapi-1.6.3.jar" />
+				<pathelement location="test-model/UserModuleOverrideFromJar.jar" />
+				<pathelement path="${class.dir}" />
+				<pathelement path="${test.class.dir}" />
+				<pathelement path="${test.class.dir}" />
+				<pathelement path="test-model/" />
+			</classpath>
+
+			<!-- Pass the base path of the tlatools project to unit tests in case they need it to locate TLA+ specs or configs -->
+			<sysproperty key="basedir" value="${basedir}/"/>
+			<sysproperty key="tlc2.tool.fp.FPSet.impl" value="tlc2.tool.fp.OffHeapDiskFPSet"/>
+			<sysproperty key="util.FileUtil.milliseconds" value="true"/>
+			<sysproperty key="tlc2.tool.distributed.TLCWorker.threadCount" value="4"/>
+
+			<!-- Print all output of the test to the screen. -->
+			<formatter type="plain" usefile="false" />
+			<!-- Run a single test case specified by its class name, by setting the property 'test.testcase'. -->
+			<test name="${test.testcase}" skipNonTests="true"/>
+		</junit>
+
+		<!-- remove copied class.dir -->
+		<delete dir="${ws.class.dir}" deleteonexit="true"/>
+	</target>
+
 	<!-- Executes accompining unit tests on jar file -->
 	<target name="test-dist" unless="test.skip">
 		<!-- run junit tests on tlatools.jar -->


### PR DESCRIPTION
Addresses issue #363. Adds a new ant target `test-single` so you can run a single unit test class from the command line. For example, you can run

```
ant -Dtest.testcase="pcal.AssignmentToUndeclaredVariableTest" -f customBuild.xml test-single
```

and the output will be:
```
Buildfile: /Users/williamschultz/Desktop/scratchpad/tla-dev/tlatools/customBuild.xml

test-single:
    [junit] Running pcal.AssignmentToUndeclaredVariableTest
    [junit] Testsuite: pcal.AssignmentToUndeclaredVariableTest
    [junit] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 sec
    [junit] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.123 sec
    [junit]
    [junit] Testcase: macroParam took 0.071 sec
    [junit] Testcase: procedure took 0.004 sec
    [junit] Testcase: constant took 0.002 sec
    [junit] Testcase: boundIdentifier took 0.002 sec
    [junit] Testcase: process took 0.007 sec
    [junit] Testcase: macro took 0.004 sec
    [junit] Testcase: multiAssignment took 0.004 sec

BUILD SUCCESSFUL
Total time: 1 second
```

For a failing run of the test, we get the following:
```
Buildfile: /Users/williamschultz/Desktop/scratchpad/tla-dev/tlatools/customBuild.xml

test-single:
    [junit] Running pcal.AssignmentToUndeclaredVariableTest
    [junit] Testsuite: pcal.AssignmentToUndeclaredVariableTest
    [junit] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.16 sec
    [junit] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.16 sec
    [junit]
    [junit] Testcase: macroParam took 0.094 sec
    [junit] Testcase: procedure took 0.01 sec
    [junit] 	FAILED
    [junit] [
    [junit] Unrecoverable error:
    [junit]  -- Expected "(" but found "c1"
    [junit]     line 10, column 16.
    [junit] ]
    [junit] junit.framework.AssertionFailedError: [
    [junit] Unrecoverable error:
    [junit]  -- Expected "(" but found "c1"
    [junit]     line 10, column 16.
    [junit] ]
    [junit] 	at pcal.AssignmentToUndeclaredVariableTest.procedure(AssignmentToUndeclaredVariableTest.java:58)
    [junit] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    [junit] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    [junit] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    [junit]
    [junit] Testcase: constant took 0.007 sec
    [junit] Testcase: boundIdentifier took 0.005 sec
    [junit] Testcase: process took 0.008 sec
    [junit] Testcase: macro took 0.003 sec
    [junit] Testcase: multiAssignment took 0.003 sec

BUILD FAILED
/Users/williamschultz/Desktop/scratchpad/tla-dev/tlatools/customBuild.xml:457: Test pcal.AssignmentToUndeclaredVariableTest failed

Total time: 1 second
```