### PR TITLE
Fix some instances of string comparison using ==

### DIFF
--- a/tlatools/org.lamport.tlatools/src/pcal/PcalSymTab.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalSymTab.java
@@ -571,7 +571,7 @@ public class PcalSymTab {
     }
         
     private void ExtractVarDecl(AST.VarDecl ast, String context) {
-        int vtype = (context == "") ? GLOBAL : PROCESSVAR;
+        int vtype = context.isEmpty() ? GLOBAL : PROCESSVAR;
         if (! InsertSym(vtype, ast.var, context, "process", ast.line, ast.col))
             errorReport = errorReport + "\n" + vtypeName[vtype] + " " + ast.var +
             " redefined at line " + ast.line + ", column " + ast.col;

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
@@ -207,26 +207,26 @@ public class PcalTranslate {
                 TLAToken tok = ((TLAToken) line.elementAt(j));
                 tok.column = nextCol;
                 nextCol = nextCol + tok.getWidth();
-                if (tok.type == TLAToken.BUILTIN && tok.string == "|->") {
+                if (tok.type == TLAToken.BUILTIN && tok.string.equals("|->")) {
                     tok.column = tok.column + 1;
                     if (tok.column < 16) tok.column = 16;
                     nextCol = tok.column + 5;
                 }
-                else if (tok.type == TLAToken.BUILTIN && tok.string == "[") {
+                else if (tok.type == TLAToken.BUILTIN && tok.string.equals("[")) {
                     nextCol = nextCol + 1;
                 }
-                else if (tok.type == TLAToken.BUILTIN && tok.string == "]") {
+                else if (tok.type == TLAToken.BUILTIN && tok.string.equals("]")) {
                     tok.column = tok.column + 1;
                     nextCol = nextCol + 1;
                 }
-                else if (tok.type == TLAToken.BUILTIN && tok.string == "<<") {
+                else if (tok.type == TLAToken.BUILTIN && tok.string.equals("<<")) {
                     nextCol = nextCol + 1;
                 }
-                else if (tok.type == TLAToken.BUILTIN && tok.string == ">>") {
+                else if (tok.type == TLAToken.BUILTIN && tok.string.equals(">>")) {
                     tok.column = tok.column + 1;
                     nextCol = nextCol + 1;
                 }
-                else if (tok.type == TLAToken.BUILTIN && tok.string == "\\o") {
+                else if (tok.type == TLAToken.BUILTIN && tok.string.equals("\\o")) {
                     tok.column = tok.column + 1;
                     nextCol = nextCol + 2;
                 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorationSpec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorationSpec.java
@@ -337,7 +337,7 @@ public class TraceExplorationSpec {
 		/**
 		 * Write TEConstants module, if needed.
 		 */
-		if (modelValuesAsConstants != "") {
+		if (!modelValuesAsConstants.isEmpty()) {
 			writer.addFooter();
 			writer.append(TLAConstants.CR);
 			writer.addPrimer(teConstantSpecName, originalSpecName);

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -602,9 +602,9 @@ public class Simulator {
 	}
 
 	private void writeActionFlowGraph() throws IOException {
-		if (traceActions == "BASIC") {
+		if (traceActions.equals("BASIC")) {
 			writeActionFlowGraphBasic();
-		} else if (traceActions == "FULL") {
+		} else if (traceActions.equals("FULL")) {
 			writeActionFlowGraphFull();
 		}
 	}


### PR DESCRIPTION
In Java, == compares pointers.  Two `String` instances can have the same characters but live at different locations in memory.  Therefore, strings should always be compared using `a.equals(b)`, not `a == b`.

There are exceptions to the rule: if two strings are "interned" (using `str.intern()`) then they can be safely compared using ==.  All string literals written in the program text are guaranteed to be interned, but strings from user input are not, even if they are equal to a string literal.

Since there are no calls to `.intern()` in the TLA+ source code that I can find, we ought to fix these dangerous comparisons.  However, it is worth noting that these have not caused any (reported) issues so far, and may actually be safe if the strings being compared always point to program string literals.

There may be instances of this pattern that I have not caught.  I identified the locations to fix using IntelliJ's built-in string comparison inspection.  There are limitations to this analysis! If two strings are cast to `Object` before the comparison, the analyis will not detect a problem.

This issue was originally reported and fixed by @ElliotSwart in pull request #756.