### PR TITLE
TraceExplorationSpec was given main TLA+ file path

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -1007,16 +1007,20 @@ public class TLC {
                 
 		
 		if (generateTESpec) {
+			// Get module name out of main file path
+			final File f = new File(mainFile);
+			final String mainModuleName = f.getName();
+
 			if (teSpecOut == null) {
-				this.teSpec = new TraceExplorationSpec(getTlaFileParentDir(mainFile), new Date(startTime), mainFile,
+				this.teSpec = new TraceExplorationSpec(getTlaFileParentDir(mainFile), new Date(startTime), mainModuleName,
 						this.recorder);
 			} else {
 				if (teSpecOut.toString().toLowerCase().endsWith(TLAConstants.Files.TLA_EXTENSION)) {
 					this.teSpec = new TraceExplorationSpec(teSpecOut.getParent(), teSpecOut.getFileName().toFile()
-							.getName().replaceFirst(TLAConstants.Files.TLA_EXTENSION + "$", ""), mainFile,
+							.getName().replaceFirst(TLAConstants.Files.TLA_EXTENSION + "$", ""), mainModuleName,
 							this.recorder);
 				} else {
-					this.teSpec = new TraceExplorationSpec(teSpecOut, new Date(startTime), mainFile, this.recorder);
+					this.teSpec = new TraceExplorationSpec(teSpecOut, new Date(startTime), mainModuleName, this.recorder);
 				}
 			}
 		}


### PR DESCRIPTION
instead of module name.

Fixes Github issue #733

[Bug][TLC]