### PR TITLE
Add missing hyphen in brew install command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ The Toolbox's nightly builds are also made available as a [cask](https://github.
 
 ```bash
 $ brew tap homebrew/cask-versions
-$ brew install tlaplus-toolbox-nightly
+$ brew install tla-plus-toolbox-nightly
 ```
 
 Quality Metrics


### PR DESCRIPTION
The name of the nightly build cask is actually `tla-plus-toolbox-nightly` (https://formulae.brew.sh/cask/tla-plus-toolbox)