### PR TITLE
Add action names for simulation mode trace dumps

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
@@ -551,7 +551,10 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 				}
 			}.get();
 			for (int idx = 0; idx < stateTrace .size(); idx++) {
-				pw.println("\\* " + stateTrace.elementAt(idx).getAction().getLocation());
+				Action curAction = stateTrace.elementAt(idx).getAction();
+				if (curAction != null) {
+					pw.println("\\* " + curAction.getLocation());
+				}
 				pw.println("STATE_" + (idx + 1) + " == ");
 				pw.println(stateTrace.elementAt(idx) + "\n");
 			}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
@@ -551,6 +551,7 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 				}
 			}.get();
 			for (int idx = 0; idx < stateTrace .size(); idx++) {
+				pw.println("\\* " + stateTrace.elementAt(idx).getAction().getLocation());
 				pw.println("STATE_" + (idx + 1) + " == ");
 				pw.println(stateTrace.elementAt(idx) + "\n");
 			}


### PR DESCRIPTION
Resolves #666.

It is a very simple pull request to add action names for simulation mode trace dumps. The added lines are TLA+ comments, which conforms to TLA+ syntax.

Generated trace example:
```
\* <Init line 9, col 9 to line 11, col 17 of module DieHard>
STATE_1 == 
/\ big = 0
/\ small = 0


\* <FillBig line 17, col 12 to line 19, col 21 of module DieHard>
STATE_2 == 
/\ big = 5
/\ small = 0
```