### PR TITLE
Allow "-workers auto" to automatically detect available parallelism

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -747,7 +747,9 @@ public class TLC {
                 {
                     try
                     {
-                        int num = Integer.parseInt(args[index]);
+                        int num = args[index].strip().toLowerCase().equals("auto")
+                                ? Runtime.getRuntime().availableProcessors()
+                                : Integer.parseInt(args[index]);
                         if (num < 1)
                         {
                             printErrorMsg("Error: at least one worker required.");
@@ -757,12 +759,12 @@ public class TLC {
                         index++;
                     } catch (Exception e)
                     {
-                        printErrorMsg("Error: worker number required. But encountered " + args[index]);
+                        printErrorMsg("Error: worker number or 'auto' required. But encountered " + args[index]);
                         return false;
                     }
                 } else
                 {
-                    printErrorMsg("Error: expect an integer for -workers option.");
+                    printErrorMsg("Error: expect an integer or 'auto' for -workers option.");
                     return false;
                 }
             } else if (args[index].equals("-dfid"))
@@ -1438,7 +1440,9 @@ public class TLC {
 														"an absolute path to a file in which to log user output (for\n"
     														+ "example, that which is produced by Print)", true));
     	sharedArguments.add(new UsageGenerator.Argument("-workers", "num",
-														"the number of TLC worker threads; defaults to 1", true));
+														"the number of TLC worker threads; defaults to 1. Use 'auto'\n"
+    														+ "to automatically select the number of threads based on the\n"
+    														+ "number of available cores.", true));
     	
     	sharedArguments.add(new UsageGenerator.Argument("SPEC", null));
     	

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -814,7 +814,7 @@ public class TLC {
                     }
                 } else
                 {
-                    printErrorMsg("Error: expect an integer for -workers option.");
+                    printErrorMsg("Error: expect an integer for -fp option.");
                     return false;
                 }
             } else if (args[index].equals("-fpmem"))


### PR DESCRIPTION
I often forget how many cores my laptop has. (It's more than one but less than eight, I think.)

In any case, now I don't need to know. The toolbox GUI has had this feature forever, but I have wanted it in the command-line tools for a while.

As a bonus, this change also fixes a typo in another error message.