### PR TITLE
LazyValue refactor

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/EvalControl.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/EvalControl.java
@@ -1,9 +1,12 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at  9:27:06 PST by lamport 
 //      modified on Fri Jan  4 22:46:57 PST 2002 by yuanyu 
 
 package tlc2.tool;
+
+import tlc2.util.PartialBoolean;
 
 public class EvalControl {
 
@@ -81,4 +84,46 @@ public class EvalControl {
 	public static boolean isConst(int control) {
 		return isSet(control, Const);
 	}
+
+    /**
+     * Determine whether two {@link EvalControl} settings are semantically equivalent.  Formally,
+     * they are semantically equivalent if
+     * <pre>
+     *     \A expr, context, behavior:
+     *         eval(expr, context, behavior, control1) =
+     *         eval(expr, context, behavior, control2)
+     * </pre>
+     *
+     * <p>Many control settings like {@link #Clear} and {@link #Enabled} are not equivalent; they
+     * will often result in different computed values.
+     *
+     * <p>This function always returns {@link PartialBoolean#YES} when
+     * <code>control1 == control2</code>, and it can identify a small set of other cases where
+     * the inputs are semantically equivalent.
+     *
+     * @param control1 the first control value
+     * @param control2 the second control value
+     * @return whether the values are semantically equivalent
+     */
+    public static PartialBoolean semanticallyEquivalent(int control1, int control2) {
+        // *** CAUTION ***
+        // The implementation of this function is quite subtle.  First we'll define `flagsThatCanBeSafelyIgnored`
+        // as a special whitelist of flags we know won't affect the evaluation outcome.  Each whitelisted flag
+        // has to be carefully justified:
+        //   - KeepLazy: this is a performance hint that affects handling of function definitions.  Although it
+        //     can change the exact structure of the IValue returned by eval(...), it does not affect the semantic
+        //     meaning of that value.
+        //   - Init: this is a flag to indicate that we are evaluating part of a specification's initial condition.
+        //     It is used for debugging.
+        //   - Const: similar to Init, this is a flag to indicate that we are evaluating part of a specification's
+        //     constant definitions.  It is used for debugging.
+        int flagsThatCanBeSafelyIgnored = KeepLazy | Init | Const;
+
+        // Compute a mask capturing all possible flags that CAN'T be safely ignored.
+        int mask = ~flagsThatCanBeSafelyIgnored;
+
+        // If the two inputs are identical on all flags not present in `flagsThatCanBeSafelyIgnored`, then they are
+        // certainly equivalent.  Otherwise, conservatively return `MAYBE`.
+        return (control1 & mask) == (control2 & mask) ? PartialBoolean.YES : PartialBoolean.MAYBE;
+    }
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateFun.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateFun.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:29:58 PST by lamport
 //      modified on Fri Jul 20 23:54:51 PDT 2001 by yuanyu
 
@@ -26,9 +27,9 @@ import util.WrongInvocationException;
  * can not be used in getInitStates and getNextStates.
  */
 public final class TLCStateFun extends TLCState {
-  private SymbolNode name;
-  private IValue value;
-  private TLCStateFun next;
+  private final SymbolNode name;
+  private final IValue value;
+  private final TLCStateFun next;
 
   public final static TLCState Empty = new TLCStateFun(null, null, null);
   
@@ -64,10 +65,16 @@ public final class TLCStateFun extends TLCState {
   }
   
   public final TLCState copy() {
-      // The following code added blindly by LL on 28 May 2010
-      // to fix a bug.  I have no idea what's going on here.
-       return new TLCStateFun(this.name, this.value, this.next);
-      // throw new WrongInvocationException("TLCStateFun.copy: This is a TLC bug.");
+    // NOTE 2023/4/10: Since instances of this class are immutable, there is no need
+    // to create an actual copy.  In addition to being more performant, this fixes a
+    // latent bug: LL's code below can copy the `Empty` TLCState, creating "corrupt"
+    // instances of TLCStateFun that have null fields but are not equal to `Empty`.
+    return this;
+    // The following code added blindly by LL on 28 May 2010
+    // to fix a bug.  I have no idea what's going on here.
+    // return new TLCStateFun(this.name, this.value, this.next);
+    // NOTE: the original implementation threw an exception:
+    // throw new WrongInvocationException("TLCStateFun.copy: This is a TLC bug.");
   }
   
   public final TLCState deepCopy() {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:30:01 PST by lamport
 //      modified on Wed Dec  5 23:18:37 PST 2001 by yuanyu
 
@@ -127,9 +128,7 @@ public final class TLCStateMut extends TLCState implements Cloneable, Serializab
   public final TLCState copy() {
     int len = this.values.length;
     IValue[] vals = new IValue[len];
-    for (int i = 0; i < len; i++) {
-      vals[i] = this.values[i];
-    }
+    System.arraycopy(this.values, 0, vals, 0, len);
     return copy(new TLCStateMut(vals));
   }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:30:01 PST by lamport
 //      modified on Wed Dec  5 23:18:37 PST 2001 by yuanyu
 
@@ -127,9 +128,7 @@ public final class TLCStateMutExt extends TLCState implements Cloneable, Seriali
   public final TLCState copy() {
     int len = this.values.length;
     IValue[] vals = new IValue[len];
-    for (int i = 0; i < len; i++) {
-      vals[i] = this.values[i];
-    }
+    System.arraycopy(this.values, 0, vals, 0, len);
     return copyExt(new TLCStateMutExt(vals));
   }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SymbolNodeValueLookupProvider.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SymbolNodeValueLookupProvider.java
@@ -88,18 +88,6 @@ public interface SymbolNodeValueLookupProvider {
 
 	default Object getVal(final ExprOrOpArgNode expr, final Context c, final boolean cachable, final CostModel cm, final int forToolId) {
 		// For INSTANCE Foo With x <- z, y <- z, this currently creates two distinct LazyValues.  Is this really what should happen?
-		if (!LazyValue.LAZYEVAL_OFF && expr instanceof OpApplNode) {
-			final OpApplNode oan = (OpApplNode) expr;
-			// Do not create a LazyValue that "points to" another LazyValue.
-			// Related:
-			// https://github.com/tlaplus/tlaplus/issues/113
-			// https://github.com/tlaplus/tlaplus/issues/798
-			final Object l = c.lookup(oan.getOperator());
-			if (l instanceof LazyValue) {
-				return l;
-			}
-			return new LazyValue(expr, c, cachable, cm);
-		}
 		if (expr instanceof ExprNode) {
 			return new LazyValue(expr, c, cachable, cm);
 		}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Thu  2 Aug 2007 at 10:25:48 PST by lamport
 //      modified on Fri Jan  4 22:46:57 PST 2002 by yuanyu
@@ -22,8 +22,6 @@ import tla2sany.semantic.ExternalModuleTable;
 import tla2sany.semantic.FormalParamNode;
 import tla2sany.semantic.LabelNode;
 import tla2sany.semantic.LetInNode;
-import tla2sany.semantic.LevelConstants;
-import tla2sany.semantic.LevelNode;
 import tla2sany.semantic.OpApplNode;
 import tla2sany.semantic.OpArgNode;
 import tla2sany.semantic.OpDeclNode;
@@ -605,11 +603,11 @@ public abstract class Tool
 
           if (val instanceof LazyValue) {
             LazyValue lv = (LazyValue)val;
-            if (lv.getValue() == null || lv.isUncachable()) {
+            val = lv.getCachedValue(this, ps, null, EvalControl.Clear);
+            if (val == null) {
               this.getInitStates(lv.expr, acts, lv.con, ps, states, cm);
               return;
             }
-            val = lv.getValue();
           }
 
           Object bval = val;
@@ -1093,10 +1091,10 @@ public abstract class Tool
 
           if (val instanceof LazyValue) {
             final LazyValue lv = (LazyValue)val;
-            if (lv.getValue() == null || lv.isUncachable()) {
+            val = lv.getCachedValue(this, s0, s1, EvalControl.Clear);
+            if (val == null) {
               return this.getNextStates(action, lv.expr, acts, lv.con, s0, s1, nss, lv.cm);
             }
-            val = lv.getValue();
           }
 
           //TODO If all eval/apply in getNextStatesApplEvalAppl would be side-effect free (ie. not mutate args, c, s0,...), 
@@ -1837,114 +1835,117 @@ public abstract class Tool
 //          if (val instanceof Supplier) {
 //        	  val = ((Supplier) val).get();
 //          }
-          
+
           // First, unlazy if it is a lazy value. We cannot use the cached
           // value when s1 == null or isEnabled(control).
-			if (val instanceof LazyValue) {
-				final LazyValue lv = (LazyValue) val;
-				if (s1 == null) {
-					val = this.eval(lv.expr, lv.con, s0, TLCState.Null, control, lv.getCostModel());
-			    } else if (lv.isUncachable() || EvalControl.isEnabled(control)) {
-					// Never use cached LazyValues in an ENABLED expression. This is why all
-					// this.enabled* methods pass EvalControl.Enabled (the only exception being the
-					// call on line line 2799 which passes EvalControl.Primed). This is why we can
-			    	// be sure that ENALBED expressions are not affected by the caching bug tracked
-			    	// in Github issue 113 (see below).
-					val = this.eval(lv.expr, lv.con, s0, s1, control, lv.getCostModel());
-				} else {
-					val = lv.getValue();
-					if (val == null) {
-						final Value res = this.eval(lv.expr, lv.con, s0, s1, control, lv.getCostModel());
-						// This check has been suggested by Yuan Yu on 01/15/2018:
-						//
-						// If init-states are being generated, level has to be <= ConstantLevel for
-						// caching/LazyValue to be allowed. If next-states are being generated, level
-						// has to be <= VariableLevel. The level indicates if the expression to be
-						// evaluated contains only constants, constants & variables, constants & 
-						// variables and primed variables (thus action) or is a temporal formula.
-						//
-						// This restriction is in place to fix Github issue 113
-						// (https://github.com/tlaplus/tlaplus/issues/113) - 
-						// TLC can generate invalid sets of init or next-states caused by broken
-						// LazyValue evaluation. The related tests are AssignmentInit* and
-						// AssignmentNext*. Without this fix, TLC essentially reuses a stale lv.val when
-						// it needs to re-evaluate res because the actual operands to eval changed.
-						// Below is Leslie's formal description of the bug:
-						// 
-						// The possible initial values of some variable  var  are specified by a subformula
-						// 
-						// F(..., var, ...)
-						// 
-						// in the initial predicate, for some operator F such that expanding the
-						// definition of F results in a formula containing more than one occurrence of
-						// var , not all occurring in separate disjuncts of that formula.
-						// 
-						// The possible next values of some variable  var  are specified by a subformula
-						// 
-						// F(..., var', ...)
-						// 
-						// in the next-state relation, for some operator F such that expanding the
-						// definition of F results in a formula containing more than one occurrence of
-						// var' , not all occurring in separate disjuncts of that formula.
-						// 
-						// An example of the first case is an initial predicate  Init  defined as follows:
-						// 
-						// VARIABLES x, ...
-						// F(var) == \/ var \in 0..99 /\ var % 2 = 0
-						//           \/ var = -1
-						// Init == /\ F(x)
-						//         /\ ...
-						// 
-						// The error would not appear if  F  were defined by:
-						// 
-						// F(var) == \/ var \in {i \in 0..99 : i % 2 = 0}
-						//           \/ var = -1
-						// 
-						// or if the definition of  F(x)  were expanded in  Init :
-						// 
-						// Init == /\ \/ x \in 0..99 /\ x % 2 = 0
-						//            \/ x = -1
-						//         /\ ...
-						// 
-						// A similar example holds for case 2 with the same operator F and the
-						// next-state formula
-						// 
-						// Next == /\ F(x')
-						//         /\ ...
-						// 
-						// The workaround is to rewrite the initial predicate or next-state relation so
-						// it is not in the form that can cause the bug. The simplest way to do that is
-						// to expand (in-line) the definition of F in the definition of the initial
-						// predicate or next-state relation.
-						//
-						// Note that EvalControl.Init is only set in the scope of this.getInitStates*,
-						// but not in the scope of methods such as this.isInModel, this.isGoodState...
-						// which are invoked by DFIDChecker and ModelChecker#doInit and doNext. These
-						// invocation however don't pose a problem with regards to issue 113 because
-						// they don't generate the set of initial or next states but get passed fully
-						// generated/final states.
-						//
-						// !EvalControl.isInit(control) means Tool is either processing the spec in
-						// this.process* as part of initialization or that next-states are being
-						// generated. The latter case has to restrict usage of cached LazyValue as
-						// discussed above.
-						final int level = ((LevelNode) lv.expr).getLevel(); // cast to LevelNode is safe because LV only subclass of SN.
-						if ((EvalControl.isInit(control) && level <= LevelConstants.ConstantLevel)
-								|| (!EvalControl.isInit(control) && level <= LevelConstants.VariableLevel)) {
-							// The performance benefits of caching values is generally debatable. The time
-							// it takes TLC to check a reasonable sized model of the PaxosCommit [1] spec is
-							// ~2h with, with limited caching due to the fix for issue 113 or without
-							// caching. There is no measurable performance difference even though the change
-							// for issue 113 reduces the cache hits from ~13 billion to ~4 billion. This was
-							// measured with an instrumented version of TLC.
-							// [1] general/performance/PaxosCommit/  
-							lv.setValue(res);
-						}
-						val = res;
-					}
-				}
-
-			}
+          if (val instanceof LazyValue) {
+              final LazyValue lv = (LazyValue) val;
+              if (s1 == null) {
+                  // NOTE 2023/4/7: Strictly speaking, this branch is not necessary.  TLC could return
+                  // `lv.getValue(...)` here as it does in the else-branch below.  Today I considered
+                  // removing it since it prevents LazyValue's caching benefits in some cases.
+                  // However, I retained it for two reasons:
+                  //   (1) There are some debugger-related tests that make assertions about when certain
+                  //       LazyValues are evaluated and cached.  Those tests fail if TLC skips this branch.
+                  //       I suspect those tests need some additional thought; if it is really important
+                  //       that TLC not cache LazyValues during certain debugger actions, it might need a
+                  //       stronger prevention mechanism.
+                  //   (2) I am worried that this branch serves some subtle purpose I do not yet understand.
+                  //       I do not want to remove it unless I am sure that I understand why it was here to
+                  //       begin with.
+                  val = this.eval(lv.expr, lv.con, s0, TLCState.Null, control, lv.getCostModel());
+              } else {
+                  // NOTE 2023/6/15: TLC has historically had a few critical bugs due to mishandling of cached
+                  // LazyValues.  With a little refactoring we think we have finally squashed them by moving
+                  // the safety responsibility out of this method and into the LazyValue class itself.  So,
+                  // this branch can be simply:
+                  return lv.getValue(this, s0, s1, control);
+                  // However, I am retaining the big comment that used to live here about LazyValues.  It contains
+                  // some out-of-date notes about the code, but also some useful insights that are still relevant.
+                  //
+                  // ------------------------------------------------------------------------------------------------
+                  // Never use cached LazyValues in an ENABLED expression. This is why all
+                  // this.enabled* methods pass EvalControl.Enabled (the only exception being the
+                  // call on line line 2799 which passes EvalControl.Primed). This is why we can
+                  // be sure that ENABLED expressions are not affected by the caching bug tracked
+                  // in Github issue 113 (see below).
+                  //
+                  // This check has been suggested by Yuan Yu on 01/15/2018:
+                  //
+                  // If init-states are being generated, level has to be <= ConstantLevel for
+                  // caching/LazyValue to be allowed. If next-states are being generated, level
+                  // has to be <= VariableLevel. The level indicates if the expression to be
+                  // evaluated contains only constants, constants & variables, constants &
+                  // variables and primed variables (thus action) or is a temporal formula.
+                  //
+                  // This restriction is in place to fix Github issue 113
+                  // (https://github.com/tlaplus/tlaplus/issues/113) -
+                  // TLC can generate invalid sets of init or next-states caused by broken
+                  // LazyValue evaluation. The related tests are AssignmentInit* and
+                  // AssignmentNext*. Without this fix, TLC essentially reuses a stale lv.val when
+                  // it needs to re-evaluate res because the actual operands to eval changed.
+                  // Below is Leslie's formal description of the bug:
+                  //
+                  // The possible initial values of some variable  var  are specified by a subformula
+                  //
+                  // F(..., var, ...)
+                  //
+                  // in the initial predicate, for some operator F such that expanding the
+                  // definition of F results in a formula containing more than one occurrence of
+                  // var , not all occurring in separate disjuncts of that formula.
+                  //
+                  // The possible next values of some variable  var  are specified by a subformula
+                  //
+                  // F(..., var', ...)
+                  //
+                  // in the next-state relation, for some operator F such that expanding the
+                  // definition of F results in a formula containing more than one occurrence of
+                  // var' , not all occurring in separate disjuncts of that formula.
+                  //
+                  // An example of the first case is an initial predicate  Init  defined as follows:
+                  //
+                  // VARIABLES x, ...
+                  // F(var) == \/ var \in 0..99 /\ var % 2 = 0
+                  //           \/ var = -1
+                  // Init == /\ F(x)
+                  //         /\ ...
+                  //
+                  // The error would not appear if  F  were defined by:
+                  //
+                  // F(var) == \/ var \in {i \in 0..99 : i % 2 = 0}
+                  //           \/ var = -1
+                  //
+                  // or if the definition of  F(x)  were expanded in  Init :
+                  //
+                  // Init == /\ \/ x \in 0..99 /\ x % 2 = 0
+                  //            \/ x = -1
+                  //         /\ ...
+                  //
+                  // A similar example holds for case 2 with the same operator F and the
+                  // next-state formula
+                  //
+                  // Next == /\ F(x')
+                  //         /\ ...
+                  //
+                  // The workaround is to rewrite the initial predicate or next-state relation so
+                  // it is not in the form that can cause the bug. The simplest way to do that is
+                  // to expand (in-line) the definition of F in the definition of the initial
+                  // predicate or next-state relation.
+                  //
+                  // Note that EvalControl.Init is only set in the scope of this.getInitStates*,
+                  // but not in the scope of methods such as this.isInModel, this.isGoodState...
+                  // which are invoked by DFIDChecker and ModelChecker#doInit and doNext. These
+                  // invocation however don't pose a problem with regards to issue 113 because
+                  // they don't generate the set of initial or next states but get passed fully
+                  // generated/final states.
+                  //
+                  // !EvalControl.isInit(control) means Tool is either processing the spec in
+                  // this.process* as part of initialization or that next-states are being
+                  // generated. The latter case has to restrict usage of cached LazyValue as
+                  // discussed above.
+                  // ------------------------------------------------------------------------------------------------
+              }
+          }
 
 			Value res = null;
           if (val instanceof OpDefNode) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/PartialBoolean.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/PartialBoolean.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+
+package tlc2.util;
+
+/**
+ * An enum for {@link #YES}, {@link #NO}, or {@link #MAYBE} (not all questions have definite answers).
+ */
+public enum PartialBoolean {
+    YES,
+    NO,
+    MAYBE;
+
+    public boolean isDefinitely(boolean value) {
+        switch (this) {
+            case YES:   return value;
+            case NO:    return !value;
+            case MAYBE: return false;
+            default:
+                // unreachable; necessary to satisfy javac
+                throw new UnsupportedOperationException(this.toString());
+        }
+    }
+
+    public boolean couldBe(boolean value) {
+        return !isDefinitely(!value);
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazySupplierValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazySupplierValue.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2022 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -28,7 +29,9 @@ package tlc2.value.impl;
 import java.util.function.Supplier;
 
 import tla2sany.semantic.SemanticNode;
+import tlc2.tool.TLCState;
 import tlc2.tool.coverage.CostModel;
+import tlc2.tool.impl.Tool;
 import tlc2.util.Context;
 
 public class LazySupplierValue extends LazyValue {
@@ -41,7 +44,8 @@ public class LazySupplierValue extends LazyValue {
 	}
 
 	@Override
-	public Value getValue() {
+	public Value getValue(Tool tool, TLCState s0, TLCState s1, int control) {
+		// TODO: is it OK to ignore the args here?  What are the semantics of this particular value?
 		return (Value) s.get();
 	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:08 PST by lamport
 //      modified on Thu Feb  8 21:23:55 PST 2001 by yuanyu
@@ -22,6 +23,52 @@ import tlc2.value.IValue;
 import util.Assert;
 import util.ToolIO;
 
+/**
+ * LazyValue is TLA+ expression that has not been reduced to a simple value.
+ *
+ * <h2>The Need for Laziness</h2>
+ *
+ * <p>TLC uses LazyValue when it "computes" the arguments to an operator or the bound value in a LET...IN expression.
+ * Because TLA+ has temporal operators, it cannot behave like a normal call-by-value interpreter in these cases.
+ *
+ * <p>For example, suppose a TLA+ spec contains the definition
+ * <pre>
+ *     F(x) == x'
+ * </pre>
+ * and TLC has to evaluate the expression <code>F(var)</code> in a behavior where <code>var = 1</code> and
+ * <code>var' = 2</code>.  The correct output is 2.  However, fully reducing the argument <code>var</code> before
+ * expanding <code>F</code> would lead to wrong output:
+ * <pre>
+ *     F(var) = F(1)   \* wrong!
+ *            = 1'
+ *            = 1
+ *
+ *     F(var) = var'   \* right!
+ *            = 2
+ * </pre>
+ * When expanding <code>F</code> TLC needs to keep the expression that was used as the <code>x</code> argument in order
+ * to get the right output.
+ *
+ * <h2>Caching and Performance</h2>
+ *
+ * <p>For performance, LazyValue can cache the reduced value when it is computed.  This enables TLC to have similar
+ * performance to a call-by-value language in many cases.  For example, if <code>G(x) == x + x</code>, then evaluating
+ * the expression <code>G(very_expensive_arg)</code> should only evaluate the very expensive argument once.
+ *
+ * <p>TLC has had multiple soundness bugs due to mishandling of cached LazyValues: see Github issues #113 and #798.  As
+ * a result, reads of the cached value are now guarded and callers must specify the tool, behavior, and evaluation mode
+ * they are using when reading it (see {@link #getCachedValue(Tool, TLCState, TLCState, int)}).
+ *
+ * <p>The performance benefits of caching values is generally debatable. The time
+ * it takes TLC to check a reasonable sized model of the PaxosCommit [1] spec is
+ * ~2h with, with limited caching due to the fix for issue 113 or without
+ * caching. There is no measurable performance difference even though the change
+ * for issue 113 reduces the cache hits from ~13 billion to ~4 billion. This was
+ * measured with an instrumented version of TLC.
+ * [1] general/performance/PaxosCommit/
+ *
+ * @see #getValue(Tool, TLCState, TLCState, int)
+ */
 public class LazyValue extends Value {
 	/**
 	 * Allow to completely disable LazyValue by passing a VM property/system
@@ -40,6 +87,10 @@ public class LazyValue extends Value {
 			ToolIO.out.println("LazyValue is disabled.");
 		}
 	}
+
+  public final SemanticNode expr;
+  public final Context con;
+
   /**
    * The field val is the result of evaluating expr in context con and
    * a pair of states.  If val is null, then the value has not been
@@ -47,10 +98,12 @@ public class LazyValue extends Value {
    * val. If val is ValUndef, then the value has not been computed,
    * and when computed, it can not be cached in the field val.
    */
-
-  public SemanticNode expr;
-  public Context con;
   private Value val;
+  private int toolID;
+  private TLCState s0;
+  private TLCState s1;
+  private int control;
+  private int cacheCount = 0;
 
   public LazyValue(SemanticNode expr, Context con, final CostModel cm) {
 	  this(expr, con, true, coverage ? cm.get(expr) : cm);
@@ -61,26 +114,74 @@ public class LazyValue extends Value {
     this.con = con;
     this.cm = coverage ? cm.get(expr) : cm;
     this.val = null;
-    // See comment on cachable's meager performance in Tool.java on line 1408.
-    // See other note about a bug that surfaced with LazyValue in Tool.java on line ~1385.
+    // See comment on cachable's meager performance in the docstring above.
+    // See other note about a bug that surfaced with LazyValue in the docstring above.
     if (LAZYEVAL_OFF || !cachable) {
     	this.val = UndefValue.ValUndef;
     }
   }
 
-  public final boolean isUncachable() { return this.val == UndefValue.ValUndef; }
+  private boolean isCachable() { return this.val != UndefValue.ValUndef; }
 
-  public final void setValue(final Value aValue) {
-	  assert !isUncachable();
-	  this.val = aValue;
+  /** For testing only. */
+  public int getNumTimesThatANewValueWasCached() {
+    return cacheCount;
   }
 
-  public Value getValue() {
-	  // cache hit on (this.val != null && !isUncachable)
-      // cache miss on (this.val == null)
-	  return this.val;
+  /**
+   * Equivalent to {@link #getValue(Tool, TLCState, TLCState, int)}, but does not
+   * compute a new value.  Instead, if a new value would need to be computed, this
+   * method returns null.
+   *
+   * @param tool a tool that evaluates expressions
+   * @param s0 the first state in the behavior
+   * @param s1 the next state in the behavior
+   * @param control see {@link EvalControl}
+   * @return a cached value for the given tool, behavior, and control; or null if
+   *         computing the requested value would require work
+   */
+  public Value getCachedValue(Tool tool, TLCState s0, TLCState s1, int control) {
+    if (val != null &&
+            isCachable() &&
+            tool.getId() == toolID &&
+            TLCState.isSubset(s0, this.s0).isDefinitely(true) &&
+            TLCState.isSubset(s1, this.s1).isDefinitely(true) &&
+            EvalControl.semanticallyEquivalent(control, this.control).isDefinitely(true)) {
+      return val;
+    }
+    return null;
   }
- 
+
+  /**
+   * Reduce this LazyValue to a fully-reduced value in the given behavior.
+   * The returned value might be cached to accelerate future calls.  LazyValue
+   * guarantees not to misuse the cached value; if this method is called later
+   * with a different tool, behavior, or control option that is incompatible
+   * with the ones used to compute the cached value, then the cached value will
+   * not be returned.
+   *
+   * @param tool a tool that evaluates expressions
+   * @param s0 the first state in the behavior
+   * @param s1 the next state in the behavior
+   * @param control see {@link EvalControl}
+   * @return a fully-reduced value
+   */
+  public Value getValue(Tool tool, TLCState s0, TLCState s1, int control) {
+    Value res = getCachedValue(tool, s0, s1, control);
+    if (res == null) {
+      res = tool.eval(this.expr, this.con, s0, s1, control, getCostModel());
+      if (isCachable()) {
+        this.val = res;
+        this.toolID = tool.getId();
+        this.s0 = s0 != null ? s0.copy() : null;
+        this.s1 = s1 != null ? s1.copy() : null;
+        this.control = control;
+        ++cacheCount;
+      }
+    }
+    return res;
+  }
+
   @Override
   public final byte getKind() { return LAZYVALUE; }
 

--- a/tlatools/org.lamport.tlatools/test-model/Github817.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github817.tla
@@ -1,0 +1,46 @@
+---------------------------- MODULE Github817 ---------------------------
+VARIABLES x
+
+Init == x = "init"
+Next ==
+    \/ x = "init" /\ x' = "in-progress"
+    \/ x = "in-progress" /\ x' = "done"
+
+AbstractX == IF x = "done" THEN "done" ELSE "in-progress"
+Abstract == INSTANCE Abstract WITH
+    x <- AbstractX
+
+Spec ==
+    /\ Init
+    /\ [][Next]_x
+    /\ WF_x(Next)
+
+Refinement == Abstract!Spec
+==========================================================================
+
+----------------------------- MODULE Abstract ----------------------------
+VARIABLES x
+Super == INSTANCE Abstract2
+Init == Super!Init
+Next == Super!Next
+Spec ==
+    /\ Init
+    /\ [][Next]_x
+    /\ WF_x(Next)
+==========================================================================
+
+----------------------------- MODULE Abstract2 ---------------------------
+VARIABLES x
+Init == x = "in-progress"
+Next == x' = "done"
+Spec ==
+    /\ Init
+    /\ [][Next]_x
+    /\ WF_x(Next)
+==========================================================================
+
+---------------------------- CONFIG Github817 ----------------------------
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+PROPERTY Refinement
+===========================================================================

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2020 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -219,13 +220,13 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 		// Showing variables in the debugger does *not* unlazy LazyValues, i.e.
 		// interferes with TLC's evaluation.
 		final List<LazyValue> lazies = new ArrayList<>();
+		final List<Integer> lazyCounts = new ArrayList<>();
 		Context context = f.getContext();
 		while (context != null) {
 			if (context.getValue() instanceof LazyValue) {
 				LazyValue lv = (LazyValue) context.getValue();
-				if (lv.getValue() == null) {
-					lazies.add(lv);
-				}
+				lazies.add(lv);
+				lazyCounts.add(lv.getNumTimesThatANewValueWasCached());
 			}
 			context = context.next();
 		}
@@ -241,7 +242,9 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			}
 			fail();
 		}
-		lazies.forEach(lv -> assertNull(lv.getValue()));
+		for (int i = 0; i < lazies.size(); ++i) {
+			assertEquals((int)lazyCounts.get(i), lazies.get(i).getNumTimesThatANewValueWasCached());
+		}
 	}
 
 	protected static void assertTLCActionFrame(final StackFrame stackFrame, final int beginLine, final int endLine,
@@ -311,13 +314,13 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 		// Showing variables in the debugger does *not* unlazy LazyValues, i.e.
 		// interferes with TLC's evaluation.
 		final List<LazyValue> lazies = new ArrayList<>();
+		final List<Integer> lazyCounts = new ArrayList<>();
 		Context context = f.getContext();
 		while (context != null) {
 			if (context.getValue() instanceof LazyValue) {
 				LazyValue lv = (LazyValue) context.getValue();
-				if (lv.getValue() == null) {
-					lazies.add(lv);
-				}
+				lazies.add(lv);
+				lazyCounts.add(lv.getNumTimesThatANewValueWasCached());
 			}
 			context = context.next();
 		}
@@ -328,7 +331,9 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			assertEquals(expected.get(variable.getName()), variable.getValue());
 		}
 		
-		lazies.forEach(lv -> assertNull(lv.getValue()));
+		for (int i = 0; i < lazies.size(); ++i) {
+			assertEquals((int)lazyCounts.get(i), lazies.get(i).getNumTimesThatANewValueWasCached());
+		}
 	}
 
 	protected static void assertTLCStateFrame(final StackFrame stackFrame, final int beginLine, final int endLine,

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github817Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github817Test.java
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class Github817Test extends ModelCheckerTestCase {
+
+	public Github817Test() {
+		super("Github817", new String[] { "-config", "Github817.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+	}
+
+}


### PR DESCRIPTION
This is a small(ish) refactor to the way that `LazyValue` works. It fixes #798, although I want to clarify that I'm not certain this is the right approach. I'm more interested in discussing whether this is a good direction to push. If we decide this is worth doing, I believe it is also compatible with the changes in #799.

**Key idea:**

TLC has had several bugs involving misuse of `LazyValue.val`. Instead of proving every use of that field correct, this change shifts the management of the field to the `LazyValue` class itself. Now callers _must_ specify the behavior and evaluation mode that they are evaluating with when reading the cached value. The cached value is only returned if it was computed using the same behavior and evaluation mode. If it wasn't, it must be recomputed.

**Pros:**

A lot of complexity can be removed without losing any potential benefits of `LazyValue`.

**Cons:**

There are some test failures related to interaction between the debugger and `LazyValue`. I believe they are relatively benign. Also, the `LazyValue` class now stores several more fields. It is possible that this will worsen TLC's performance since many instances of this class are created during evaluation.