### PR TITLE
Make variables appear before definitions on pluscal translation

### DIFF
--- a/tlatools/org.lamport.tlatools/src/pcal/PcalTLAGen.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalTLAGen.java
@@ -1920,24 +1920,19 @@ public class PcalTLAGen
         }
         ;
 
-        if (EmptyExpr(defs))
+        /******************************************************************
+        * Generate a single VARIABLES statement and set gVars to vector   *
+        * of all variables.                                               *        
+        ******************************************************************/
+        gVars.addAll(lVars);
+        gVarsSource.addAll(lVarsSource) ;
+        GenVarDecl(gVars, gVarsSource); 
+        
+        if (!EmptyExpr(defs))
         {
             /******************************************************************
-            * There is no `define' statement.  In this case, generate a       *
-            * single VARIABLES statement and set gVars to vector of all       *
-            * variables.                                                      *
+            * There is a `define' statement.                                  *
             ******************************************************************/
-            gVars.addAll(lVars);
-            gVarsSource.addAll(lVarsSource) ;
-            GenVarDecl(gVars, gVarsSource); 
-        } else
-        {
-            /******************************************************************
-            * There is a `define' statement.  In this case, must declare      *
-            * global and local variables separately.  Also, set gVars to      *
-            * vector of all variables.                                        *
-            ******************************************************************/
-            GenVarDecl(gVars, gVarsSource);
             addOneLineOfTLA("");
             addOneLineOfTLA("(* define statement *)");
             addExprToTLA(defs);
@@ -1945,12 +1940,7 @@ public class PcalTLAGen
 //            for (int i = 0; i < sv.size(); i++)
 //            {
 //                tlacode.addElement((String) sv.elementAt(i));
-//            }
-            ;
-            addOneLineOfTLA("");
-            GenVarDecl(lVars, lVarsSource); // to be fixed
-            gVars.addAll(lVars);
-            gVarsSource.addAll(lVarsSource);
+//            }            
         }
         ;
         addOneLineOfTLA("");

--- a/tlatools/org.lamport.tlatools/src/pcal/PlusCal.tla
+++ b/tlatools/org.lamport.tlatools/src/pcal/PlusCal.tla
@@ -1301,7 +1301,7 @@ procVars(proc) == {proc.decls[j].var : j \in 1..Len(proc.decls)}
 (* recursively to be the sequence with commas inserted between the         *)
 (* strings.  Thus,                                                         *)
 (*                                                                         *)
-(*    CommaSeq( << "foo", "bar", "x" >> = << "foo", "," "bar", ",", "x" >>  *)
+(*    CommaSeq( << "foo", "bar", "x" >> = << "foo", ",", "bar", ",", "x" >>  *)
 (***************************************************************************)
 (*RECURSIVE*) CONSTANT CommaSeq(_)
 XCommaSeq(seq) ==
@@ -1965,13 +1965,10 @@ Translation ==
       (*********************************************************************)
       (* The VARIABLES declaration(s) and the `define' section, if any.    *)
       (*********************************************************************)
-      <<"VARIABLES">> \o 
-      (IF ast.defs = << >>
-         THEN CommaSeq(varSeq)
-         ELSE CommaSeq(preDefsVars) \o ast.defs \o
-              (IF postDefsVars # << >> 
-                 THEN <<"VARIABLES">> \o CommaSeq(postDefsVars)
-                 ELSE << >>)
+      <<"VARIABLES">> \o CommaSeq(varSeq) \o
+      (IF ast.defs # << >>
+         THEN ast.defs
+         ELSE << >>
       ) \o
 
       (*********************************************************************)

--- a/tlatools/org.lamport.tlatools/src/pcal/PlusCal2.tla
+++ b/tlatools/org.lamport.tlatools/src/pcal/PlusCal2.tla
@@ -1272,7 +1272,7 @@ procVars(proc) == {proc.decls[j].var : j \in 1..Len(proc.decls)}
 (* recursively to be the sequence with commas inserted between the         *)
 (* strings.  Thus,                                                         *)
 (*                                                                         *)
-(*    CommaSeq( << "foo", "bar", "x" >> = << "foo", "," "bar", ",", "x" >>  *)
+(*    CommaSeq( << "foo", "bar", "x" >> = << "foo", ",", "bar", ",", "x" >>  *)
 (***************************************************************************)
 RECURSIVE CommaSeq(_)
 CommaSeq(seq) ==
@@ -1936,13 +1936,10 @@ Translation ==
       (*********************************************************************)
       (* The VARIABLES declaration(s) and the `define' section, if any.    *)
       (*********************************************************************)
-      <<"VARIABLES">> \o 
-      (IF ast.defs = << >>
-         THEN CommaSeq(varSeq)
-         ELSE CommaSeq(preDefsVars) \o ast.defs \o
-              (IF postDefsVars # << >> 
-                 THEN <<"VARIABLES">> \o CommaSeq(postDefsVars)
-                 ELSE << >>)
+      <<"VARIABLES">> \o CommaSeq(varSeq) \o
+      (IF ast.defs # << >>
+         THEN ast.defs
+         ELSE << >>
       ) \o
 
       (*********************************************************************)


### PR DESCRIPTION
Resolves #617.

Just concatenates all variables before any definition on pluscal
translation.

This may break some existing pluscal specs which define operators in
`define` with arguments having the same name as some of the local
variables.

Example
```tla
(*--algorithm wire
variables
 people = {"alice", "bob"},
 acc = [p \in people |-> 5],
define
 XX(amount) == amount
 NoOverdrafts == \A p \in people: acc[p] >= 0
end define;
process Wire \in 1..2
 ...
 amount \in 1..acc[sender];
 ...
end algorithm;*)
\* BEGIN TRANSLATION (chksum(pcal) = "4a6f14c6" /\ chksum(tla) = "5be7c6b2")
VARIABLES people, acc, pc, sender, receiver, amount

(* define statement *)
XX(amount) == amount \* <------ "Multiply-defined symbol 'amount'" error!
...
```

The changes in `PlusCal.tla` and `PlusCal2.tla` are not needed, but
I've thought that maybe we are trying to maintain the algorithm in
sync with each other?

I can add test for it if we want.