### PR TITLE
Add -progressInterval CLI arg to modify logging frequency

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -974,6 +974,36 @@ public class TLC {
                     printErrorMsg("Error: fpbits required.");
                     return false;
                 }
+            } else if (args[index].equals("-progressInterval"))
+            {
+                index++;
+                if (index < args.length)
+                {
+                    try
+                    {
+                    	int progressIntervalS = Integer.parseInt(args[index]);
+
+                    	// make sure it's in valid range
+                    	if (progressIntervalS <= 0) {
+                            
+                            printErrorMsg("Error: expect a positive integer for -progressInterval option.");
+                            return false;
+                    	}
+                    	
+                        // convert seconds to milliseconds
+                        TLCGlobals.progressInterval = progressIntervalS * 1000;
+                    	
+                        index++;
+                    } catch (Exception e)
+                    {
+                        printErrorMsg("Error: A positive integer for progressInterval required. But encountered " + args[index]);
+                        return false;
+                    }
+                } else
+                {
+                    printErrorMsg("Error: progressInterval required.");
+                    return false;
+                }
             } else
             {
                 if (args[index].charAt(0) == '-')
@@ -1579,6 +1609,9 @@ public class TLC {
 															+ "SPEC-directory/states if not specified", true));
     	sharedArguments.add(new UsageGenerator.Argument("-nowarning",
 														"disable all warnings; defaults to reporting warnings", true));
+    	sharedArguments.add(new UsageGenerator.Argument("-progressInterval", "num",
+														"the number of seconds to wait between printing progress updates; \n"
+                                                            + "defaults to 60", true));
     	sharedArguments.add(new UsageGenerator.Argument("-recover", "id",
 														"recover from the checkpoint with the specified id", true));
     	sharedArguments.add(new UsageGenerator.Argument("-terse",

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLCGlobals.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLCGlobals.java
@@ -124,7 +124,7 @@ public class TLCGlobals
     public static boolean warn = true;
 
     // The time interval to report progress (in milliseconds)
-    public static final int progressInterval = 1 * 60 * 1000;
+    public static int progressInterval = 1 * 60 * 1000;
 
     // The time interval to checkpoint. (in milliseconds)
 	public static long chkptDuration = Integer.getInteger(


### PR DESCRIPTION
I'd like to use TLC to check specs in 10s of seconds, rather than hours. The logging period is currently hard-coded to 60s with the `final progressInterval` value, providing no progress reporting for such cases. I've added a CLI argument to modify that, eg:

```
$ java -jar dist/tla2tools.jar -progressInterval 2 my_spec.tla
...
Starting... (2023-07-24 14:33:28)
Computing initial states...
Finished computing initial states: 1 distinct state generated at 2023-07-24 14:33:28.
Progress(520) at 2023-07-24 14:33:31: 12,427 states generated (372,810 s/min), 1,038 distinct states found (31,140 ds/min), 1 states left on queue.
Progress(633) at 2023-07-24 14:33:33: 15,139 states generated (81,360 s/min), 1,264 distinct states found (6,780 ds/min), 1 states left on queue.
Progress(718) at 2023-07-24 14:33:35: 17,157 states generated (60,540 s/min), 1,433 distinct states found (5,070 ds/min), 2 states left on queue.
Progress(786) at 2023-07-24 14:33:37: 18,805 states generated (49,440 s/min), 1,570 distinct states found (4,110 ds/min), 2 states left on queue.
Progress(845) at 2023-07-24 14:33:39: 20,219 states generated (42,420 s/min), 1,688 distinct states found (3,540 ds/min), 2 states left on queue.
```

The `s/min` rate starts with an overestimate, but I haven't dug into the other users of `progressInterval` in detail to work out why that is.

This is not a blocker or previously requested feature, just a nice-to-have - happy to discuss other ways to achieve this.