### PR TITLE
LazyValue refactor: use LazyValue to cache LetInKind definitions in Tool#getNextStatesImpl

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/EvalControl.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/EvalControl.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at  9:27:06 PST by lamport 
 //      modified on Fri Jan  4 22:46:57 PST 2002 by yuanyu 
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateFun.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateFun.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:29:58 PST by lamport
 //      modified on Fri Jul 20 23:54:51 PDT 2001 by yuanyu
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateFun.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateFun.java
@@ -26,9 +26,9 @@ import util.WrongInvocationException;
  * can not be used in getInitStates and getNextStates.
  */
 public final class TLCStateFun extends TLCState {
-  private SymbolNode name;
-  private IValue value;
-  private TLCStateFun next;
+  private final SymbolNode name;
+  private final IValue value;
+  private final TLCStateFun next;
 
   public final static TLCState Empty = new TLCStateFun(null, null, null);
   
@@ -64,10 +64,16 @@ public final class TLCStateFun extends TLCState {
   }
   
   public final TLCState copy() {
-      // The following code added blindly by LL on 28 May 2010
-      // to fix a bug.  I have no idea what's going on here.
-       return new TLCStateFun(this.name, this.value, this.next);
-      // throw new WrongInvocationException("TLCStateFun.copy: This is a TLC bug.");
+    // NOTE 2023/4/10: Since instances of this class are immutable, there is no need
+    // to create an actual copy.  In addition to being more performant, this fixes a
+    // latent bug: LL's code below can copy the `Empty` TLCState, creating "corrupt"
+    // instances of TLCStateFun that have null fields but are not equal to `Empty`.
+    return this;
+    // The following code added blindly by LL on 28 May 2010
+    // to fix a bug.  I have no idea what's going on here.
+    // return new TLCStateFun(this.name, this.value, this.next);
+    // NOTE: the original implementation threw an exception:
+    // throw new WrongInvocationException("TLCStateFun.copy: This is a TLC bug.");
   }
   
   public final TLCState deepCopy() {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:30:01 PST by lamport
 //      modified on Wed Dec  5 23:18:37 PST 2001 by yuanyu
 
@@ -127,9 +128,7 @@ public final class TLCStateMut extends TLCState implements Cloneable, Serializab
   public final TLCState copy() {
     int len = this.values.length;
     IValue[] vals = new IValue[len];
-    for (int i = 0; i < len; i++) {
-      vals[i] = this.values[i];
-    }
+    System.arraycopy(this.values, 0, vals, 0, len);
     return copy(new TLCStateMut(vals));
   }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:30:01 PST by lamport
 //      modified on Wed Dec  5 23:18:37 PST 2001 by yuanyu
 
@@ -127,9 +128,7 @@ public final class TLCStateMutExt extends TLCState implements Cloneable, Seriali
   public final TLCState copy() {
     int len = this.values.length;
     IValue[] vals = new IValue[len];
-    for (int i = 0; i < len; i++) {
-      vals[i] = this.values[i];
-    }
+    System.arraycopy(this.values, 0, vals, 0, len);
     return copyExt(new TLCStateMutExt(vals));
   }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SymbolNodeValueLookupProvider.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SymbolNodeValueLookupProvider.java
@@ -88,18 +88,6 @@ public interface SymbolNodeValueLookupProvider {
 
 	default Object getVal(final ExprOrOpArgNode expr, final Context c, final boolean cachable, final CostModel cm, final int forToolId) {
 		// For INSTANCE Foo With x <- z, y <- z, this currently creates two distinct LazyValues.  Is this really what should happen?
-		if (!LazyValue.LAZYEVAL_OFF && expr instanceof OpApplNode) {
-			final OpApplNode oan = (OpApplNode) expr;
-			// Do not create a LazyValue that "points to" another LazyValue.
-			// Related:
-			// https://github.com/tlaplus/tlaplus/issues/113
-			// https://github.com/tlaplus/tlaplus/issues/798
-			final Object l = c.lookup(oan.getOperator());
-			if (l instanceof LazyValue) {
-				return l;
-			}
-			return new LazyValue(expr, c, cachable, cm);
-		}
 		if (expr instanceof ExprNode) {
 			return new LazyValue(expr, c, cachable, cm);
 		}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -904,8 +904,7 @@ public abstract class Tool
           }
         case LetInKind:
           {
-            LetInNode pred1 = (LetInNode)pred;
-            return this.getNextStates(action, pred1.getBody(), acts, c, s0, s1, nss, cm);
+            return getNextStatesImplLetInKind(action, (LetInNode) pred, acts, c, s0, s1, nss, cm);
           }
         case SubstInKind:
           {
@@ -928,6 +927,19 @@ public abstract class Tool
           }
         }
     	return s1;
+  }
+
+  @ExpectInlined
+  private final TLCState getNextStatesImplLetInKind(final Action action, LetInNode pred1, ActionItemList acts, Context c, TLCState s0, TLCState s1, INextStateFunctor nss, final CostModel cm) {
+    OpDefNode[] letDefs = pred1.getLets();
+    Context c1 = c;
+    for (OpDefNode opDef : letDefs) {
+      if (opDef.getArity() == 0) {
+        Value rhs = new LazyValue(opDef.getBody(), c1, cm);
+        c1 = c1.cons(opDef, rhs);
+      }
+    }
+    return this.getNextStates(action, pred1.getBody(), acts, c1, s0, s1, nss, cm);
   }
 
   @ExpectInlined

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -477,7 +477,15 @@ public abstract class Tool
         case LetInKind:
           {
             LetInNode init1 = (LetInNode)init;
-            this.getInitStates(init1.getBody(), acts, c, ps, states, cm);
+            OpDefNode[] letDefs = init1.getLets();
+            Context c1 = c;
+            for (OpDefNode opDef : letDefs) {
+              if (opDef.getArity() == 0) {
+                Value rhs = new LazyValue(opDef.getBody(), c1, cm);
+                c1 = c1.cons(opDef, rhs);
+              }
+            }
+            this.getInitStates(init1.getBody(), acts, c1, ps, states, cm);
             return;
           }
         case SubstInKind:

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/PartialBoolean.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/PartialBoolean.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+
+package tlc2.util;
+
+/**
+ * An enum for {@link #YES}, {@link #NO}, or {@link #MAYBE} (not all questions have definite answers).
+ */
+public enum PartialBoolean {
+    YES,
+    NO,
+    MAYBE;
+
+    public boolean isDefinitely(boolean value) {
+        switch (this) {
+            case YES:   return value;
+            case NO:    return !value;
+            case MAYBE: return false;
+            default:
+                // unreachable; necessary to satisfy javac
+                throw new UnsupportedOperationException(this.toString());
+        }
+    }
+
+    public boolean couldBe(boolean value) {
+        return !isDefinitely(!value);
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazySupplierValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazySupplierValue.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2022 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -28,7 +29,9 @@ package tlc2.value.impl;
 import java.util.function.Supplier;
 
 import tla2sany.semantic.SemanticNode;
+import tlc2.tool.TLCState;
 import tlc2.tool.coverage.CostModel;
+import tlc2.tool.impl.Tool;
 import tlc2.util.Context;
 
 public class LazySupplierValue extends LazyValue {
@@ -41,7 +44,8 @@ public class LazySupplierValue extends LazyValue {
 	}
 
 	@Override
-	public Value getValue() {
+	public Value getValue(Tool tool, TLCState s0, TLCState s1, int control) {
+		// TODO: is it OK to ignore the args here?  What are the semantics of this particular value?
 		return (Value) s.get();
 	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
@@ -10,7 +10,6 @@ package tlc2.value.impl;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Objects;
 
 import tla2sany.semantic.SemanticNode;
 import tlc2.tool.EvalControl;
@@ -142,7 +141,12 @@ public class LazyValue extends Value {
    *         computing the requested value would require work
    */
   public Value getCachedValue(Tool tool, TLCState s0, TLCState s1, int control) {
-    if (val != null && isCachable() && tool.getId() == toolID && Objects.equals(s0, this.s0) && Objects.equals(s1, this.s1) && control == this.control) {
+    if (val != null &&
+            isCachable() &&
+            tool.getId() == toolID &&
+            TLCState.isSubset(s0, this.s0).isDefinitely(true) &&
+            TLCState.isSubset(s1, this.s1).isDefinitely(true) &&
+            control == this.control) {
       return val;
     }
     return null;
@@ -169,8 +173,8 @@ public class LazyValue extends Value {
       if (isCachable()) {
         this.val = res;
         this.toolID = tool.getId();
-        this.s0 = s0 == null ? null : s0.copy();
-        this.s1 = s1 == null ? null : s1.copy();
+        this.s0 = s0 != null ? s0.copy() : null;
+        this.s1 = s1 != null ? s1.copy() : null;
         this.control = control;
         ++cacheCount;
       }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:08 PST by lamport
 //      modified on Thu Feb  8 21:23:55 PST 2001 by yuanyu
@@ -9,6 +10,7 @@ package tlc2.value.impl;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Objects;
 
 import tla2sany.semantic.SemanticNode;
 import tlc2.tool.EvalControl;
@@ -22,6 +24,52 @@ import tlc2.value.IValue;
 import util.Assert;
 import util.ToolIO;
 
+/**
+ * LazyValue is TLA+ expression that has not been reduced to a simple value.
+ *
+ * <h2>The Need for Laziness</h2>
+ *
+ * <p>TLC uses LazyValue when it "computes" the arguments to an operator or the bound value in a LET...IN expression.
+ * Because TLA+ has temporal operators, it cannot behave like a normal call-by-value interpreter in these cases.
+ *
+ * <p>For example, suppose a TLA+ spec contains the definition
+ * <pre>
+ *     F(x) == x'
+ * </pre>
+ * and TLC has to evaluate the expression <code>F(var)</code> in a behavior where <code>var = 1</code> and
+ * <code>var' = 2</code>.  The correct output is 2.  However, fully reducing the argument <code>var</code> before
+ * expanding <code>F</code> would lead to wrong output:
+ * <pre>
+ *     F(var) = F(1)   \* wrong!
+ *            = 1'
+ *            = 1
+ *
+ *     F(var) = var'   \* right!
+ *            = 2
+ * </pre>
+ * When expanding <code>F</code> TLC needs to keep the expression that was used as the <code>x</code> argument in order
+ * to get the right output.
+ *
+ * <h2>Caching and Performance</h2>
+ *
+ * <p>For performance, LazyValue can cache the reduced value when it is computed.  This enables TLC to have similar
+ * performance to a call-by-value language in many cases.  For example, if <code>G(x) == x + x</code>, then evaluating
+ * the expression <code>G(very_expensive_arg)</code> should only evaluate the very expensive argument once.
+ *
+ * <p>TLC has had multiple soundness bugs due to mishandling of cached LazyValues: see Github issues #113 and #798.  As
+ * a result, reads of the cached value are now guarded and callers must specify the tool, behavior, and evaluation mode
+ * they are using when reading it (see {@link #getCachedValue(Tool, TLCState, TLCState, int)}).
+ *
+ * <p>The performance benefits of caching values is generally debatable. The time
+ * it takes TLC to check a reasonable sized model of the PaxosCommit [1] spec is
+ * ~2h with, with limited caching due to the fix for issue 113 or without
+ * caching. There is no measurable performance difference even though the change
+ * for issue 113 reduces the cache hits from ~13 billion to ~4 billion. This was
+ * measured with an instrumented version of TLC.
+ * [1] general/performance/PaxosCommit/
+ *
+ * @see #getValue(Tool, TLCState, TLCState, int)
+ */
 public class LazyValue extends Value {
 	/**
 	 * Allow to completely disable LazyValue by passing a VM property/system
@@ -40,6 +88,10 @@ public class LazyValue extends Value {
 			ToolIO.out.println("LazyValue is disabled.");
 		}
 	}
+
+  public final SemanticNode expr;
+  public final Context con;
+
   /**
    * The field val is the result of evaluating expr in context con and
    * a pair of states.  If val is null, then the value has not been
@@ -47,10 +99,12 @@ public class LazyValue extends Value {
    * val. If val is ValUndef, then the value has not been computed,
    * and when computed, it can not be cached in the field val.
    */
-
-  public SemanticNode expr;
-  public Context con;
   private Value val;
+  private int toolID;
+  private TLCState s0;
+  private TLCState s1;
+  private int control;
+  private int cacheCount = 0;
 
   public LazyValue(SemanticNode expr, Context con, final CostModel cm) {
 	  this(expr, con, true, coverage ? cm.get(expr) : cm);
@@ -61,26 +115,69 @@ public class LazyValue extends Value {
     this.con = con;
     this.cm = coverage ? cm.get(expr) : cm;
     this.val = null;
-    // See comment on cachable's meager performance in Tool.java on line 1408.
-    // See other note about a bug that surfaced with LazyValue in Tool.java on line ~1385.
+    // See comment on cachable's meager performance in the docstring above.
+    // See other note about a bug that surfaced with LazyValue in the docstring above.
     if (LAZYEVAL_OFF || !cachable) {
     	this.val = UndefValue.ValUndef;
     }
   }
 
-  public final boolean isUncachable() { return this.val == UndefValue.ValUndef; }
+  private boolean isCachable() { return this.val != UndefValue.ValUndef; }
 
-  public final void setValue(final Value aValue) {
-	  assert !isUncachable();
-	  this.val = aValue;
+  /** For testing only. */
+  public int getNumTimesThatANewValueWasCached() {
+    return cacheCount;
   }
 
-  public Value getValue() {
-	  // cache hit on (this.val != null && !isUncachable)
-      // cache miss on (this.val == null)
-	  return this.val;
+  /**
+   * Equivalent to {@link #getValue(Tool, TLCState, TLCState, int)}, but does not
+   * compute a new value.  Instead, if a new value would need to be computed, this
+   * method returns null.
+   *
+   * @param tool a tool that evaluates expressions
+   * @param s0 the first state in the behavior
+   * @param s1 the next state in the behavior
+   * @param control see {@link EvalControl}
+   * @return a cached value for the given tool, behavior, and control; or null if
+   *         computing the requested value would require work
+   */
+  public Value getCachedValue(Tool tool, TLCState s0, TLCState s1, int control) {
+    if (val != null && isCachable() && tool.getId() == toolID && Objects.equals(s0, this.s0) && Objects.equals(s1, this.s1) && control == this.control) {
+      return val;
+    }
+    return null;
   }
- 
+
+  /**
+   * Reduce this LazyValue to a fully-reduced value in the given behavior.
+   * The returned value might be cached to accelerate future calls.  LazyValue
+   * guarantees not to misuse the cached value; if this method is called later
+   * with a different tool, behavior, or control option that is incompatible
+   * with the ones used to compute the cached value, then the cached value will
+   * not be returned.
+   *
+   * @param tool a tool that evaluates expressions
+   * @param s0 the first state in the behavior
+   * @param s1 the next state in the behavior
+   * @param control see {@link EvalControl}
+   * @return a fully-reduced value
+   */
+  public Value getValue(Tool tool, TLCState s0, TLCState s1, int control) {
+    Value res = getCachedValue(tool, s0, s1, control);
+    if (res == null) {
+      res = tool.eval(this.expr, this.con, s0, s1, control, getCostModel());
+      if (isCachable()) {
+        this.val = res;
+        this.toolID = tool.getId();
+        this.s0 = s0 == null ? null : s0.copy();
+        this.s1 = s1 == null ? null : s1.copy();
+        this.control = control;
+        ++cacheCount;
+      }
+    }
+    return res;
+  }
+
   @Override
   public final byte getKind() { return LAZYVALUE; }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
@@ -146,7 +146,7 @@ public class LazyValue extends Value {
             tool.getId() == toolID &&
             TLCState.isSubset(s0, this.s0).isDefinitely(true) &&
             TLCState.isSubset(s1, this.s1).isDefinitely(true) &&
-            control == this.control) {
+            EvalControl.semanticallyEquivalent(control, this.control).isDefinitely(true)) {
       return val;
     }
     return null;

--- a/tlatools/org.lamport.tlatools/test-model/Github824a.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github824a.tla
@@ -1,0 +1,14 @@
+---- MODULE Github824a ----
+VARIABLES var
+
+Init ==
+    /\ LET x == 1 IN var = x
+    /\ var = 1
+
+Next == UNCHANGED var
+
+====
+---- CONFIG Github824a ----
+INIT Init
+NEXT Next
+====

--- a/tlatools/org.lamport.tlatools/test-model/Github824b.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github824b.tla
@@ -1,0 +1,14 @@
+---- MODULE Github824b ----
+VARIABLES var
+
+Init == var = 0
+
+Next ==
+    /\ LET x == 1 IN var' = x
+    /\ var' = 1
+
+====
+---- CONFIG Github824b ----
+INIT Init
+NEXT Next
+====

--- a/tlatools/org.lamport.tlatools/test-model/Github824c.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github824c.tla
@@ -1,0 +1,14 @@
+---- MODULE Github824c ----
+VARIABLES var
+
+Init == var = 0
+
+Next ==
+    /\ LET x == 1 IN var' = [field |-> <<10, x>>]
+    /\ var' = [field |-> <<10, 1>>]
+
+====
+---- CONFIG Github824c ----
+INIT Init
+NEXT Next
+====

--- a/tlatools/org.lamport.tlatools/test-model/Github824d.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github824d.tla
@@ -1,0 +1,14 @@
+---- MODULE Github824d ----
+VARIABLES var
+
+Init == var = 0
+
+Next ==
+    /\ LET x == (var' = 1) IN x
+    /\ var' = 1
+
+====
+---- CONFIG Github824d ----
+INIT Init
+NEXT Next
+====

--- a/tlatools/org.lamport.tlatools/test-model/Github824e.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github824e.tla
@@ -1,0 +1,15 @@
+---- MODULE Github824e ----
+EXTENDS Naturals
+
+VARIABLES var
+
+Init == var = 0
+
+Next ==
+    /\ (LET x == var' IN ENABLED (x = 1 /\ var < 1)) = ENABLED (var' = 1 /\ var < 1)
+    /\ var' = 1
+====
+---- CONFIG Github824e ----
+INIT Init
+NEXT Next
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2020 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -208,13 +209,13 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 		// Showing variables in the debugger does *not* unlazy LazyValues, i.e.
 		// interferes with TLC's evaluation.
 		final List<LazyValue> lazies = new ArrayList<>();
+		final List<Integer> lazyCounts = new ArrayList<>();
 		Context context = f.getContext();
 		while (context != null) {
 			if (context.getValue() instanceof LazyValue) {
 				LazyValue lv = (LazyValue) context.getValue();
-				if (lv.getValue() == null) {
-					lazies.add(lv);
-				}
+				lazies.add(lv);
+				lazyCounts.add(lv.getNumTimesThatANewValueWasCached());
 			}
 			context = context.next();
 		}
@@ -230,7 +231,9 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			}
 			fail();
 		}
-		lazies.forEach(lv -> assertNull(lv.getValue()));
+		for (int i = 0; i < lazies.size(); ++i) {
+			assertEquals((int)lazyCounts.get(i), lazies.get(i).getNumTimesThatANewValueWasCached());
+		}
 	}
 
 	protected static void assertTLCActionFrame(final StackFrame stackFrame, final int beginLine, final int endLine,
@@ -300,13 +303,13 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 		// Showing variables in the debugger does *not* unlazy LazyValues, i.e.
 		// interferes with TLC's evaluation.
 		final List<LazyValue> lazies = new ArrayList<>();
+		final List<Integer> lazyCounts = new ArrayList<>();
 		Context context = f.getContext();
 		while (context != null) {
 			if (context.getValue() instanceof LazyValue) {
 				LazyValue lv = (LazyValue) context.getValue();
-				if (lv.getValue() == null) {
-					lazies.add(lv);
-				}
+				lazies.add(lv);
+				lazyCounts.add(lv.getNumTimesThatANewValueWasCached());
 			}
 			context = context.next();
 		}
@@ -317,7 +320,9 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			assertEquals(expected.get(variable.getName()), variable.getValue());
 		}
 		
-		lazies.forEach(lv -> assertNull(lv.getValue()));
+		for (int i = 0; i < lazies.size(); ++i) {
+			assertEquals((int)lazyCounts.get(i), lazies.get(i).getNumTimesThatANewValueWasCached());
+		}
 	}
 
 	protected static void assertTLCStateFrame(final StackFrame stackFrame, final int beginLine, final int endLine,

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824aTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824aTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import org.junit.Test;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Github824aTest extends ModelCheckerTestCase {
+	public Github824aTest() {
+		super("Github824a", new String[] { "-config", "Github824a.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "1"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "1", "0"));
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824bTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824bTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import org.junit.Test;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+public class Github824bTest extends ModelCheckerTestCase {
+	public Github824bTest() {
+		super("Github824b", new String[] { "-config", "Github824b.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824cTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824cTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import org.junit.Test;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+public class Github824cTest extends ModelCheckerTestCase {
+	public Github824cTest() {
+		super("Github824c", new String[] { "-config", "Github824c.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824dTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824dTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import org.junit.Test;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+public class Github824dTest extends ModelCheckerTestCase {
+	public Github824dTest() {
+		super("Github824d", new String[] { "-config", "Github824d.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824eTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github824eTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import org.junit.Test;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+import static org.junit.Assert.assertTrue;
+
+public class Github824eTest extends ModelCheckerTestCase {
+	public Github824eTest() {
+		super("Github824e", new String[] { "-config", "Github824e.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+}


### PR DESCRIPTION
Part of LazyValue refactor (https://github.com/tlaplus/tlaplus/pull/800)
Relevant comment: https://github.com/tlaplus/tlaplus/pull/800#issuecomment-1654202331