### PR TITLE
Remove uses and overrides of `Object.clone()`

### DIFF
--- a/tlatools/org.lamport.tlatools/src/pcal/ParseAlgorithm.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/ParseAlgorithm.java
@@ -2200,7 +2200,7 @@ public class ParseAlgorithm
      /**********************************************************************
      * Returns S \cup T.                                                   *
      **********************************************************************/
-     { Vector result = (Vector) S.clone() ;
+     { Vector result = new Vector<>(S);
        int i = 0 ;
        while (i < T.size())
          { String str = (String) T.elementAt(i) ;

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalTLAGen.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalTLAGen.java
@@ -3348,7 +3348,7 @@ public class PcalTLAGen
                      * that is commented out.  Note that this change can add a token with
                      * type ADDED rather than IDENT.  I don't think this matters.
                      */
-                    TLAToken newTok = tok.Clone() ;
+                    TLAToken newTok = new TLAToken(tok);
                     /*
                      * The new token should inherit nothing from the baggage of tok, whose
                      * only function is to provide the name
@@ -3590,7 +3590,7 @@ public class PcalTLAGen
     /***********************************************************/
     private static Vector SortSass(Vector vec)
     {
-        Vector v = (Vector) vec.clone();
+        Vector v = new Vector<>(vec);
         Vector r = new Vector(); // The sorted version of v.
         while (v.size() > 0)
         { // Good old n^2 insertion sort.

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
@@ -179,7 +179,7 @@ public class PcalTranslate {
         int nextCol = 0 ;
         int i = 0 ;
         while (i < vec.size())
-          { TLAToken tok = ((TLAToken) vec.elementAt(i)).Clone() ;
+          { TLAToken tok = new TLAToken((TLAToken) vec.elementAt(i));
             tok.column = nextCol ;
             firstLine.addElement(tok) ;
             nextCol = nextCol + tok.getWidth() + spaces ;
@@ -675,7 +675,7 @@ public class PcalTranslate {
         }
         AST.LabeledStmt newast = new AST.LabeledStmt();
         Vector pair = 
-                CopyAndExplodeLastStmtWithGoto((Vector) ast.stmts.clone(), 
+                CopyAndExplodeLastStmtWithGoto(new Vector<>(ast.stmts),
                                                next);
         Vector result = new Vector();
         newast.setOrigin(ast.getOrigin()) ;
@@ -789,11 +789,11 @@ public class PcalTranslate {
         /* explode unlabDo */
         String unlabDoNext = (firstLS == null) ? ast.label : firstLS.label ;
         Vector pair1 = 
-                CopyAndExplodeLastStmtWithGoto((Vector) w.unlabDo.clone(),
+                CopyAndExplodeLastStmtWithGoto(new Vector<>(w.unlabDo),
                                                 unlabDoNext);
         /* explode the rest of the statements */
-        Vector rest = (Vector) ast.stmts.clone();
-           // Note: experimentation shows that clone() does a shallow copy, so
+        Vector rest = new Vector<>(ast.stmts);
+           // Note: `rest` is a shallow copy, so
            // the elements of rest are == to the elements of ast.stmts.
         rest.remove(0);
         Vector pair2 = CopyAndExplodeLastStmtWithGoto(rest, next);

--- a/tlatools/org.lamport.tlatools/src/pcal/TLAExpr.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/TLAExpr.java
@@ -502,7 +502,7 @@ public class TLAExpr
             Vector line = (Vector) this.tokens.elementAt(i) ;
             int j = 0 ;
             while (j < line.size())
-              { newline.add(((TLAToken) line.elementAt(j)).Clone()) ;
+              { newline.add(new TLAToken((TLAToken) line.elementAt(j)));
                 j = j + 1 ;
               } ;
             result.tokens.add(newline) ;

--- a/tlatools/org.lamport.tlatools/src/pcal/TLAToken.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/TLAToken.java
@@ -266,6 +266,19 @@ public class TLAToken
         type   = 0 ;
       } ;
 
+    /**
+     * Create a copy of the given token.
+     *
+     * @param other the token to copy
+     */
+    public TLAToken(TLAToken other) {
+        this(other.string, other.column, other.type);
+        this.source = other.source;
+        this.beginSubst = new Vector<>(other.beginSubst);
+        this.endSubst = new Vector<>(other.endSubst);
+        this.isAppended = other.isAppended;
+    }
+
     public int getWidth() 
       /*********************************************************************
       * Returns a width, which is the number of columns the token spans    *
@@ -313,23 +326,6 @@ public class TLAToken
 //        }
         return result; 
       };
- 
-
-   /**
-    * Modified by LL on 6 Dec 2011 to set the source field too.
-    * And on 14 Dec 2011 to set the beginSubst and endSubst fields.
-    * 
-    * @return
-    */
-   public TLAToken Clone()
-     { 
-	   TLAToken result = new TLAToken(this.string, this.column, this.type) ;
-	   result.source = this.source ;
-	   result.beginSubst = (Vector) this.beginSubst.clone();
-	   result.endSubst = (Vector) this.endSubst.clone();
-	   result.isAppended = this.isAppended;
-	   return result ;
-     }
 
   }
 

--- a/tlatools/org.lamport.tlatools/src/pcal/Test.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/Test.java
@@ -77,7 +77,7 @@ class Test
         int nextCol = 0 ;
         int i = 0 ;
         while (i < vec.size())
-          { TLAToken tok = ((TLAToken) vec.elementAt(i)).Clone() ;
+          { TLAToken tok = new TLAToken((TLAToken) vec.elementAt(i));
             tok.column = nextCol ;
             firstLine.addElement(tok) ;
             nextCol = nextCol + tok.getWidth() + spaces ;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/Operator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/Operator.java
@@ -35,10 +35,6 @@ public class Operator implements tla2sany.st.SyntaxTreeConstants {
     Id = id; Low = l; High = h; Associativity = a; Fix = f;
   }
 
-  public Operator clone ( UniqueString name ) {
-    return new Operator( name, Low, High, Associativity, Fix);
-  }
-
   public String toString() {
   switch ( Fix ) {
     case 0 /* Operators.nofix   */ : return Id.toString() + ", nofix";

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
@@ -144,9 +144,10 @@ implements ExploreNode, LevelConstants {
     * don't think this is needed and that everything works fine despite    *
     * the aliasing of the levelParams and allParams fields of this node    *
     * and its body to the same HashSets, but it doesn't hurt to be safe.   *
+    * 23 October 2023: Replaced ".clone" with copy constructor.            *
     ***********************************************************************/
-    this.levelParams = (HashSet<SymbolNode>)this.body.getLevelParams().clone();
-    this.allParams   = (HashSet<SymbolNode>) this.body.getAllParams().clone();
+    this.levelParams = new HashSet<>(this.body.getLevelParams());
+    this.allParams   = new HashSet<>(this.body.getAllParams());
 
 //    this.levelConstraints = new SetOfLevelConstraints();
     this.levelConstraints.putAll(this.body.getLevelConstraints());

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -1108,12 +1108,12 @@ public class OpDefNode extends OpDefOrDeclNode
        } ;
     }
 
-    this.levelConstraints = (SetOfLevelConstraints)lcSet.clone();
+    this.levelConstraints = new SetOfLevelConstraints(lcSet);
     for (int i = 0; i < this.params.length; i++) {
       this.levelConstraints.remove(this.params[i]);
     }
 
-    this.argLevelConstraints = (SetOfArgLevelConstraints)alcSet.clone();
+    this.argLevelConstraints = new SetOfArgLevelConstraints(alcSet);
     for (int i = 0; i < this.params.length; i++) {
       int alen = this.params[i].getArity();
       for (int j = 0; j < alen; j++) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfArgLevelConstraints.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfArgLevelConstraints.java
@@ -17,7 +17,14 @@ class SetOfArgLevelConstraints extends HashMap<ParamAndPosition, Integer> implem
   * be able to accept an argument of level v in its argument number        *
   * k.position.                                                            *
   *************************************************************************/
-  
+
+  public SetOfArgLevelConstraints() {
+  }
+
+  public SetOfArgLevelConstraints(Map<? extends ParamAndPosition, ? extends Integer> m) {
+    super(m);
+  }
+
   /**
    * This method adds <pap, level> into this set, and "subsumes"
    * it with another one for the same parameter if one is there, or

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfLevelConstraints.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfLevelConstraints.java
@@ -14,7 +14,14 @@ class SetOfLevelConstraints extends HashMap<SymbolNode, Integer> implements Leve
   * SymbolNode and whose value is an int.  An entry in this table means    *
   * that the key/parameter must have a level <= the value/int.             *
   *************************************************************************/
-  
+
+  public SetOfLevelConstraints() {
+  }
+
+  public SetOfLevelConstraints(Map<? extends SymbolNode, ? extends Integer> m) {
+    super(m);
+  }
+
   /**
    * This method adds <param, level> into this map. It subsumes
    * any existing one. 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -372,9 +372,10 @@ public class SubstInNode extends ExprNode {
     /***********************************************************************
     * 23 February 2009: Added ".clone" to the following statements to fix  *
     * bug.                                                                 *
+    * 23 October 2023: Replaced ".clone" with copy constructor.            *
     ***********************************************************************/
-    this.allParams        = (HashSet<SymbolNode>)this.body.getAllParams().clone() ;
-    this.nonLeibnizParams = (HashSet<SymbolNode>)this.body.getNonLeibnizParams().clone() ;
+    this.allParams        = new HashSet<>(this.body.getAllParams());
+    this.nonLeibnizParams = new HashSet<>(this.body.getNonLeibnizParams());
     for (int i = 0 ; i < this.substs.length ; i++) {
       OpDeclNode param = substs[i].getOp() ;
       if (this.allParams.contains(param)) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
@@ -503,12 +503,12 @@ public class ThmOrAssumpDefNode extends SymbolNode
          } ;
       }
 
-      this.levelConstraints = (SetOfLevelConstraints)lcSet.clone();
+      this.levelConstraints = new SetOfLevelConstraints(lcSet);
       for (int i = 0; i < this.params.length; i++) {
         this.levelConstraints.remove(this.params[i]);
       }
 
-      this.argLevelConstraints = (SetOfArgLevelConstraints)alcSet.clone();
+      this.argLevelConstraints = new SetOfArgLevelConstraints(alcSet);
       for (int i = 0; i < this.params.length; i++) {
         int alen = this.params[i].getArity();
         for (int j = 0; j < alen; j++) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCState.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCState.java
@@ -25,7 +25,7 @@ import tlc2.value.impl.Value;
 import util.Assert;
 import util.UniqueString;
 
-public abstract class TLCState implements Cloneable, Serializable {
+public abstract class TLCState implements Serializable {
   public short workerId = Short.MAX_VALUE; // Must be set to a non-negative number. Valid worker ids \in [0,Short.MAX_VALUE] and start at 0.
   public static final int INIT_UID = -1;
   public long uid = INIT_UID;   // Must be set to a non-negative number

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
@@ -36,7 +36,7 @@ import util.WrongInvocationException;
  *
  * The viewMap was added by Rajeev Joshi.
  */
-public final class TLCStateMut extends TLCState implements Cloneable, Serializable {
+public final class TLCStateMut extends TLCState implements Serializable {
   private IValue values[];
   private static ITool mytool = null;
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
@@ -36,7 +36,7 @@ import util.WrongInvocationException;
  * Attention! Copy of TLCStateMut except for getter/setter and fields callable,
  * predecessor and action.
  */
-public final class TLCStateMutExt extends TLCState implements Cloneable, Serializable {
+public final class TLCStateMutExt extends TLCState implements Serializable {
   private IValue values[];
   private static ITool mytool = null;
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutSource.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutSource.java
@@ -37,7 +37,7 @@
 // * The viewMap was added by Rajeev Joshi.
 // */
 //public final class TLCStateMutSource extends TLCState
-//implements Cloneable, Serializable {
+//implements Serializable {
 //  private Value[] values;
 //  private SemanticNode[] asts;
 //  private static Tool mytool = null;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateVec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateVec.java
@@ -10,7 +10,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
-public class TLCStateVec implements Cloneable, Serializable {
+public class TLCStateVec implements Serializable {
   private TLCState[] elementData;
   private int elementCount;
          

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/BigInt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/BigInt.java
@@ -9,7 +9,7 @@ import java.math.BigInteger;
 import java.util.Random;
 
 
-public class BigInt extends BigInteger implements Cloneable, ExternalSortable {
+public class BigInt extends BigInteger implements ExternalSortable {
 
   public final static BigInt BigZero = new BigInt("0");
   public final static BigInt BigOne = new BigInt("1");

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/BigSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/BigSet.java
@@ -15,7 +15,7 @@ import util.Set;
  * @deprecated currently not used
  * @version $Id$
  */
-public class BigSet implements Cloneable {
+public class BigSet {
   private static int MaxSize = 10000;
   // four rehashings give ~(>) 13440 els., and .75*13440 ~ 10000
   private static int InitialSize = 840; 

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/LongVec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/LongVec.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 
 import util.FileUtil;
 
-public class LongVec implements Cloneable, Serializable {
+public class LongVec implements Serializable {
 	private static final long serialVersionUID = 2406899362740899071L;
 	protected long[] elementData;
 	protected int elementCount;

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/Vect.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/Vect.java
@@ -14,7 +14,7 @@ import java.util.Vector;
  * 		we've also written our own "Vector" class in SANY...
  */
 @SuppressWarnings("unchecked")
-public class Vect<E> implements Cloneable, Serializable {
+public class Vect<E> implements Serializable {
 	private static final long serialVersionUID = 1L;
 
 	
@@ -80,13 +80,6 @@ public class Vect<E> implements Cloneable, Serializable {
   }
 
   public int capacity() { return this.elementData.length; }
-
-  public Object clone() {
-    Vect<E> v = new Vect<>(this.elementData.length);
-    System.arraycopy(this.elementData, 0, v.elementData, 0, this.elementCount);
-    v.elementCount = this.elementCount;
-    return v;
-  }
 
   public final boolean contains(Object elem) {
     return (this.indexOf(elem) != -1);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/ValueVec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/ValueVec.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import tlc2.TLCGlobals;
 import util.WrongInvocationException;
 
-public class ValueVec implements Cloneable, Serializable {
+public class ValueVec implements Serializable {
   private Value [] elementData;
   private int elementCount;
          
@@ -72,15 +72,6 @@ public class ValueVec implements Cloneable, Serializable {
   }
 
   public final int capacity() { return elementData.length; }
-
-  @Override
-  public final Object clone() {
-    ValueVec v = new ValueVec(this.elementData.length);
-	
-    System.arraycopy(elementData, 0, v.elementData, 0, elementCount);
-    v.elementCount = elementCount;
-    return v;
-  }
 
   public final boolean contains(Value  elem) {
     return (indexOf(elem) != -1);


### PR DESCRIPTION
This commit makes one iota of progress toward the suggestions in #756 by replacing uses of `.clone()` with copy constructors, adding new copy constructors as necessary, and removing `implements Cloneable` from all types that have it.  In my mind, these changes are prerequisites for removing the tools' custom data structures (e.g. `util.Set` and `tlc2.util.Vect`).

The `clone()` method has widely been considered bad practice for many years [1].  Problems include:
 - Lack of type safety
 - A vague contract
 - "Magical" capabilities that can't be replicated in pure Java

Copy constructors are considered a better pattern.

[1]: https://www.artima.com/articles/josh-bloch-on-design