### PR TITLE
Fix issue #362: only variables should be looked up as variables

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
@@ -357,9 +357,11 @@ abstract class Spec
             return result;
         }
 
-        result = s.lookup(opNode.getName());
-        if (result != null) {
-            return result;
+        if (opNode.getKind() == VariableDeclKind) {
+            result = s.lookup(opNode.getName());
+            if (result != null) {
+                return result;
+            }
         }
 
         return opNode;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
@@ -352,19 +352,22 @@ abstract class Spec
      */
     public final Object lookup(SymbolNode opNode, Context c, TLCState s, boolean cutoff)
     {
-    	Object result = lookup(opNode, c, cutoff, toolId);
-    	if (result != opNode) {
-    		return result;
-    	}
+        Object result = lookup(opNode, c, cutoff, toolId);
+        if (result != opNode) {
+            return result;
+        }
+
         result = s.lookup(opNode.getName());
         if (result != null) {
-        	return result;
+            return result;
         }
+
         return opNode;
     }
 
-    public final Object lookup(final SymbolNode opNode) {
-    	return lookup(opNode, Context.Empty, false, toolId);
+    public final Object lookup(final SymbolNode opNode)
+    {
+        return lookup(opNode, Context.Empty, false, toolId);
     }
 
     /**

--- a/tlatools/org.lamport.tlatools/test-model/Github362.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/Github362.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+PROPERTY Correct

--- a/tlatools/org.lamport.tlatools/test-model/Github362.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github362.tla
@@ -1,0 +1,21 @@
+---- MODULE Github362 ----
+
+EXTENDS TLC
+
+VARIABLES overloadedName
+
+\* Github362B.tla contains the definition "overloadedName == x".  It is
+\* unrelated to the variable "overloadedName" defined above.
+Abstract == INSTANCE Github362B WITH
+    x <- "x"
+
+Init ==
+    /\ overloadedName = "fizzbuzz"
+    /\ Print(<<"Evaluated initial state in A; overloadedName is: ", overloadedName>>, TRUE)
+    /\ Print(<<"From A's perspective, B's overloadedName is: ", Abstract!overloadedName>>, TRUE)
+
+Next == UNCHANGED overloadedName
+
+Correct == Abstract!Spec
+
+==================

--- a/tlatools/org.lamport.tlatools/test-model/Github362B.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github362B.tla
@@ -1,0 +1,22 @@
+---- MODULE Github362B ----
+
+\* Auxiliary spec instantiated by Github362.tla.
+
+EXTENDS TLC
+
+VARIABLES x
+
+\* This name also exists in Github362.tla with a different definition (it is a
+\* variable rather than a user-defined operator).  The definition in Github362
+\* should not conflict with this one.
+overloadedName == x
+
+Init ==
+    /\ Print(<<"Evaluating initial state in B; overloadedName is ", overloadedName>>, TRUE)
+    /\ overloadedName = "x"
+    /\ x = "x"
+
+Next == UNCHANGED x
+Spec == Init /\ [][Next]_x
+
+==================

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github362Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github362Test.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+import util.TestPrintStream;
+import util.ToolIO;
+
+public class Github362Test extends ModelCheckerTestCase {
+
+  private TestPrintStream testPrintStream;
+
+  public Github362Test() {
+    super("Github362", ExitStatus.SUCCESS);
+  }
+
+  @Override
+  public void beforeSetUp() {
+    testPrintStream = new TestPrintStream();
+    ToolIO.out = testPrintStream;
+  }
+
+  @Test
+  public void testSpec() {
+    testPrintStream.assertSubstring("<<\"Evaluated initial state in A; overloadedName is: \", \"fizzbuzz\">>");
+    testPrintStream.assertSubstring("<<\"From A's perspective, B's overloadedName is: \", \"x\">>");
+    testPrintStream.assertSubstring("<<\"Evaluating initial state in B; overloadedName is \", \"x\">>");
+    assertTrue(recorder.recorded(EC.TLC_FINISHED));
+    assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+  }
+
+}


### PR DESCRIPTION
By poking around in a debugger, I determined that this lookup method is the source of the problem. Most of the time it is true that a symbol with the same name as a variable is indeed itself a variable---but that is not always true, as the test case demonstrates.