### PR TITLE
Fix TLC rerun at same JVM for some temporal property

### DIFF
--- a/tlatools/src/tlc2/TLC.java
+++ b/tlatools/src/tlc2/TLC.java
@@ -990,17 +990,21 @@ public class TLC {
 		return dumpFile + suffix;
 	}
 
+    public void resetStartTime() {
+        startTime = System.currentTimeMillis();
+    }
+
 	/**
      * The processing method
      */
     public int process()
     {
         // UniqueString.initialize();
-        
-        // a JMX wrapper that exposes runtime statistics 
+
+        // a JMX wrapper that exposes runtime statistics
         TLCStandardMBean modelCheckerMXWrapper = TLCStandardMBean.getNullTLCStandardMBean();
-        
-		// SZ Feb 20, 2009: extracted this method to separate the 
+
+		// SZ Feb 20, 2009: extracted this method to separate the
         // parameter handling from the actual processing
         try
         {

--- a/tlatools/src/tlc2/tool/liveness/LiveWorker.java
+++ b/tlatools/src/tlc2/tool/liveness/LiveWorker.java
@@ -89,6 +89,13 @@ public class LiveWorker extends IdThread {
 		}
 	}
 
+        /**
+         * Clears errFoundByThread by resetting it.
+         */
+        public static void resetErrFound() {
+                errFoundByThread = -1;
+        }
+
 	/**
 	 * Returns true iff either an error has not been found or the error is found
 	 * by this thread.


### PR DESCRIPTION
I'm in a clojure REPL (but it's only a technicality). When running
the TLC model checker for some TLA file for the first time, it shows
me the correct error for a temporal property. But for a rerun of the
TLC model checker, it does not show me this error.

```clojure
;; Code which is run twice
(doto (tlc2.TLC.)
  (.handleParameters (into-array
                      ["/Users/feodrippe/dev/my-practical-tlaplus/ch1/wire.tla"]))
  (.process))
```

I was debugging it and found that there are some assumptions for the
initial values of the `LiveWorker` class. Maybe it should reset all the
static variables to their initial values when the method `process` is run,
but for now I've just created a public function to reset `errFoundByThread`
whenever someone needs it, I don't want to break anyone's code.

To give a more accurate time, you can also reset startTime at TLC class.