### PR TITLE
Fix typo in tla+.jj

### DIFF
--- a/tlatools/org.lamport.tlatools/javacc/tla+.jj
+++ b/tlatools/org.lamport.tlatools/javacc/tla+.jj
@@ -4372,7 +4372,7 @@ SyntaxTreeNode
 Junctions () : {
   BStack.newReference(getToken(1).endColumn, getToken(1).kind);
     /***********************************************************************
-    * Pushes onto BStack an element of the appropriate kind with offest    *
+    * Pushes onto BStack an element of the appropriate kind with offset    *
     * equal to the column of the last character in the /\ or \/ token.     *
     ***********************************************************************/
     


### PR DESCRIPTION
- Fix a typo in `tla+.jj` I found when I was reading through the code