### PR TITLE
[feature] add TLC constructor for custom state writer

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -162,10 +162,15 @@ public class TLC {
         traceDepth = 100;
 
         fpSetConfiguration = new FPSetConfiguration();
-        
+
         avoidMonolithSpecTECreation = false;
         waitingOnGenerationCompletion = new AtomicBoolean(false);
 	}
+
+    public TLC(IStateWriter stateWriter) {
+        this();
+        this.stateWriter = stateWriter;
+    }
 
     /*
      * This TLA checker (TLC) provides the following functionalities:

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/ILivenessStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/ILivenessStateWriter.java
@@ -34,5 +34,5 @@ public interface ILivenessStateWriter extends IStateWriter {
 
 	void writeState(TLCState state, TBGraphNode tableauNode, TLCState successor, TBGraphNode tableauNodeSuccessor, BitVector actionChecks, int from, int length, boolean successorStateIsNew);
 
-	void writeState(TLCState state, TBGraphNode tableauNode, TLCState successor, TBGraphNode tableauNodeSuccessor, BitVector actionChecks, int from, int length, boolean successorStateIsNew, Visualization visulation);
+	void writeState(TLCState state, TBGraphNode tableauNode, TLCState successor, TBGraphNode tableauNodeSuccessor, BitVector actionChecks, int from, int length, boolean successorStateIsNew, Visualization visualization);
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/NoopLivenessStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/NoopLivenessStateWriter.java
@@ -80,7 +80,7 @@ public class NoopLivenessStateWriter implements ILivenessStateWriter {
 	 * @see tlc2.tool.liveness.ILivenessStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.liveness.TBGraphNode, tlc2.tool.TLCState, tlc2.tool.liveness.TBGraphNode, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization)
 	 */
 	public final void writeState(TLCState state, TBGraphNode tableauNode, TLCState successor,
-			TBGraphNode tableauNodeSuccessor, BitVector actionChecks, int from, int to, boolean successorStateIsNew, Visualization visulation) {
+			TBGraphNode tableauNodeSuccessor, BitVector actionChecks, int from, int to, boolean successorStateIsNew, Visualization visualization) {
 		// noop
 	}
 
@@ -95,9 +95,16 @@ public class NoopLivenessStateWriter implements ILivenessStateWriter {
 	 * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization)
 	 */
 	public void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int to, boolean successorStateIsNew,
-			Visualization visulation) {
+			Visualization visualization) {
 		// noop
 	}
+
+    /* (non-Javadoc)
+     * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization, tlc2.tool.Action)
+     */
+    public void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int to, boolean successorStateIsNew, Visualization visualization, Action action) {
+        // noop
+    }
 
 	/* (non-Javadoc)
 	 * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, boolean, tlc2.tool.Action)

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
@@ -183,12 +183,12 @@ public class DotStateWriter extends StateWriter {
 	}
 
 	/* (non-Javadoc)
-	 * @see tlc2.util.StateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, java.lang.String, boolean, tlc2.util.IStateWriter.Visualization)
+	 * @see tlc2.util.StateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, java.lang.String, boolean, tlc2.util.IStateWriter.Visualization, tlc2.tool.Action)
 	 */
 	public synchronized void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int length, boolean successorStateIsNew,
 			Visualization visualization, Action action) {
 		final String successorsFP = Long.toString(successor.fingerPrint());
-		
+
 		// Write the transition edge.
 		this.writer.append(Long.toString(state.fingerPrint()));
 		this.writer.append(" -> ");

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/IStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/IStateWriter.java
@@ -51,21 +51,23 @@ public interface IStateWriter {
 	void writeState(TLCState state);
 
 	void writeState(TLCState state, TLCState successor, boolean successorStateIsNew);
-	
+
 	void writeState(TLCState state, TLCState successor, boolean successorStateIsNew, Action action);
 
-	void writeState(TLCState state, TLCState successor, boolean successorStateIsNew, Visualization visulation);
-	
+	void writeState(TLCState state, TLCState successor, boolean successorStateIsNew, Visualization visualization);
+
 	void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int length, boolean successorStateIsNew);
 
-	void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int length, boolean successorStateIsNew, Visualization visulation);
-	
+	void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int length, boolean successorStateIsNew, Visualization visualization);
+
+    void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int length, boolean successorStateIsNew, Visualization visualization, Action action);
+
 	void close();
 
 	String getDumpFileName();
 
 	boolean isNoop();
-	
+
 	boolean isDot();
 
 	void snapshot() throws IOException;

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/NoopStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/NoopStateWriter.java
@@ -71,9 +71,16 @@ public final class NoopStateWriter implements IStateWriter {
 	 * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization)
 	 */
 	public void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int to, boolean successorStateIsNew,
-			Visualization visulation) {
+			Visualization visualization) {
 		// noop
 	}
+
+    /* (non-Javadoc)
+     * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization, tlc2.tool.Action)
+     */
+    public void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int to, boolean successorStateIsNew, Visualization visualization, Action action) {
+        // noop
+    }
 
 	/* (non-Javadoc)
 	 * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, boolean, tlc2.tool.Action)

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/StateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/StateWriter.java
@@ -103,11 +103,20 @@ public class StateWriter implements IStateWriter
 	 * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization)
 	 */
 	public void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int to, boolean successorStateIsNew,
-			Visualization visulation) {
+			Visualization visualization) {
     	if (successorStateIsNew) {
     		this.writeState(state);
     	}
 	}
+
+    /* (non-Javadoc)
+     * @see tlc2.util.IStateWriter#writeState(tlc2.tool.TLCState, tlc2.tool.TLCState, tlc2.util.BitVector, int, int, boolean, tlc2.util.IStateWriter.Visualization, tlc2.tool.Action)
+     */
+    public void writeState(TLCState state, TLCState successor, BitVector actionChecks, int from, int to, boolean successorStateIsNew, Visualization visualization, Action action) {
+    	if (successorStateIsNew) {
+            this.writeState(state);
+    	}
+    }
 
 	@Override
 	public void snapshot() throws IOException {


### PR DESCRIPTION
## Changes

- Add a custom TLC constructor to receive a `IStateWriter` and use it.
- Add `IStateWrite.writeState` method with 8 args (receiving a `Action` at the very end), it is used at `DotStateWriter.java` as if it was already at the interface.
- Fix some typos (well, I've assumed they were typos).

I could add tests for it, maybe at `TLCTest.java`? 

## Reason
There may be applications (or tooling) using TLA+ which could benefit of a fined control of the State Writer. One use case is to print the states in real time for custom debugging (could be interactive or not, it's up to the application). Another use case is to check the trace in a override operator without having to read from a file (I had no success using `TLCTrace` while in runtime, maybe someone could point me out other ways to do it?).

I have the second case. I'm testing some real system code from a simple TLA+ Spec (there were some other changes I've needed to make to at tlaplus code to know the current state when calling some operator, but it's very rough and need more think time).

If this is not desired, please tell me.