### PR TITLE
Store original TLC value in `MCVariable`

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/model/MCState.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/model/MCState.java
@@ -170,7 +170,7 @@ public class MCState {
 			IValue value = variableMap.get(key);
 			// value is null if the successor state is not completely specified by the
 			// next-state relation. See e.g. IncompleteNextTest.java
-			MCVariable variable = new MCVariable(key.toString(), value != null ? value.toString() : "");
+			MCVariable variable = new MCVariable(key.toString(), value);
 			variableList.add(variable);
 		}
 		

--- a/tlatools/org.lamport.tlatools/src/tlc2/model/MCVariable.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/model/MCVariable.java
@@ -1,11 +1,13 @@
 package tlc2.model;
 
 import tlc2.output.EC;
+import tlc2.value.IValue;
 import util.Assert;
 
 public class MCVariable {
     private final String name;
     private final String valueAsString;
+	private final IValue tlcValue;
     private String traceExpression;
 
 	/**
@@ -18,10 +20,28 @@ public class MCVariable {
 		Assert.check(value != null, EC.GENERAL);
 		valueAsString = value;
 		traceExpression = null;
+		this.tlcValue = null;
+	}
+
+	/**
+	 * @param varName  name of the variable
+	 * @param tlcValue Original TLC representation of the value
+	 */
+	public MCVariable(final String varName, final IValue tlcValue) {
+		Assert.check(varName != null, EC.GENERAL);
+		name = varName;
+		valueAsString = tlcValue != null ? tlcValue.toString() : "";
+		traceExpression = null;
+		this.tlcValue = tlcValue;
 	}
 
 	public String getName() {
 		return name;
+	}
+
+	// `tlcValue` may be null.
+	public IValue getTLCValue() {
+		return tlcValue;
 	}
 
     /**


### PR DESCRIPTION
It will help to read error traces when calling TLC directly from Java,
no need to parse the value string of `MCVariable`.

It appears that it will not incur in problems in other parts of the code.

One application is the one where I read the `recorder` field from
`TLC` (through reflection at the moment, but if you want I can create
a getter for it), read the error trace (like we do in
`TraceExplorationSpec.generate`) and convert to a Clojure map (which
could also be JSON, XML, whatever output needed).

```clojure
(->> (private-field tlc "recorder")
     .getMCErrorTrace
     .get
     .getStates
     ;; I don't care about the var name for this case, only the value.
     (mapv #(-> % .getVariables first .getTLCValue))
     (mapv tla-edn/to-edn))
```

Output without converting to a map.

```clojure
[#object[tlc2.value.impl.RecordValue 0xb6f3e392 "[recife___core_2_SLASH_procs |-> [y |-> [amount |-> 2, pc |-> \"recife___datlafy_SLASH_check_funds\"], x |-> [amount |-> 4, pc |-> \"recife___datlafy_SLASH_check_funds\"]], account_SLASH_alice |-> 5, account_SLASH_bob |-> 5]"]
 #object[tlc2.value.impl.RecordValue 0x5f2260a8 "[recife___core_2_SLASH_procs |-> [y |-> [amount |-> 2, pc |-> \"recife___datlafy_SLASH_withdraw\"], x |-> [amount |-> 4, pc |-> \"recife___datlafy_SLASH_check_funds\"]], account_SLASH_alice |-> 5, account_SLASH_bob |-> 5]"]
 #object[tlc2.value.impl.RecordValue 0x1452de87 "[recife___core_2_SLASH_procs |-> [y |-> [amount |-> 2, pc |-> \"recife___datlafy_SLASH_withdraw\"], x |-> [amount |-> 4, pc |-> \"recife___datlafy_SLASH_withdraw\"]], account_SLASH_alice |-> 5, account_SLASH_bob |-> 5]"]
 #object[tlc2.value.impl.RecordValue 0x4178e77d "[recife___core_2_SLASH_procs |-> [y |-> [amount |-> 2, pc |-> \"recife___datlafy_SLASH_deposit\"], x |-> [amount |-> 4, pc |-> \"recife___datlafy_SLASH_withdraw\"]], account_SLASH_alice |-> 3, account_SLASH_bob |-> 5]"]
 #object[tlc2.value.impl.RecordValue 0xe36a0b1d "[recife___core_2_SLASH_procs |-> [y |-> [amount |-> 2, pc |-> \"recife___datlafy_SLASH_deposit\"], x |-> [amount |-> 4, pc |-> \"recife___datlafy_SLASH_deposit\"]], account_SLASH_alice |-> -1, account_SLASH_bob |-> 5]"]]
```

And then converting to a map (just to show the conversion using a
existent library).

```clojure
[{:recife.core-2/procs
  {:y {:amount 2, :pc :recife.datlafy/check-funds},
   :x {:amount 4, :pc :recife.datlafy/check-funds}},
  :account/alice 5,
  :account/bob 5}
 {:recife.core-2/procs
  {:y {:amount 2, :pc :recife.datlafy/withdraw},
   :x {:amount 4, :pc :recife.datlafy/check-funds}},
  :account/alice 5,
  :account/bob 5}
 {:recife.core-2/procs
  {:y {:amount 2, :pc :recife.datlafy/withdraw},
   :x {:amount 4, :pc :recife.datlafy/withdraw}},
  :account/alice 5,
  :account/bob 5}
 {:recife.core-2/procs
  {:y {:amount 2, :pc :recife.datlafy/deposit},
   :x {:amount 4, :pc :recife.datlafy/withdraw}},
  :account/alice 3,
  :account/bob 5}
 {:recife.core-2/procs
  {:y {:amount 2, :pc :recife.datlafy/deposit},
   :x {:amount 4, :pc :recife.datlafy/deposit}},
  :account/alice -1,
  :account/bob 5}]
```

Let me know what you think, I can close it if this is not desired.