### PR TITLE
Fix SANY confusing print about not finding module

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -20,7 +20,6 @@ import tla2sany.st.TreeNode;
 import tla2sany.utilities.Vector;
 import util.FileUtil;
 import util.FilenameToStream;
-import util.MonolithSpecExtractor;
 import util.NamedInputStream;
 import util.ToolIO;
 
@@ -279,34 +278,19 @@ public class SpecObj
         // See if ParseUnit "name" is already in parseUnitContext table
         parseUnit = (ParseUnit) parseUnitContext.get(name);
 
-        NamedInputStream nis;
-
         // if not, then we have to get it from the file system
         if (parseUnit == null)
         {
-            // Try loading the module from a monolithic spec (one big .tla
-            // file consisting of multiple TLA+ modules and TLC configs) that is what is the
-            // rootModule here (compare tlc2.tool.impl.ModelConfig.parse()).
-            if (rootParseUnit != null &&
-                rootParseUnit.getNis() != null &&
-                rootParseUnit.getNis().sourceFile() != null) {
-                try {
-                    final File monolithSpec = rootParseUnit.getNis().sourceFile();
-                    nis = MonolithSpecExtractor.module(monolithSpec, name);
-                } catch (IOException e) {
-                    nis = null;
-                }
-            }
-            else {
-                nis = FileUtil.createNamedInputStream(name, this.resolver);
-            }
-
             // if module "name" is not already in parseUnitContext table
+
             // find a file derived from the name and create a
             // NamedInputStream for it if possible
             // SZ 23.02.2009: split the name resolution from the stream retrieval
             // NamedInputStream nis = this.ntfis.toNIStream(name);
-            if (nis == null) {
+            NamedInputStream nis;
+            if (rootParseUnit != null) {
+                nis = FileUtil.createNamedInputStream(name, this.resolver, rootParseUnit.getNis());
+            } else {
                 nis = FileUtil.createNamedInputStream(name, this.resolver);
             }
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -279,28 +279,35 @@ public class SpecObj
         // See if ParseUnit "name" is already in parseUnitContext table
         parseUnit = (ParseUnit) parseUnitContext.get(name);
 
+        NamedInputStream nis;
+
         // if not, then we have to get it from the file system
         if (parseUnit == null)
         {
-            // if module "name" is not already in parseUnitContext table
+            // Try loading the module from a monolithic spec (one big .tla
+            // file consisting of multiple TLA+ modules and TLC configs) that is what is the
+            // rootModule here (compare tlc2.tool.impl.ModelConfig.parse()).
+            if (rootParseUnit != null &&
+                rootParseUnit.getNis() != null &&
+                rootParseUnit.getNis().sourceFile() != null) {
+                try {
+                    final File monolithSpec = rootParseUnit.getNis().sourceFile();
+                    nis = MonolithSpecExtractor.module(monolithSpec, name);
+                } catch (IOException e) {
+                    nis = null;
+                }
+            }
+            else {
+                nis = FileUtil.createNamedInputStream(name, this.resolver);
+            }
 
+            // if module "name" is not already in parseUnitContext table
             // find a file derived from the name and create a
             // NamedInputStream for it if possible
             // SZ 23.02.2009: split the name resolution from the stream retrieval
             // NamedInputStream nis = this.ntfis.toNIStream(name);
-            NamedInputStream nis = FileUtil.createNamedInputStream(name, this.resolver);
-            
-			if (nis == null && rootParseUnit != null && rootParseUnit.getNis() != null
-					&& rootParseUnit.getNis().sourceFile() != null) {
-				// Fall back and try loading the module from a monolithic spec (one big .tla
-				// file consisting of multiple TLA+ modules and TLC configs) that is what is the
-				// rootModule here (compare tlc2.tool.impl.ModelConfig.parse()).
-            	try {
-					final File monolithSpec = rootParseUnit.getNis().sourceFile();
-					nis = MonolithSpecExtractor.module(monolithSpec, name);
-            	} catch (IOException e) {
-            		nis = null;
-            	}
+            if (nis == null) {
+                nis = FileUtil.createNamedInputStream(name, this.resolver);
             }
 
             if (nis != null)

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/MonolithSpecTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/MonolithSpecTest.java
@@ -1,9 +1,9 @@
 /*******************************************************************************
- * Copyright (c) 2020 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2020 Microsoft Research. All rights reserved.
  *
  * The MIT License (MIT)
- * 
- * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
@@ -11,8 +11,8 @@
  * so, subject to the following conditions:
  *
  * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software. 
- * 
+ * copies or substantial portions of the Software.
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -26,22 +26,35 @@
 package tlc2.tool;
 
 import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
 import org.junit.Test;
 
 import tlc2.output.EC;
 import tlc2.tool.liveness.ModelCheckerTestCase;
+import util.TestPrintStream;
+import util.ToolIO;
 
 public class MonolithSpecTest extends ModelCheckerTestCase {
+        final TestPrintStream testPrintStream = new TestPrintStream();
 
 	public MonolithSpecTest() {
 		super("MonolithSpec", new String[] { "-config", "MonolithSpec.tla" /* note the extension */ });
 	}
 
+        @Before
+        public void beforeSetUp() {
+            ToolIO.err = testPrintStream;
+            ToolIO.reset();
+        }
+
 	@Test
 	public void testSpec() {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
 		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "214", "54", "0"));
+
+                // Check that the warning or inexistent file does not occur
+                testPrintStream.assertNoSubstring("File does not exist");
 
 		assertZeroUncovered();
 	}


### PR DESCRIPTION
Fixes https://github.com/tlaplus/tlaplus/issues/547.

Try to load the module from a eventual monolithic spec first before
try to load it from a file.

Instead of 
```shell
tlaplus-ex $ java -cp ~/dev/tlaplus/tlatools/org.lamport.tlatools/dist/tla2tools.jar tla2sany.SANY EWD840_TTrace_1608881116.tla

****** SANY2 Version 2.2 created 08 July 2020

Parsing file /home/rafael/dev/tlaplus-ex/EWD840_TTrace_1608881116.tla
Parsing file /tmp/Toolbox.tla
Parsing file /tmp/TLC.tla
Parsing file /home/rafael/dev/tlaplus-ex/EWD840.tla
Parsing file /tmp/Naturals.tla
File does not exist: /home/rafael/dev/tlaplus-ex/EWD840_TE.tla while looking in these directories: jar:file:/home/rafael/dev/tlaplus/tlatools/org.lamport.tlatools/dist/tla2tools.jar!/tla2sany/StandardModules/
Parsing file /tmp/EWD840_TE.tla
File does not exist: /home/rafael/dev/tlaplus-ex/TTraceTraceDef.tla while looking in these directories: jar:file:/home/rafael/dev/tlaplus/tlatools/org.lamport.tlatools/dist/tla2tools.jar!/tla2sany/StandardModules/
Parsing file /tmp/TTraceTraceDef.tla
Parsing file /tmp/FiniteSets.tla
Parsing file /tmp/Sequences.tla
Semantic processing of module Naturals
Semantic processing of module Sequences
Semantic processing of module FiniteSets
Semantic processing of module TLC
Semantic processing of module Toolbox
Semantic processing of module EWD840
Semantic processing of module EWD840_TE
Semantic processing of module TTraceTraceDef
Semantic processing of module EWD840_TTrace_1608881116
tlaplus-ex $ java -cp ~/dev/tlaplus/tlatools/org.lamport.tlatools/dist/tla2tools.jar tla2sany.SANY EWD840_TTrace_1608881116.tla
```

we now have
```shell
tlaplus-ex $ java -cp ~/dev/tlaplus/tlatools/org.lamport.tlatools/dist/tla2tools.jar tla2sany.SANY EWD840_TTrace_1608881116.tla

****** SANY2 Version 2.2 created 08 July 2020

Parsing file /home/rafael/dev/tlaplus-ex/EWD840_TTrace_1608881116.tla
Parsing file /tmp/Toolbox.tla
Parsing file /tmp/TLC.tla
Parsing file /home/rafael/dev/tlaplus-ex/EWD840.tla
Parsing file /tmp/Naturals.tla
Parsing file /tmp/EWD840_TE.tla
Parsing file /tmp/TTraceTraceDef.tla
Parsing file /tmp/FiniteSets.tla
Parsing file /tmp/Sequences.tla
Semantic processing of module Naturals
Semantic processing of module Sequences
Semantic processing of module FiniteSets
Semantic processing of module TLC
Semantic processing of module Toolbox
Semantic processing of module EWD840
Semantic processing of module EWD840_TE
Semantic processing of module TTraceTraceDef
Semantic processing of module EWD840_TTrace_1608881116
```