### PR TITLE
Fix typo in the comment about TLCFcnElementVariableValue parsing

### DIFF
--- a/toolbox/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/output/data/TLCVariableValue.java
+++ b/toolbox/org.lamport.tla.toolbox.tool.tlc.ui/src/org/lamport/tla/toolbox/tool/tlc/output/data/TLCVariableValue.java
@@ -298,7 +298,7 @@ public abstract class TLCVariableValue
                     innerValue = innerParse(input);
                     if (innerValue == null)
                     {
-                        // no right side of |->
+                        // no right side of :>
                         throw new VariableValueParseException();
                     }
 


### PR DESCRIPTION
## Summary
- Fix a typo in the comment about `TLCFcnElementVariableValue` parsing
  * `|->` should be `:>`