### PR TITLE
Improve error messages for TupleValue and RecordValue

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
@@ -232,8 +232,7 @@ public static final RecordValue EmptyRcd = new RecordValue(new UniqueString[0], 
   public final Value apply(Value arg, int control) {
     try {
       if (!(arg instanceof StringValue)) {
-        Assert.fail("Attempted to apply record to a non-string value " +
-        Values.ppr(arg.toString()) + ".");
+        Assert.fail("Attempted to access record by a non-string argument: " + Values.ppr(arg.toString()));
       }
       UniqueString name = ((StringValue)arg).getVal();
       int rlen = this.names.length;
@@ -242,8 +241,8 @@ public static final RecordValue EmptyRcd = new RecordValue(new UniqueString[0], 
           return this.values[i];
         }
       }
-      Assert.fail("Attempted to apply the record\n" + Values.ppr(this.toString()) +
-      "\nto nonexistent record field " + name + ".");
+      Assert.fail("Attempted to access nonexistent field '" + name +
+          "' of record\n" + Values.ppr(this.toString()));
       return null;    // make compiler happy
     }
     catch (RuntimeException | OutOfMemoryError e) {
@@ -271,8 +270,7 @@ public static final RecordValue EmptyRcd = new RecordValue(new UniqueString[0], 
   public final Value select(Value arg) {
     try {
       if (!(arg instanceof StringValue)) {
-        Assert.fail("Attempted to apply record to a non-string argument " +
-        Values.ppr(arg.toString()) + ".");
+        Assert.fail("Attempted to access record by a non-string argument: " + Values.ppr(arg.toString()));
       }
       UniqueString name = ((StringValue)arg).getVal();
       int rlen = this.names.length;

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/TupleValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/TupleValue.java
@@ -126,12 +126,12 @@ public class TupleValue extends Value implements Applicable, ITupleValue {
   public final Value apply(Value arg, int control) {
     try {
       if (!(arg instanceof IntValue)) {
-        Assert.fail("Attempted to apply tuple to a non-integer argument.");
+        Assert.fail("Attempted to access tuple at a non integral index: " + Values.ppr(arg.toString()));
       }
       int idx = ((IntValue)arg).val;
       if (idx <= 0 || idx > this.elems.length) {
-        Assert.fail("Attempted to apply tuple\n" + Values.ppr(this.toString()) +
-        "\nto integer " + idx + " which is out of domain.");
+        Assert.fail("Attempted to access index " + idx + " of tuple\n"
+            + Values.ppr(this.toString()) + "\nwhich is out of bounds.");
       }
       return (Value) this.elems[idx-1];
     }
@@ -145,7 +145,7 @@ public class TupleValue extends Value implements Applicable, ITupleValue {
   public final Value apply(Value[] args, int control) {
     try {
       if (args.length != 1) {
-        Assert.fail("Attetmpted to apply tuple with wrong number of arguments.");
+        Assert.fail("Attempted to access tuple with " + args.length + " arguments when it expects 1.");
       }
       return this.apply(args[0], EvalControl.Clear);
     }
@@ -159,8 +159,7 @@ public class TupleValue extends Value implements Applicable, ITupleValue {
   public final Value select(Value arg) {
     try {
       if (!(arg instanceof IntValue)) {
-        Assert.fail("Attempted to apply tuple to a non-integer argument " +
-        Values.ppr(arg.toString()) + ".");
+        Assert.fail("Attempted to access tuple at a non integral index: " + Values.ppr(arg.toString()));
       }
       int idx = ((IntValue)arg).val;
       if (idx > 0 && idx <= this.elems.length) {

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/RecordValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/RecordValueTest.java
@@ -78,4 +78,28 @@ public class RecordValueTest {
 		assertTrue(deepCopy.values[0].equals(bVal));
 		assertTrue(deepCopy.values[1].equals(aVal));
 	}
+
+	@Test
+	public void testErrorMessages() {
+		final Value aVal = new StringValue("aVal");
+		final RecordValue recVal = new RecordValue(UniqueString.of("a"), aVal);
+
+		try{
+			recVal.apply(new StringValue("b"), 0);
+		} catch(util.Assert.TLCRuntimeException ex){
+			assertTrue(ex.getMessage().contains("Attempted to access nonexistent field 'b' of record\n[a |-> \"aVal\"]"));
+		}
+
+		try{
+			recVal.apply(IntValue.gen(0), 0);
+		} catch(util.Assert.TLCRuntimeException ex){
+			assertTrue(ex.getMessage().contains("Attempted to access record by a non-string argument: 0"));
+		}
+
+		try{
+			recVal.select(IntValue.gen(0));
+		} catch(util.Assert.TLCRuntimeException ex){
+			assertTrue(ex.getMessage().contains("Attempted to access record by a non-string argument: 0"));
+		}
+	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/TupleValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/TupleValueTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ ******************************************************************************/
+package tlc2.value.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.TLCGlobals;
+import tlc2.value.impl.IntervalValue;
+import tlc2.value.impl.SetOfTuplesValue;
+import tlc2.value.impl.TupleValue;
+import tlc2.value.impl.IntValue;
+import tlc2.value.impl.StringValue;
+import tlc2.value.impl.Value;
+import util.Assert;
+
+
+public class TupleValueTest {
+
+    @Test
+    public void testErrorMessages() {
+        Value elems[] = {new StringValue("A")};
+        final TupleValue tupVal = new TupleValue(elems);
+
+        try{
+            tupVal.apply(IntValue.gen(2), 0);
+        } catch(Assert.TLCRuntimeException ex){
+            assertTrue(ex.getMessage().contains("Attempted to access index 2 of tuple\n<<\"A\">>\nwhich is out of bounds"));
+        }
+
+        try{
+            tupVal.apply(new StringValue("a"), 0);
+        } catch(Assert.TLCRuntimeException ex){
+            assertTrue(ex.getMessage().contains("Attempted to access tuple at a non integral index: \"a\""));
+        }
+
+        try{
+            tupVal.select(new StringValue("a"));
+        } catch(Assert.TLCRuntimeException ex){
+            assertTrue(ex.getMessage().contains("Attempted to access tuple at a non integral index: \"a\""));
+        }
+
+        try{
+            Value args[] = {new StringValue("arg1"), new StringValue("arg2")};
+            tupVal.apply(args, 0);
+        } catch(Assert.TLCRuntimeException ex){
+            assertTrue(ex.getMessage().contains("Attempted to access tuple with 2 arguments when it expects 1."));
+        }
+    }
+}


### PR DESCRIPTION
Addresses #456.

I went through the some of the main error messages in TupleValue and RecordValue and tried to make their wording more natural for a reader. I added unit tests for the new error messages. This is how the error messages appear for the test cases I added (each message corresponds to one of the try-catch blocks in the unit test):

**TupleValue**
```
Attempted to access index 2 of tuple
<<"A">>
which is out of bounds.
```

```
Attempted to access tuple at a non integral index: "a"
```

```
Attempted to access tuple at a non integral index: "a"
```

```
Attempted to access tuple with 2 arguments when it expects 1.
```

**RecordValue**

```
Attempted to access nonexistent field 'b' of record
[a |-> "aVal"]
```
```
Attempted to access record by a non-string argument: 0
```

```
Attempted to access record by a non-string argument: 0
```
You can run the tests with the following commands:
```
ant -Dtest.testcase="tlc2.value.impl.TupleValueTest" -f customBuild.xml compile compile-test test-single
ant -Dtest.testcase="tlc2.value.impl.RecordValueTest" -f customBuild.xml compile compile-test test-single
```
I'm sure there is more work that could be done to improve error messages across the TLC codebase, but this is a start. If there are other parts of TLC or the Toolbox that depend on the exact wording of these messages, then my changes here might be unworkable or would have to be altered.