### PR TITLE
Include the test classes in the benchmark JAR

### DIFF
--- a/tlatools/customBuild.xml
+++ b/tlatools/customBuild.xml
@@ -728,6 +728,7 @@
 			</manifest>
 <!--			<zipfileset dir="${src.dir}" includes="**/*.java" />-->
 			<fileset dir="${class.dir}" includes="**/*" />
+			<fileset dir="${test.class.dir}" includes="**/*" />
 			<zipfileset src="lib/jmh/jmh-core-1.21.jar" excludes="**/META-INF/services/**" />
 			<zipfileset src="lib/jmh/jopt-simple-4.6.jar" />
 			<zipfileset src="lib/jmh/commons-math3-3.2.jar" />


### PR DESCRIPTION
The "ant" benchmark instructions in `tlatools/test-benchmark/README.txt` did not work for me without this change.

I believe this is a correct fix since the test classes are included in the compile classpath several lines above. Without this fix, the instructions in the README lead to many errors of the form:

```
# JMH version: 1.21
# VM version: JDK 12.0.1, Java HotSpot(TM) 64-Bit Server VM, 12.0.1+12
# VM invoker: /Library/Java/JavaVirtualMachines/jdk-12.0.1.jdk/Contents/Home/bin/java
# VM options: -ea -Xms8192m -Xmx8192m -Dtlc2.tool.ModuleOverwritesBenchmark.base=/Users/loncaric/src/tlaplus/tlatools/test-model
# Warmup: 1 iterations, 10 s each
# Measurement: 1 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 2 threads (1 group; 1x "consumer1", 1x "producer1" in each group), will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: tlc2.tool.queue.DiskQueueBenachmark.g02
# Parameters: (impl = DiskByteArrayQueue, vars = 1)

# Run progress: 0.00% complete, ETA 00:18:40
# Fork: 1 of 1
# Warmup Iteration   1: <failure>

java.lang.NoClassDefFoundError: tlc2/tool/TLCStates
    at tlc2.tool.queue.DiskQueueBenachmark.up(Unknown Source)
    at tlc2.tool.queue.generated.DiskQueueBenachmark_g02_jmhTest._jmh_tryInit_f_diskqueuebenachmark0_G(Unknown Source)
    at tlc2.tool.queue.generated.DiskQueueBenachmark_g02_jmhTest.g02_Throughput(Unknown Source)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:567)
    at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
    at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:835)
Caused by: java.lang.ClassNotFoundException: tlc2.tool.TLCStates
    at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
    at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
    ... 15 more
```

Someone who understands the build file better than me should advise on whether this is a correct change, or whether the benchmark instructions need to be updated.