### PR TITLE
Fix OpRcdValue initialization

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2022, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 13:21:01 PST by lamport
 //      modified on Sat Nov 13 12:43:44 PST 1999 by yuanyu
@@ -13,6 +14,16 @@ import tlc2.value.Values;
 import util.Assert;
 import util.WrongInvocationException;
 
+/**
+ * An operator defined as a finite map from inputs to outputs.
+ *
+ * <p>Today (2022/8/22), this class is only used to represent CONSTANT definitions in configuration files of the form
+ * <pre>
+ *     CONSTANT
+ *         op(1, 1) = "a"
+ *         op(1, 2) = "b"
+ * </pre>
+ */
 public class OpRcdValue extends OpValue implements Applicable {
   public Vect domain;
   public Vect values;

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
@@ -25,16 +25,16 @@ import util.WrongInvocationException;
  * </pre>
  */
 public class OpRcdValue extends OpValue implements Applicable {
-  public Vect domain;
-  public Vect values;
+  public Vect<Value[]> domain;
+  public Vect<Value> values;
 
   /* Constructor */
   public OpRcdValue() {
-    this.domain = new Vect();
-    this.values = new Vect();
+    this.domain = new Vect<>();
+    this.values = new Vect<>();
   }
 
-  public OpRcdValue(Vect domain, Vect values) {
+  public OpRcdValue(Vect<Value[]> domain, Vect<Value> values) {
     this.domain = domain;
     this.values = values;
   }
@@ -101,7 +101,7 @@ public class OpRcdValue extends OpValue implements Applicable {
         args[i] = (Value)vs.elementAt(i+1);
       }
       this.domain.addElement(args);
-      this.values.addElement(vs.elementAt(len-1));
+      this.values.addElement((Value)vs.elementAt(len-1));
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
@@ -247,7 +247,7 @@ public class OpRcdValue extends OpValue implements Applicable {
     try {
       boolean defined = true;
       for (int i = 0; i < this.values.size(); i++) {
-        defined = defined && ((Value)this.values.elementAt(i)).isDefined();
+        defined = defined && this.values.elementAt(i).isDefined();
       }
       return defined;
     }
@@ -278,22 +278,22 @@ public class OpRcdValue extends OpValue implements Applicable {
       sb.append("{ ");
       if (this.values.size() != 0) {
         sb.append("<");
-        Value[] args = (Value[])this.domain.elementAt(0);
+        Value[] args = this.domain.elementAt(0);
         for (int j = 0; j < args.length; j++) {
           sb = args[j].toString(sb, offset, swallow);
           sb.append(", ");
         }
-        sb = ((Value)this.values.elementAt(0)).toString(sb, offset, swallow);
+        sb = this.values.elementAt(0).toString(sb, offset, swallow);
         sb.append(">");
       }
       for (int i = 1; i < this.values.size(); i++) {
         sb.append(", <");
-        Value[] args = (Value[])this.domain.elementAt(i);
+        Value[] args = this.domain.elementAt(i);
         for (int j = 0; j < args.length; j++) {
           sb = args[j].toString(sb, offset, swallow);
           sb.append(", ");
         }
-        sb = ((Value)this.values.elementAt(i)).toString(sb, offset, swallow);
+        sb = this.values.elementAt(i).toString(sb, offset, swallow);
         sb.append(">");
       }
       return sb.append("}");

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
@@ -25,8 +25,8 @@ import util.WrongInvocationException;
  * </pre>
  */
 public class OpRcdValue extends OpValue implements Applicable {
-  public Vect<Value[]> domain;
-  public Vect<Value> values;
+  public final Vect<Value[]> domain;
+  public final Vect<Value> values;
 
   /* Constructor */
   public OpRcdValue() {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
@@ -40,6 +40,24 @@ public class OpRcdValue extends OpValue implements Applicable {
   }
 
   @Override
+  public IValue initialize() {
+    // The default implementation initializes by calling fingerPrint, which has no
+    // meaningful definition for this class.  So, we'll initialize all contained
+    // values by hand.
+
+    for (int i = 0; i < domain.size(); ++i) {
+      Value[] args = domain.elementAt(i);
+      for (int j = 0; j < args.length; ++j) {
+        args[j] = (Value)args[j].initialize();
+      }
+
+      Value output = values.elementAt(i);
+      values.setElementAt((Value)output.initialize(), i);
+    }
+    return this;
+  }
+
+  @Override
   public final byte getKind() { return OPRCDVALUE; }
 
   @Override

--- a/tlatools/org.lamport.tlatools/test-model/ConstantOperatorConfiguration.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ConstantOperatorConfiguration.cfg
@@ -1,0 +1,9 @@
+INIT Init
+NEXT Next
+
+CONSTANT
+    F(0) = 1
+    F(1) = 2
+    F(2) = 2
+
+INVARIANT Inv

--- a/tlatools/org.lamport.tlatools/test-model/ConstantOperatorConfiguration.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ConstantOperatorConfiguration.tla
@@ -1,0 +1,10 @@
+---- MODULE ConstantOperatorConfiguration ----
+
+CONSTANT F(_)
+VARIABLE x
+
+Init == x = 0
+Next == x' = F(x)
+Inv == x /= 2
+
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstantOperatorConfigurationTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstantOperatorConfigurationTest.java
@@ -1,0 +1,23 @@
+// Copyright (c) 2022, Oracle and/or its affiliates.
+
+package tlc2.tool;
+
+import org.junit.Test;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+public class ConstantOperatorConfigurationTest extends ModelCheckerTestCase {
+
+    public ConstantOperatorConfigurationTest() {
+        super("ConstantOperatorConfiguration", "", EC.ExitStatus.VIOLATION_SAFETY);
+    }
+
+    @Test
+    public void testSpec() {
+        assertTrue(recorder.recorded(EC.TLC_FINISHED));
+        assertTrue(recorder.recordedWithStringValue(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, "Inv"));
+    }
+
+}


### PR DESCRIPTION
TLC allows configuration files to define partial implementations for constant operators:

```
CONSTANT
    F(0) = 1
    F(1) = 2
    F(2) = 2
```

Because of the way values are initialized, this functionality does not work in current `master`. This PR fixes the problem by defining a custom `initialize()` method for `OpRcdValue` that does not call `fingerPrint()`.

It also adds a regression test to help us preserve this functionality in the future.