### PR TITLE
Add Bug Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,56 @@
+---
+name: "\U0001F41C Bug Report"
+about: Something strange happened? Please tell us about it!
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--- 
+Hi!
+Have you tried searching for your issue on the following forums?
+If you have any questions, please ask them there.
+
+Forums:
+ - TLA⁺ Google Groups forum: https://groups.google.com/g/tlaplus/
+ - Stack Overflow questions (TLA+): https://stackoverflow.com/questions/tagged/tla%2b
+ - Stack Overflow questions (PlusCal): https://stackoverflow.com/questions/tagged/pluscal 
+ - GitHub Discussions forum: (TBA?)
+
+Thanks!
+-->
+
+## Description
+<!--- 
+Provide a more detailed introduction to the issue itself, and why you consider it to be a bug. 
+
+If you need to share a specification, either:
+ - Paste it in your description between the <details> </details> tags if it's too long;
+ - Send a link to a Gist, GitHub reposity, Pastebin, etc.;
+-->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
+
+## Steps to Reproduce
+1.
+2.
+3.
+4.
+
+## Steps Taken to Fix
+<!--- When this problem came up, what did you try before reporting it? -->
+
+## Possible Fix
+<!--- Do you suggest some fix for us you haven't tried yet? -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment in which you experienced the issue. -->
+<!--- Remove information if not applicable -->
+ - TLC version:
+ - Toolbox version:
+ - Operating System: <!-- (Windows 10, Ubuntu 22.04, etc.) -->

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -14,8 +14,6 @@ If you have any questions, please ask them there.
 
 Forums:
  - TLA⁺ Google Groups forum: https://groups.google.com/g/tlaplus/
- - Stack Overflow questions (TLA+): https://stackoverflow.com/questions/tagged/tla%2b
- - Stack Overflow questions (PlusCal): https://stackoverflow.com/questions/tagged/pluscal 
  - GitHub Discussions forum: (TBA?)
 
 Thanks!


### PR DESCRIPTION
I created one template for bugs in issues. If you need other templates, or changes to them, I can do it. Just tell me. :)

We can also make people add Issues before opening PRs. There's a few interesting features we can discuss.

Also, I wonder about preferred discussion forums for TLA+. 
Do you have any thoughts on GitHub Discussions for this repo? 

Edit:
And a few references for later:
GitHub Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
Examples: https://github.com/stevemao/github-issue-templates

https://github.com/explosion/spaCy/blob/e626df959fdcbf7a5fbc9d24a86af8e093238c82/CONTRIBUTING.md