### PR TITLE
Augment simulate stats with basic and full options.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -159,7 +159,7 @@ public class TLC {
      * Name of the file to which to write state traces.
      */
     private String traceFile = null;
-    private boolean traceActions = false;
+    private String traceActions = null;
     /**
      * Maximum state trace depth. Set to 100 by default.
      */
@@ -426,8 +426,10 @@ public class TLC {
 							traceNum = Long.parseLong(arg.replace("num=", ""));
 						} else if (arg.startsWith("file=")) {
 							traceFile = arg.replace("file=", "");
-						} else if (arg.startsWith("stats=")) {
-							traceActions = true;
+						} else if (arg.equals("stats=basic")) {
+							traceActions = "BASIC";
+						} else if (arg.equals("stats=full")) {
+							traceActions = "FULL";
 						}
 					}
 				}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
@@ -103,7 +103,7 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 	// Adjacency Matrix with link weights.
 	final long[][] actionStats;
 
-	private final boolean collectActionStats;
+	private final String traceActions;
 	
 	/**
 	 * Encapsulates information about an error produced by a simulation worker.
@@ -192,15 +192,15 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 	public SimulationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue,
 			long seed, int maxTraceDepth, long maxTraceNum, boolean checkDeadlock, String traceFile,
 			ILiveCheck liveCheck) {
-		this(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, false, checkDeadlock, traceFile, liveCheck,
+		this(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, null, checkDeadlock, traceFile, liveCheck,
 				new LongAdder(), new LongAdder(), new AtomicLong());
 	}
 
 	public SimulationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue,
-			long seed, int maxTraceDepth, long maxTraceNum, boolean actionStats, boolean checkDeadlock, String traceFile,
+			long seed, int maxTraceDepth, long maxTraceNum, String traceActions, boolean checkDeadlock, String traceFile,
 			ILiveCheck liveCheck, LongAdder numOfGenStates, LongAdder numOfGenTraces, AtomicLong m2AndMean) {
 		super(id);
-		this.collectActionStats = actionStats;
+		this.traceActions = traceActions;
 		this.localRng = new RandomGenerator(seed);
 		this.tool = tool;
 		this.maxTraceDepth = maxTraceDepth;
@@ -213,7 +213,7 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 		this.numOfGenTraces = numOfGenTraces;
 		this.welfordM2AndMean = m2AndMean;
 		
-		if (collectActionStats) {
+		if (traceActions != null) {
 			final Action[] actions = this.tool.getActions();
 			final int len = actions.length;
 			this.actionStats = new long[len][len];
@@ -430,7 +430,7 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 			
 			// In case actionStats are off, we waste a few cycles to increment this counter
 			// nobody is going to look at.
-			if (collectActionStats) {
+			if (traceActions != null) {
 				this.actionStats[curState.getAction().getId()][s1.getAction().getId()]++;
 			}
 			curState = s1;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -49,7 +49,7 @@ public class Simulator {
 
 	public static boolean EXPERIMENTAL_LIVENESS_SIMULATION = Boolean
 			.getBoolean(Simulator.class.getName() + ".experimentalLiveness");
-	private final boolean actionStats;
+	private final String traceActions;
 
 	/* Constructors */
 
@@ -58,7 +58,7 @@ public class Simulator {
 			long traceNum, RandomGenerator rng, long seed, FilenameToStream resolver,
 			int numWorkers) throws IOException {
 		this(new FastTool(extracted(specFile), configFile, resolver, Tool.Mode.Simulation), "", traceFile, deadlock,
-				traceDepth, traceNum, false, rng, seed, resolver, numWorkers);
+				traceDepth, traceNum, null, rng, seed, resolver, numWorkers);
 	}
 
 	private static String extracted(String specFile) {
@@ -67,7 +67,7 @@ public class Simulator {
 	}
 
 	public Simulator(ITool tool, String metadir, String traceFile, boolean deadlock, int traceDepth,
-				long traceNum, boolean traceActions, RandomGenerator rng, long seed, FilenameToStream resolver,
+				long traceNum, String traceActions, RandomGenerator rng, long seed, FilenameToStream resolver,
 				int numWorkers) throws IOException {
 		this.tool = tool;
 
@@ -84,7 +84,7 @@ public class Simulator {
 		}
 		this.traceFile = traceFile;
 		this.traceNum = traceNum;
-		this.actionStats = traceActions;
+		this.traceActions = traceActions;
 		this.rng = rng;
 		this.seed = seed;
 		this.aril = 0;
@@ -104,7 +104,7 @@ public class Simulator {
 		this.workers = new ArrayList<>(numWorkers);
 		for (int i = 0; i < this.numWorkers; i++) {
 			this.workers.add(new SimulationWorker(i, this.tool, this.workerResultQueue, this.rng.nextLong(),
-					this.traceDepth, this.traceNum, this.actionStats, this.checkDeadlock, this.traceFile,
+					this.traceDepth, this.traceNum, this.traceActions, this.checkDeadlock, this.traceFile,
 					this.liveCheck, this.numOfGenStates, this.numOfGenTraces, this.welfordM2AndMean));
 		}
 		
@@ -556,11 +556,16 @@ public class Simulator {
 		}
 
 	}
-	
+
 	private void writeActionFlowGraph() throws IOException {
-		if (!actionStats) {
-			return;
+		if (traceActions == "BASIC") {
+			writeActionFlowGraphBasic();
+		} else if (traceActions == "FULL") {
+			writeActionFlowGraphFull();
 		}
+	}
+	
+	private void writeActionFlowGraphFull() throws IOException {		
 		// The number of actions is expected to be low (dozens commons and hundreds a
 		// rare). This is why the code below isn't optimized for performance.
 		final Action[] actions = Simulator.this.tool.getActions();
@@ -582,7 +587,7 @@ public class Simulator {
 		
 		// Write clusters to dot file (override previous file).
 		final DotActionWriter dotActionWriter = new DotActionWriter(
-				Simulator.this.tool.getRootName() + "_actions.dot", "");
+				Simulator.this.tool.getRootName() + "_full_actions.dot", "");
 		for (Entry<String, Set<Integer>> cluster : clusters.entrySet()) {
 			// key is a unique set of chars accepted/valid as a graphviz cluster id.
 			final String key = Integer.toString(Math.abs(cluster.getKey().hashCode()));
@@ -615,11 +620,90 @@ public class Simulator {
 					// LogLog l (to keep the graph readable) and round to two decimal places (to not
 					// write a gazillion decimal places truncated by graphviz anyway).
 					final double loglogWeight = Math.log10(Math.log10(l+1)); // +1 to prevent negative inf.
-					dotActionWriter.write(actions[i], i, actions[j], j,
+					dotActionWriter.write(i, j,
 							BigDecimal.valueOf(loglogWeight).setScale(2, RoundingMode.HALF_UP)
 							.doubleValue());
 				} else {
-					dotActionWriter.write(actions[i], i, actions[j], j);
+					dotActionWriter.write(i, j);
+				}
+			}
+		}
+		
+		// Close dot file.
+		dotActionWriter.close();
+	}
+
+	private void writeActionFlowGraphBasic() throws IOException {
+		// The number of actions is expected to be low (dozens commons and hundreds a
+		// rare). This is why the code below isn't optimized for performance.
+		final Action[] actions = Simulator.this.tool.getActions();
+		final int len = actions.length;
+		
+		// Create a map from id to action name.
+		final Map<Integer, String> idToActionName = new HashMap<>();
+		for (int i = 0; i < len; i++) {
+			final String actionName;
+			if (actions[i].isNamed()) {
+				actionName = actions[i].getName().toString();
+			} else {
+				// If we have an unnamed action, action name will be
+				// the string representation of the action (which has information
+				// about line, column etc).
+				actionName = actions[i].toString();
+			}
+			idToActionName.put(i, actionName);
+		}
+
+		// Override previous basic file.
+		final DotActionWriter dotActionWriter = new DotActionWriter(
+				Simulator.this.tool.getRootName() + "_basic_actions.dot", "");
+
+		// Identify actions in the dot file.
+	    final List<String> distinctActionNames = idToActionName.values().stream().distinct().sorted().collect(Collectors.toList());
+		for (int i = 0; i < distinctActionNames.size(); i ++) {
+			final String actionName = distinctActionNames.get(i);
+			// Uses the position in `distinctActionNames` as the id.
+			dotActionWriter.write(actionName, i);
+		}
+		
+		// Element-wise sum the statistics from all workers.
+		long[][] aggregateActionStats = new long[len][len];
+		final List<SimulationWorker> workers = Simulator.this.workers;
+		for (SimulationWorker sw : workers) {
+			final long[][] s = sw.actionStats;
+			for (int i = 0; i < len; i++) {
+				for (int j = 0; j < len; j++) {
+					aggregateActionStats[i][j] += s[i][j];
+				}
+			}
+		}
+
+		// Having the aggregated action stats, reduce it to account for only
+		// the distinct action names.
+		long[][] reducedAggregateActionStats = new long[distinctActionNames.size()][distinctActionNames.size()];
+		for (int i = 0; i < len; i++) {
+			// Find origin id.
+			final int originActionId = distinctActionNames.indexOf(idToActionName.get(i));
+			for (int j = 0; j < len; j++) {
+				// Find next id.
+				final int nextActionId = distinctActionNames.indexOf(idToActionName.get(j));
+				reducedAggregateActionStats[originActionId][nextActionId] += aggregateActionStats[i][j];
+			}
+		}
+
+		// Write stats to dot file as edges between the action vertices.
+		for (int i = 0; i < distinctActionNames.size(); i++) {
+			for (int j = 0; j < distinctActionNames.size(); j++) {
+				long l = reducedAggregateActionStats[i][j];
+				if (l > 0L) {
+					// LogLog l (to keep the graph readable) and round to two decimal places (to not
+					// write a gazillion decimal places truncated by graphviz anyway).
+					final double loglogWeight = Math.log10(Math.log10(l+1)); // +1 to prevent negative inf.
+					dotActionWriter.write(i, j,
+							BigDecimal.valueOf(loglogWeight).setScale(2, RoundingMode.HALF_UP)
+							.doubleValue());
+				} else {
+					dotActionWriter.write(i, j);
 				}
 			}
 		}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SingleThreadedSimulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SingleThreadedSimulator.java
@@ -56,7 +56,7 @@ public class SingleThreadedSimulator extends Simulator {
 	 * Phaser, ...
 	 */
 	public SingleThreadedSimulator(ITool tool, String metadir, String traceFile, boolean deadlock, int traceDepth,
-			long traceNum, boolean traceActions, RandomGenerator rng, long seed, FilenameToStream resolver) throws IOException {
+			long traceNum, String traceActions, RandomGenerator rng, long seed, FilenameToStream resolver) throws IOException {
 		super(tool, metadir, traceFile, deadlock, traceDepth, traceNum, traceActions, rng, seed, resolver, 1);
 	}
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/DotActionWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/DotActionWriter.java
@@ -87,18 +87,23 @@ public class DotActionWriter {
 
 	public synchronized void write(final Action action, final int id) {
 		// Marker the state as an initial state by using a filled style.
+		write(action2dot(action), id);
+	}
+
+	public synchronized void write(final String actionName, final int id) {
+		// Marker the state as an initial state by using a filled style.
 		this.writer.append(Integer.toString(id));
 		this.writer.append(" [label=\"");
-		this.writer.append(action2dot(action, id));
+		this.writer.append(actionName);
 		this.writer.append("\"]");
 		this.writer.append("\n");
 	}
 
-	public synchronized void write(Action from, final int fromId, Action to, final int toId) {
-		write(from, fromId, to, toId, 0d);
+	public synchronized void write(final int fromId, final int toId) {
+		write(fromId, toId, 0d);
 	}
 
-	public synchronized void write(Action from, final int fromId, Action to, final int toId, final double weight) {
+	public synchronized void write(final int fromId, final int toId, final double weight) {
 		// Write the transition edge.
 		this.writer.append(Integer.toString(fromId));
 		this.writer.append(" -> ");
@@ -108,13 +113,13 @@ public class DotActionWriter {
 			this.writer.append("[color=\"green\",style=dotted]");
 		} else {
 			// TODO don't increase penwidth (contributes to a spaghetti ball of lines) but
-			// use heatmap approach like in ModuleCoverageInforamtion.
+			// use heatmap approach like in ModuleCoverageInformation.
 			this.writer.append(String.format("[penwidth=%s]", Double.toString(weight)));
 		}
 		this.writer.append(";\n");
 	}
 
-	protected static String action2dot(final Action action, final int id) {
+	protected static String action2dot(final Action action) {
 		return action.getName().toString();
 	}
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
@@ -420,7 +420,7 @@ public class SimulationWorkerTest extends CommonTestCase {
 		AtomicLong m2AndMean = new AtomicLong();
 		int traceDepth = 5;
 		long traceNum = 5;
-		SimulationWorker worker = new SimulationWorker(0, tool, resultQueue, 0, traceDepth, traceNum, false, false,
+		SimulationWorker worker = new SimulationWorker(0, tool, resultQueue, 0, traceDepth, traceNum, null, false,
 				null, liveCheck, numOfGenStates, numOfGenTraces, m2AndMean);
 
 		worker.start(initStates);


### PR DESCRIPTION
Proposed by @lemmy.

Replaces `stats=true` of `-simulate` by `stats=full` and adds a new options, `stats=basic`.

`stats=full` does the same things as `stats=true`, just the filename that now ends with `_full_actions.dot`.

While `stats=full` uses the full context of the actions, it can lead to a very large and hard to understand [picture of the states transition](https://user-images.githubusercontent.com/2124834/120088894-a095d480-c0cb-11eb-9fdf-5e57593cad68.png). `stats=basic` is similar, but it removes the context of the actions and leaves only the nodes and their connections (state transitions) with other nodes, letting the user with a [higher level overview](https://user-images.githubusercontent.com/2124834/120088917-e488d980-c0cb-11eb-804f-75a938b29050.png) of what's happening.