### PR TITLE
Add File.separator after BASE_DIR wherever it is used

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CommonTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CommonTestCase.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -54,7 +55,7 @@ public abstract class CommonTestCase {
 
 	protected static final String BASE_DIR = System.getProperty("basedir", "");
 	protected static final String TEST_MODEL = "test-model" + File.separator;
-	public static final String BASE_PATH = System.getProperty("basepath", BASE_DIR + TEST_MODEL);
+	public static final String BASE_PATH = System.getProperty("basepath", BASE_DIR + File.separator + TEST_MODEL);
 
 	protected final TestMPRecorder recorder;
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github432Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github432Test.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2019 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -152,8 +153,8 @@ public class Github432Test extends ModelCheckerTestCase {
 	}
 	
 	private void createConfigFile(final String humans, final String others) throws IOException {
-		final File configFile = new File(BASE_DIR + TEST_MODEL + CONFIG_FILE);
-		final File backup = new File(BASE_DIR + TEST_MODEL + CONFIG_FILE_BACKUP);
+		final File configFile = new File(BASE_DIR + File.separator + TEST_MODEL + CONFIG_FILE);
+		final File backup = new File(BASE_DIR + File.separator + TEST_MODEL + CONFIG_FILE_BACKUP);
 		
 		if (backup.exists()) {
 			Assert.fail("Github432 test state is incoherent: the backup file already exists at "
@@ -207,10 +208,10 @@ public class Github432Test extends ModelCheckerTestCase {
 	}
 	
 	private void revertConfigFile() {
-		final File backup = new File(BASE_DIR + TEST_MODEL + CONFIG_FILE_BACKUP);
+		final File backup = new File(BASE_DIR + File.separator + TEST_MODEL + CONFIG_FILE_BACKUP);
 		
 		if (backup.exists()) {
-			final File configFile = new File(BASE_DIR + TEST_MODEL + CONFIG_FILE);
+			final File configFile = new File(BASE_DIR + File.separator + TEST_MODEL + CONFIG_FILE);
 
 			try {
 				Files.move(backup.toPath(), configFile.toPath(), StandardCopyOption.REPLACE_EXISTING);

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/distributed/TLCServerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/distributed/TLCServerTestCase.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -66,7 +67,7 @@ public abstract class TLCServerTestCase extends ModelCheckerTestCase {
 			// of no use anyway.
 			TLCGlobals.chkptDuration = 0;
 			
-			final String fqSpec = BASE_DIR + TEST_MODEL + path + File.separator + spec;
+			final String fqSpec = BASE_DIR + File.separator + TEST_MODEL + path + File.separator + spec;
 			final FPSetConfiguration fpSetConfig = new DummyFPSetConfig();
 			ToolIO.setUserDir(BASE_DIR + File.separator + TEST_MODEL + path + File.separator);
 			final TLCApp app = new TLCApp(fqSpec, spec, false, null, fpSetConfig);

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/CodePlexBug08EWD840FL2FromCheckpointTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/CodePlexBug08EWD840FL2FromCheckpointTest.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -50,7 +51,7 @@ import tlc2.output.EC.ExitStatus;
 public class CodePlexBug08EWD840FL2FromCheckpointTest extends ModelCheckerTestCase {
 
 	public CodePlexBug08EWD840FL2FromCheckpointTest() {
-		super("EWD840MC2", "CodePlexBug08", new String[] {"-gzip", "-recover", BASE_DIR + TEST_MODEL + "CodePlexBug08" + File.separator + "checkpoint"}, ExitStatus.VIOLATION_LIVENESS);
+		super("EWD840MC2", "CodePlexBug08", new String[] {"-gzip", "-recover", BASE_DIR + File.separator + TEST_MODEL + "CodePlexBug08" + File.separator + "checkpoint"}, ExitStatus.VIOLATION_LIVENESS);
 	}
 	
 	
@@ -66,7 +67,7 @@ public class CodePlexBug08EWD840FL2FromCheckpointTest extends ModelCheckerTestCa
 			 * 5) Replace the content of checkpoint.zip with the content of 4)
 			 * 6) Update the number below on states found...
 			 */
-			String prefix = BASE_DIR + TEST_MODEL + "CodePlexBug08" + File.separator;
+			String prefix = BASE_DIR + File.separator + TEST_MODEL + "CodePlexBug08" + File.separator;
 			ZipFile zipFile = new ZipFile(prefix + "checkpoint.zip");
 			Enumeration<?> enu = zipFile.entries();
 			while (enu.hasMoreElements()) {


### PR DESCRIPTION
This change slightly simplifies the requirements for running the TLA+ tools tests.  Previously, BASE_DIR (read from the "basedir" system property) required a trailing separator character (e.g. "/" on Linux) to function correctly.

With this change the separator is no longer required, which simplifies running the tests from custom IDEs or other build systems.

In particular, note that Maven sets the "basedir" system property to a normalized path while running tests, meaning that it strips off trailing separators.  This behavior is undocumented and there is no way to override it.