### PR TITLE
Closes #490: look up for modules in the directories that are defined in the environment variable TLA_PATH

### DIFF
--- a/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
@@ -31,6 +31,16 @@ import java.net.URL;
 public class SimpleFilenameToStream implements FilenameToStream {
 
 	public static final String TLA_LIBRARY = "TLA-Library";
+	
+	/**
+	 * The environment variable that enumerates the directories, in which
+	 * the modules should be looked up (following the syntax of PATH).
+	 * The Java system variable TLA_LIBRARY is joined with TLA_PATH.
+	 * The paths defined in TLA_LIBRARY have priority over the paths defined in TLA_PATH.
+	 * 
+	 * July 2020 - Igor Konnov, issue #490.
+	 */
+	public static final String TLA_PATH = "TLA_PATH";
 
 	public static final String STANDARD_MODULES_FOLDER = "StandardModules";
 
@@ -57,8 +67,8 @@ public class SimpleFilenameToStream implements FilenameToStream {
 /**
  * August 2014 - TL
  * This constructor was on the interface but was not implemented.
- * Now one can pass additiona libraries which will be added to the
- * installtion path and instead the path supplied using the system property TLA_LIBRARY
+ * Now one can pass additional libraries which will be added to the
+ * installation path and instead the path supplied using the system property TLA_LIBRARY
  * (which is being used in the default constructor).
  */
   public SimpleFilenameToStream(String[] anLibraryPaths) {
@@ -119,8 +129,18 @@ public class SimpleFilenameToStream implements FilenameToStream {
   private String[] getLibraryPaths(final String installationBasePath, String[] libraries) {
     String[] res;
     String path = null;
-    if (libraries == null) path = System.getProperty(TLA_LIBRARY);
-    else {
+    if (libraries == null) {
+    	path = System.getProperty(TLA_LIBRARY);
+    	// July 2020 - Igor Konnov, issue #490
+    	String envTlaPath = System.getenv(TLA_PATH);
+    	if (path == null) {
+    		// TLA_LIBRARY points to nothing, use TLA_PATH
+    		path = envTlaPath; // as a result, path may be null
+    	} else if (envTlaPath != null) {
+    		// Both TLA_LIBRARY and TLA_PATH are defined, join them
+    		path += FileUtil.pathSeparator + envTlaPath;
+    	}
+    } else {
       StringBuffer buf = new StringBuffer();
       for (int i=0; i<libraries.length; i++) {
         buf.append(libraries[i]);


### PR DESCRIPTION
This PR closes issue #490. The paths defined in the environment variable `TLA_PATH` are joined with the paths defined in the Java system variable `TLA-Library`. The latter is having priority over the former.

As it is not clear, how to test this behavior with unit tests, I only did rudimentary testing:

```bash
$ pwd
/Users/igor/tmp/tlapath
$ export TLA_PATH=`pwd`/a:`pwd`/b
$ echo $TLA_PATH 
/Users/igor/tmp/tlapath/a:/Users/igor/tmp/tlapath/b
$ cat a/A.tla
--------- MODULE A -----------
EXTENDS Integers
DO_A(x) == x + x
=======================
$ cat b/B.tla                 
--------- MODULE B -----------
EXTENDS A
DO_B(x) == DO_A(x) + 1
=======================
$ cat c/C.tla                                           
---------- MODULE C ---------
EXTENDS B
DO_C(x) == DO_B(4)
=======================
$ cd c
$ java -cp $HOME/tmp/tla2tools.jar tla2sany.SANY C.tla

****** SANY2 Version 2.2 created 08 July 2020

Parsing file /Users/igor/tmp/tlapath/c/C.tla
Parsing file /Users/igor/tmp/tlapath/b/B.tla
Parsing file /Users/igor/tmp/tlapath/a/A.tla
Parsing file /private/var/folders/42/77j16l715bd5k68fffptzgvw0000gn/T/Integers.tla
Parsing file /private/var/folders/42/77j16l715bd5k68fffptzgvw0000gn/T/Naturals.tla
Semantic processing of module Naturals
Semantic processing of module Integers
Semantic processing of module A
Semantic processing of module B
Semantic processing of module C
```
