### PR TITLE
Support cyclic redefinitions if -Dtlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions=true is given

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/explorer/ExplorerVisitor.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/explorer/ExplorerVisitor.java
@@ -25,13 +25,17 @@
  ******************************************************************************/
 package tla2sany.explorer;
 
-public class ExplorerVisitor {
+public class ExplorerVisitor<T> {
 
-	public static final ExplorerVisitor NoopVisitor = new ExplorerVisitor();
+	public static final ExplorerVisitor<Void> NoopVisitor = new ExplorerVisitor<>();
 
 	public void preVisit(final ExploreNode exploreNode) {
 	}
 	
 	public void postVisit(final ExploreNode exploreNode) {
+	}
+	
+	public T get() {
+		return null;
 	}
 }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
@@ -234,6 +234,10 @@ public class OpApplNode extends ExprNode implements ExploreNode {
    */
   public final SymbolNode getOperator() { return this.operator; }
 
+  public void resetOperator(final OpDefNode odn) {
+	this.operator = odn;
+  }
+
   /**
    * Changes the operator field of this OpApplNode; used only to
    * change nonrecursive function definition operator to recursive

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -354,6 +354,8 @@ public abstract class Tool
                 IValue aval = this.eval(args[i], con, TLCState.Empty, cm);
                 con1 = con1.cons(formals[i], aval);
               }
+              // Recurse/go deeper if none of the (formal) parameters are of state-level or
+              // higher. In other words, only recurse if the params are constant level.
               this.getActions(opDef.getBody(), con1, opDef, cm);
               return;
             }

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/Vect.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/Vect.java
@@ -5,9 +5,11 @@
 package tlc2.util;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.NoSuchElementException;
 import java.util.Vector;
+import java.util.stream.Stream;
 
 /**
  * TODO it's unclear why we've written our own list implementation; we should consider using existing framework code for this;
@@ -210,4 +212,8 @@ public class Vect<E> implements Serializable {
     return buf.toString();
   }
 
+  public Stream<E> stream() {
+	  return Arrays.stream(elementData, 0, elementCount);
+  }
+  
 }

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefine.tla
@@ -1,0 +1,40 @@
+---- MODULE CyclicRedefine ----
+EXTENDS Base, TLC
+
+ReDefInit ==
+    /\ x \in BOOLEAN
+    /\ Init
+
+ReDefNext ==
+    Next /\ ~A(1)
+
+ReDefA(n) ==
+    /\ x' = Print(<<"ReDef", n>>, FALSE)
+    /\ A(n)
+
+YetAnotherOp(s, b, P(_)) ==
+	Print("ReDefOp", P(b))
+
+ReDefOp(b) ==
+    YetAnotherOp("ReDefOp", b, Op)
+	
+ReDefInv ==
+	Inv /\ x = FALSE
+=====
+----- MODULE Base -----
+VARIABLE x
+
+Init == x = FALSE                      \* line  4
+
+Op(b) == ~b                            \* line  6
+
+A(n)== x' = Op(FALSE)                  \* line  8
+
+B== x' = FALSE                         \* line 10
+
+Next == \E i \in {1,2,3}: A(i) \/ B    \* line 12
+
+Inv ==
+	x \in BOOLEAN
+
+====

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineInit.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineInit.cfg
@@ -1,0 +1,6 @@
+INIT Init
+NEXT Next
+INVARIANT Inv
+CONSTANT
+	Init <- ReDefInit
+	Inv <- ReDefInv

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineInstance.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineInstance.cfg
@@ -1,0 +1,4 @@
+SPECIFICATION Spec
+INVARIANT Inv
+CONSTANT
+	Next <- ReDefNext

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineInstance.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineInstance.tla
@@ -1,0 +1,20 @@
+---- MODULE CyclicRedefineInstance ----
+EXTENDS Base
+
+ReDefNext ==
+	LET B == INSTANCE Base
+	IN \/ B!Next
+	   \/ x' = TRUE
+=====
+----- MODULE Base -----
+VARIABLE x
+
+Next ==
+    x' = FALSE
+
+Spec ==
+	x = FALSE /\ [][Next]_x
+
+Inv ==
+	x = FALSE
+====

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineNext.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineNext.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+CONSTANT Next <- ReDefNext

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineOp.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineOp.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+CONSTANT Op <- ReDefOp

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineSubAction.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineSubAction.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+CONSTANT A <- ReDefA

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineVars.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineVars.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION
+	Spec
+CONSTANT
+	Init <- ReDefInit
+	A <- ReDefA
+	B <- ReDefB
+	vars <- ReDefVars

--- a/tlatools/org.lamport.tlatools/test-model/CyclicRedefineVars.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CyclicRedefineVars.tla
@@ -1,0 +1,44 @@
+---- MODULE CyclicRedefineVars ----
+EXTENDS Base, TLC
+
+VARIABLE z
+
+ReDefInit ==
+    /\ x \in BOOLEAN
+    /\ z = TRUE
+    /\ Init
+
+ReDefA(n) ==
+    /\ A(n)
+	/\ z' = ~z
+
+ReDefB ==
+	/\ B
+	/\ z' = ~z
+
+ReDefVars ==
+	<<vars, z>>
+
+=====
+----- MODULE Base -----
+VARIABLE x
+
+vars == <<x>>
+
+Init == x = FALSE
+
+Op(b) == ~b
+
+A(n)== x' = Op(FALSE)
+
+B == x' = FALSE
+
+Next == \E i \in {1,2,3}: A(i) \/ B
+
+Spec ==
+	Init /\ [][Next]_vars
+
+Inv ==
+	x \in BOOLEAN
+
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineInitTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineInitTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class CyclicRedefineInitTest extends ModelCheckerTestCase {
+
+	public CyclicRedefineInitTest() {
+		super("CyclicRedefine", new String[] { "-config", "CyclicRedefineInit.cfg" }, EC.ExitStatus.VIOLATION_SAFETY);
+		System.setProperty("tlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions", Boolean.TRUE.toString());
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+
+		// Assert the error trace
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(7);
+		// Trace prefix
+		expectedTrace.add("x = FALSE");
+		expectedTrace.add("x = TRUE");
+
+		final List<String> expectedActions = new ArrayList<>();
+		expectedActions.add(isExtendedTLCState() ? "<Initial predicate>" : TLCStateInfo.INITIAL_PREDICATE);
+		expectedActions.add("<A(1) line 8, col 8 to line 8, col 21 of module Base>");
+
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace, expectedActions);
+
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "2", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineInstanceTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineInstanceTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class CyclicRedefineInstanceTest extends ModelCheckerTestCase {
+
+	public CyclicRedefineInstanceTest() {
+		super("CyclicRedefineInstance", new String[] { "-config", "CyclicRedefineInstance.cfg" }, EC.ExitStatus.VIOLATION_SAFETY);
+		System.setProperty("tlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions", Boolean.TRUE.toString());
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+
+		// Assert the error trace
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(7);
+		// Trace prefix
+		expectedTrace.add("x = FALSE");
+		expectedTrace.add("x = TRUE");
+
+		final List<String> expectedActions = new ArrayList<>();
+		expectedActions.add(TLCStateInfo.INITIAL_PREDICATE);
+		expectedActions.add("<ReDefNext line 7, col 15 to line 7, col 23 of module CyclicRedefineInstance>");
+
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace, expectedActions);
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineNextTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineNextTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class CyclicRedefineNextTest extends ModelCheckerTestCase {
+
+	public CyclicRedefineNextTest() {
+		super("CyclicRedefine", new String[] { "-config", "CyclicRedefineNext.cfg" }, EC.ExitStatus.SUCCESS);
+		System.setProperty("tlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions", Boolean.TRUE.toString());
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "1"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "4", "1", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineOpTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineOpTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class CyclicRedefineOpTest extends ModelCheckerTestCase {
+
+	public CyclicRedefineOpTest() {
+		super("CyclicRedefine", new String[] { "-config", "CyclicRedefineOp.cfg" }, EC.ExitStatus.SUCCESS);
+		System.setProperty("tlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions", Boolean.TRUE.toString());
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "13", "2", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineSubActionTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineSubActionTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class CyclicRedefineSubActionTest extends ModelCheckerTestCase {
+
+	public CyclicRedefineSubActionTest() {
+		super("CyclicRedefine", new String[] { "-config", "CyclicRedefineSubAction.cfg" }, EC.ExitStatus.SUCCESS);
+		System.setProperty("tlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions", Boolean.TRUE.toString());
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "1"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "4", "1", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineVarsTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CyclicRedefineVarsTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class CyclicRedefineVarsTest extends ModelCheckerTestCase {
+
+	public CyclicRedefineVarsTest() {
+		super("CyclicRedefineVars", EC.ExitStatus.SUCCESS);
+		System.setProperty("tlc2.tool.impl.SpecProcessor.allowCyclicRedefinitions", Boolean.TRUE.toString());
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "3"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "25", "4", "0"));
+	}
+}


### PR DESCRIPTION
A cyclic redefinition RF is a formula that is defined from another formula F while also re-defining F:

```tla
    ---- MODULE ModuleWithF ----
    F == /\ A
         /\ B
         /\ C
    ====

    ---- MODULE Derived -----
    EXTENDS ModuleWithF

    RF == /\ F
          /\ D
    ====

    Config file:
    CONSTANT F <- RF
```

Supported:
- Initial predicate
- Next-state relation
- 0-arity and higher-arity sub-actions provided the parameters are constant level
- Invariants
- Ordinary operators