### PR TITLE
Fix lemmy.github.com link

### DIFF
--- a/toolbox/org.lamport.tla.toolbox.product.product/TLAToolbox.target
+++ b/toolbox/org.lamport.tla.toolbox.product.product/TLAToolbox.target
@@ -29,7 +29,7 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.jclouds.feature.feature.group" version="0.0.0"/>
-<repository id="github-jclouds" location="http://lemmy.github.com/jclouds2p2/"/>
+<repository id="github-jclouds" location="http://lemmster.de/jclouds2p2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.help.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Fixes a leftover github.com pages link after f919cb052eaa093f510d251265c81171fb4d397e