### PR TITLE
Split FunctionValue out of Applicable

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Bags.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Bags.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at  9:18:39 PST by lamport
 //      modified on Tue Jan  2 11:40:25 PST 2001 by yuanyu
 
@@ -13,10 +14,10 @@ import tlc2.util.Vect;
 import tlc2.value.IBoolValue;
 import tlc2.value.ValueConstants;
 import tlc2.value.Values;
-import tlc2.value.impl.Applicable;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.FcnRcdValue;
 import tlc2.value.impl.IntValue;
+import tlc2.value.impl.OpValue;
 import tlc2.value.impl.SetEnumValue;
 import tlc2.value.impl.Value;
 import tlc2.value.impl.ValueVec;
@@ -355,7 +356,7 @@ public class Bags implements ValueConstants
 
     public static Value BagOfAll(Value f, Value b)
     {
-        if (!(f instanceof Applicable))
+        if (!(f instanceof OpValue))
         {
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR_AN, new String[] { "first", "BagOfAll", "operator",
                     Values.ppr(f.toString()) });
@@ -366,7 +367,7 @@ public class Bags implements ValueConstants
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "BagOfAll",
                     "function with a finite domain", Values.ppr(b.toString()) });
         }
-        Applicable ff = (Applicable) f;
+        OpValue ff = (OpValue) f;
         ValueVec dVec = new ValueVec();
         ValueVec vVec = new ValueVec();
         Value[] domain = fcn.getDomainAsValues();
@@ -375,7 +376,7 @@ public class Bags implements ValueConstants
         for (int i = 0; i < domain.length; i++)
         {
             args[0] = domain[i];
-            Value val = ff.apply(args, EvalControl.Clear);
+            Value val = ff.eval(args, EvalControl.Clear);
             boolean found = false;
             for (int j = 0; j < dVec.size(); j++)
             {

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Sat 23 February 2008 at  9:53:48 PST by lamport
 //      modified on Fri Jun 29 23:58:36 PDT 2001 by yuanyu
 
@@ -12,12 +13,11 @@ import tlc2.tool.impl.TLARegistry;
 import tlc2.value.IBoolValue;
 import tlc2.value.ValueConstants;
 import tlc2.value.Values;
-import tlc2.value.impl.Applicable;
+import tlc2.value.impl.FunctionValue;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.IntValue;
 import tlc2.value.impl.ModelValue;
-import tlc2.value.impl.OpLambdaValue;
-import tlc2.value.impl.OpRcdValue;
+import tlc2.value.impl.OpValue;
 import tlc2.value.impl.StringValue;
 import tlc2.value.impl.TupleValue;
 import tlc2.value.impl.UserObj;
@@ -199,13 +199,13 @@ public class Sequences extends UserObj implements ValueConstants
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "first", "SelectInSeq", "sequence",
                     Values.ppr(s.toString()) });
         }
-        if (!(test instanceof Applicable))
+        if (!(test instanceof FunctionValue))
         {
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "SelectInSeq", "function",
                     Values.ppr(test.toString()) });
         }
         int len = seq.size();
-        Applicable ftest = (Applicable) test;
+        FunctionValue ftest = (FunctionValue) test;
         Value[] args = new Value[1];
         for (int i = 0; i < len; i++)
         {
@@ -335,18 +335,18 @@ public class Sequences extends UserObj implements ValueConstants
         int len = seq.size();
         if (len == 0)
             return TupleValue.EmptyTuple;
-        if (!(test instanceof OpLambdaValue) && !(test instanceof OpRcdValue))
+        if (!(test instanceof OpValue))
         {
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "SelectSeq", "operator",
                     Values.ppr(test.toString()) });
         }
         ValueVec vals = new ValueVec();
-        Applicable ftest = (Applicable) test;
+        OpValue ftest = (OpValue) test;
         Value[] args = new Value[1];
         for (int i = 0; i < len; i++)
         {
             args[0] = seq.elems[i];
-            Value val = ftest.apply(args, EvalControl.Clear);
+            Value val = ftest.eval(args, EvalControl.Clear);
             if (val instanceof IBoolValue)
             {
                 if (((BoolValue) val).val)
@@ -443,13 +443,13 @@ public class Sequences extends UserObj implements ValueConstants
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "first", "Insert", "sequence",
                     Values.ppr(s.toString()) });
         }
-        if (!(test instanceof Applicable))
+        if (!(test instanceof FunctionValue))
         {
-            throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "SubSeq", "function",
+            throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "Insert", "function",
                     Values.ppr(test.toString()) });
         }
         int len = seq.size();
-        Applicable ftest = (Applicable) test;
+        FunctionValue ftest = (FunctionValue) test;
         Value[] args = new Value[2];
         args[0] = v;
         Value[] values = new Value[len + 1];

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TLC.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at  9:19:45 PST by lamport
 //      modified on Tue Aug  7 10:46:55 PDT 2001 by yuanyu
 
@@ -16,11 +17,11 @@ import tlc2.tool.impl.TLARegistry;
 import tlc2.value.IBoolValue;
 import tlc2.value.ValueConstants;
 import tlc2.value.Values;
-import tlc2.value.impl.Applicable;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.FcnRcdValue;
 import tlc2.value.impl.IntValue;
 import tlc2.value.impl.IntervalValue;
+import tlc2.value.impl.OpValue;
 import tlc2.value.impl.RecordValue;
 import tlc2.value.impl.SetEnumValue;
 import tlc2.value.impl.SetOfFcnsValue;
@@ -252,12 +253,12 @@ public class TLC implements ValueConstants
             throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "first", "SortSeq", "natural number",
                     Values.ppr(s.toString()) });
         }
-        if (!(cmp instanceof Applicable))
+        if (!(cmp instanceof OpValue))
         {
-            throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "SortSeq", "function",
+            throw new EvalException(EC.TLC_MODULE_ARGUMENT_ERROR, new String[] { "second", "SortSeq", "operator",
                     Values.ppr(cmp.toString()) });
         }
-        Applicable fcmp = (Applicable) cmp;
+        OpValue fcmp = (OpValue) cmp;
         Value [] elems = seq.elems;
         int len = elems.length;
         if (len == 0)
@@ -283,9 +284,9 @@ public class TLC implements ValueConstants
         return new TupleValue(newElems);
     }
 
-    private static boolean compare(Applicable fcmp, Value [] args)
+    private static boolean compare(OpValue fcmp, Value[] args)
     {
-        Value  res = fcmp.apply(args, EvalControl.Clear);
+        Value  res = fcmp.eval(args, EvalControl.Clear);
         if (res instanceof IBoolValue)
         {
             return ((BoolValue) res).val;

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Applicable.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Applicable.java
@@ -1,17 +1,27 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:20:42 PST by lamport
 //      modified on Wed Jun  2 00:10:22 PDT 1999 by yuanyu
 
 package tlc2.value.impl;
 
 import tlc2.tool.EvalException;
+import tlc2.value.IValue;
 
-public interface Applicable {
-  
+/**
+ * @deprecated
+ *   This confused interface is implemented both by functions and operators, even though functions
+ *   and operators are two very different TLA+ concepts that cannot be interchanged.  Clients of this
+ *   interface should switch to either {@link FunctionValue} or {@link OpValue}, depending on the
+ *   expected type of the object.  This one will be removed in the future.
+ */
+@Deprecated
+public interface Applicable extends IValue {
+
   Value apply(Value[] args, int control) throws EvalException;
   Value apply(Value arg, int control) throws EvalException;
   Value getDomain() throws EvalException;
   Value select(Value arg) throws EvalException;
-  
+
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EvaluatingValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EvaluatingValue.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2019 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2019 Microsoft Research. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -45,7 +46,7 @@ import util.Assert;
 import util.Assert.TLCRuntimeException;
 import util.WrongInvocationException;
 
-public class EvaluatingValue extends OpValue implements Applicable {
+public class EvaluatingValue extends OpValue {
   protected final MethodHandle mh;
   protected final Method md;
   protected final int minLevel;
@@ -93,6 +94,17 @@ public class EvaluatingValue extends OpValue implements Applicable {
             return null; // make compiler happy
 		}
 	}
+
+    @Override
+    public final Value eval(Value[] args, int control) {
+        try {
+            throw new WrongInvocationException("It is a TLC bug: Should use the other eval method.");
+        }
+        catch (RuntimeException | OutOfMemoryError e) {
+            if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
+            else { throw e; }
+        }
+    }
 
   public final byte getKind() { return METHODVALUE; }
 
@@ -144,36 +156,6 @@ public class EvaluatingValue extends OpValue implements Applicable {
     }
   }
 
-  public final Value apply(Value arg, int control) {
-    try {
-      throw new WrongInvocationException("It is a TLC bug: Should use the other apply method.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  public final Value apply(Value[] args, int control) {
-	    try {
-	        throw new WrongInvocationException("It is a TLC bug: Should use the other apply method.");
-	      }
-	      catch (RuntimeException | OutOfMemoryError e) {
-	        if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-	        else { throw e; }
-	      }
-  }
-
-  public final Value select(Value arg) {
-    try {
-      throw new WrongInvocationException("It is a TLC bug: Attempted to call MethodValue.select().");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   public final Value takeExcept(ValueExcept ex) {
     try {
       Assert.fail("Attempted to appy EXCEPT construct to the operator " +
@@ -191,18 +173,6 @@ public class EvaluatingValue extends OpValue implements Applicable {
       Assert.fail("Attempted to apply EXCEPT construct to the operator " +
       this.toString() + ".", getSource());
       return null;   // make compiler happy
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  public final Value getDomain() {
-    try {
-      Assert.fail("Attempted to compute the domain of the operator " +
-      this.toString() + ".", getSource());
-      return SetEnumValue.EmptySet;   // make compiler happy
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnLambdaValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnLambdaValue.java
@@ -29,7 +29,7 @@ import tlc2.value.Values;
 import util.Assert;
 import util.UniqueString;
 
-public class FcnLambdaValue extends Value implements Applicable, IFcnLambdaValue {
+public class FcnLambdaValue extends Value implements FunctionValue, IFcnLambdaValue {
   public final FcnParams params;       // the function formals
   public final SemanticNode body;      // the function body
   public ValueExcept[] excepts;  // the EXCEPTs
@@ -261,18 +261,6 @@ public class FcnLambdaValue extends Value implements Applicable, IFcnLambdaValue
       }
       return res.takeExcept(excepts2);
 
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  /* This one does not seem to be needed anymore.  */
-  @Override
-  public final Value apply(Value[] args, int control) throws EvalException {
-    try {
-      return this.apply(new TupleValue(args), control);
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnRcdValue.java
@@ -30,7 +30,7 @@ import util.TLAConstants;
 import util.ToolIO;
 import util.UniqueString;
 
-public class FcnRcdValue extends Value implements Applicable, IFcnRcdValue {
+public class FcnRcdValue extends Value implements FunctionValue, IFcnRcdValue {
 	
 	// -Dtlc2.value.impl.FcnRcdValue.threshold=16
 	private static final int LINEAR_SEARCH_THRESHOLD = Integer.getInteger(FcnRcdValue.class.getName() + ".threshold", 32);
@@ -357,18 +357,6 @@ public class FcnRcdValue extends Value implements Applicable, IFcnRcdValue {
         " not in the domain of the function.", getSource());
       }
       return result;
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  /* This one does not seem to be needed anymore.  */
-  @Override
-  public final Value apply(Value[] args, int control) {
-    try {
-      return this.apply(new TupleValue(args), EvalControl.Clear);
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FunctionValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FunctionValue.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2023, Oracle and/or its affiliates.
+
+package tlc2.value.impl;
+
+import tlc2.tool.EvalControl;
+import tlc2.tool.EvalException;
+
+/**
+ * Operations for values that behave like functions.
+ *
+ * <p>TODO: move some of the function operations from {@link Value} to this interface,
+ *          such as {@link Value#takeExcept(ValueExcept)} and {@link Value#select(Value[])}.
+ */
+public interface FunctionValue extends Applicable {
+
+  /**
+   * Apply this function to multiple arguments.
+   *
+   * <p>All functions in TLA+ are unary.  When a function is applied to multiple arguments
+   * as in <code>f[1, 2]</code>, it is just syntactic sugar for applying the function to a
+   * tuple of those arguments (e.g. <code>f[&lt;&lt;1, 2&gt;&gt;]</code>).  Therefore, the
+   * default implementation of this method calls {@link #apply(Value, int)} with <code>args</code>
+   * wrapped in a {@link TupleValue}.  If <code>args.length == 1</code>, it does not create
+   * a tuple and just passes <code>args[0]</code> instead.
+   *
+   * @param args the arguments
+   * @param control the {@link EvalControl} mode
+   * @return the apply result
+   * @throws EvalException if evaluation fails
+   * @throws util.Assert.TLCRuntimeException if the argument is not in the function's domain
+   */
+  @Override
+  default Value apply(Value[] args, int control) throws EvalException {
+    return args.length == 1
+            ? apply(args[0], control)
+            : apply(new TupleValue(args), control);
+  }
+
+  /**
+   * Apply this function to an argument with the given {@link EvalControl}.
+   *
+   * @param arg the argument
+   * @param control the {@link EvalControl} mode
+   * @return the apply result
+   * @throws EvalException if evaluation fails
+   * @throws util.Assert.TLCRuntimeException if the argument is not in the function's domain
+   */
+  @Override
+  Value apply(Value arg, int control) throws EvalException;
+
+  /**
+   * Compute the domain of this function.
+   *
+   * @return the domain of this function
+   * @throws EvalException if evaluation fails
+   */
+  @Override
+  Value getDomain() throws EvalException;
+
+  /**
+   * Apply this function to an argument.
+   *
+   * <p>This method is very similar to {@link #apply(Value, int)} but with two critical
+   * differences:
+   * <ol>
+   *     <li>Evaluation control is assumed to be {@link EvalControl#Clear}</li>
+   *     <li>Returns null instead of throwing an exception when the argument is not in the function's domain</li>
+   * </ol>
+   *
+   * @param arg the argument
+   * @return the apply result or null if the argument is not in this function's domain
+   * @throws EvalException if evaluation fails
+   */
+  @Override
+  Value select(Value arg) throws EvalException;
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/MethodValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/MethodValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 13:21:00 PST by lamport
 //      modified on Fri Sep 22 13:18:45 PDT 2000 by yuanyu
@@ -26,7 +27,7 @@ import util.Assert;
 import util.Assert.TLCRuntimeException;
 import util.WrongInvocationException;
 
-public class MethodValue extends OpValue implements Applicable {
+public class MethodValue extends OpValue {
 
 	public static Value get(final Method md) {
 		// Call from e.g. STRING (see tlc2.module.Strings.STRING()), which has no operator
@@ -40,7 +41,7 @@ public class MethodValue extends OpValue implements Applicable {
 		// evaluate once at startup and not during state exploration.
 		final int acnt = md.getParameterTypes().length;
     	final boolean isConstant = (acnt == 0) && Modifier.isFinal(md.getModifiers());
-    	return isConstant ? mv.apply(Tool.EmptyArgs, EvalControl.Clear) : mv;
+    	return isConstant ? mv.eval(Tool.EmptyArgs, EvalControl.Clear) : mv;
 	}
 	
   private final MethodHandle mh;
@@ -133,18 +134,7 @@ public class MethodValue extends OpValue implements Applicable {
   }
 
   @Override
-  public final Value apply(Value arg, int control) {
-    try {
-      throw new WrongInvocationException("It is a TLC bug: Should use the other apply method.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value apply(Value[] args, int control) {
+  public final Value eval(Value[] args, int control) {
     try {
       Value res = null;
       try
@@ -187,17 +177,6 @@ public class MethodValue extends OpValue implements Applicable {
   }
 
   @Override
-  public final Value select(Value arg) {
-    try {
-      throw new WrongInvocationException("It is a TLC bug: Attempted to call MethodValue.select().");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
   public final Value takeExcept(ValueExcept ex) {
     try {
       Assert.fail("Attempted to appy EXCEPT construct to the operator " +
@@ -216,19 +195,6 @@ public class MethodValue extends OpValue implements Applicable {
       Assert.fail("Attempted to apply EXCEPT construct to the operator " +
       this.toString() + ".", getSource());
       return null;   // make compiler happy
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value getDomain() {
-    try {
-      Assert.fail("Attempted to compute the domain of the operator " +
-      this.toString() + ".", getSource());
-      return SetEnumValue.EmptySet;   // make compiler happy
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpLambdaValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpLambdaValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:09 PST by lamport
 //      modified on Fri Sep 22 13:18:45 PDT 2000 by yuanyu
@@ -18,7 +19,7 @@ import tlc2.value.Values;
 import util.Assert;
 import util.WrongInvocationException;
 
-public class OpLambdaValue extends OpValue implements Applicable {
+public class OpLambdaValue extends OpValue {
   public final OpDefNode opDef;       // the operator definition.
   public final ITool tool;
   public final Context con;
@@ -100,18 +101,7 @@ public class OpLambdaValue extends OpValue implements Applicable {
   }
 
   @Override
-  public final Value apply(Value arg, int control) {
-    try {
-      throw new WrongInvocationException("Should use the other apply method.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value apply(Value[] args, int control) {
+  public final Value eval(Value[] args, int control) {
     try {
       int alen = this.opDef.getArity();
       if (alen != args.length) {
@@ -125,17 +115,6 @@ public class OpLambdaValue extends OpValue implements Applicable {
       }
       return (Value) this.tool.eval(this.opDef.getBody(), c1, this.state, this.pstate,
           control);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value select(Value arg) {
-    try {
-      throw new WrongInvocationException("Error(TLC): attempted to call OpLambdaValue.select().");
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
@@ -162,19 +141,6 @@ public class OpLambdaValue extends OpValue implements Applicable {
       Assert.fail("Attempted to apply EXCEPT construct to the operator " +
       Values.ppr(this.toString()) + ".", getSource());
       return null;   // make compiler happy
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value getDomain() {
-    try {
-      Assert.fail("Attempted to compute the domain of the operator " +
-      Values.ppr(this.toString()) + ".", getSource());
-      return SetEnumValue.EmptySet;   // make compiler happy
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2022, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 13:21:01 PST by lamport
 //      modified on Sat Nov 13 12:43:44 PST 1999 by yuanyu
@@ -24,7 +24,7 @@ import util.WrongInvocationException;
  *         op(1, 2) = "b"
  * </pre>
  */
-public class OpRcdValue extends OpValue implements Applicable {
+public class OpRcdValue extends OpValue {
   public final Vect<Value[]> domain;
   public final Vect<Value> values;
 
@@ -128,18 +128,7 @@ public class OpRcdValue extends OpValue implements Applicable {
   }
 
   @Override
-  public final Value apply(Value arg, int control) {
-    try {
-      throw new WrongInvocationException("Should use the other apply method.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value apply(Value[] args, int control) {
+  public final Value eval(Value[] args, int control) {
     try {
       int sz = this.domain.size();
       for (int i = 0; i < sz; i++) {
@@ -174,18 +163,6 @@ public class OpRcdValue extends OpValue implements Applicable {
   }
 
   @Override
-  public final Value select(Value arg) {
-    try {
-      Assert.fail("Attempted to call OpRcdValue.select(). This is a TLC bug.", getSource());
-      return null;   // make compiler happy
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
   public final Value takeExcept(ValueExcept ex) {
     try {
       Assert.fail("Attempted to appy EXCEPT construct to the operator " +
@@ -204,19 +181,6 @@ public class OpRcdValue extends OpValue implements Applicable {
       Assert.fail("Attempted to apply EXCEPT construct to the operator " +
       Values.ppr(this.toString()) + ".", getSource());
       return null;     // make compiler happy
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final Value getDomain() {
-    try {
-      Assert.fail("Attempted to compute the domain of the operator " +
-      Values.ppr(this.toString()) + ".", getSource());
-      return SetEnumValue.EmptySet;   // make compiler happy
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpValue.java
@@ -1,27 +1,131 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:21:02 PST by lamport
 //      modified on Fri Sep 22 13:18:45 PDT 2000 by yuanyu
 
 package tlc2.value.impl;
 
 import tla2sany.semantic.ExprOrOpArgNode;
+import tlc2.tool.EvalException;
+import tlc2.tool.FingerprintException;
 import tlc2.tool.TLCState;
 import tlc2.tool.coverage.CostModel;
 import tlc2.tool.impl.Tool;
 import tlc2.util.Context;
+import util.Assert;
+import util.WrongInvocationException;
 
+/**
+ * Operations for values that behave like operators.
+ *
+ * <p>Operators are not really values in TLA+, but TLC needs to be able to represent operators
+ * to support operators that take higher-order operators as arguments.  To give an artificial
+ * example:
+ *
+ * <pre>
+ *     F(G(_, _), x) == G(x, x)
+ *     Eq(x, y) == x = y
+ *     Init == F(Eq, 1)
+ * </pre>
+ *
+ * The argument <code>Eq</code> will be represented as an <code>OpValue</code> when TLC evaluates
+ * the <code>Init</code> predicate.
+ */
 public abstract class OpValue extends Value implements Applicable {
 
-	// Allow sub-classes to override.
-	public Value eval(final Tool tool, final ExprOrOpArgNode[] args, final Context c, final TLCState s0,
-			final TLCState s1, final int control, final CostModel cm) {
-		final Value[] argVals = new Value[args.length];
-		// evaluate the operator's arguments:
-		for (int i = 0; i < args.length; i++) {
-			argVals[i] = tool.eval(args[i], c, s0, s1, control, cm);
-		}
-		// evaluate the operator:
-		return this.apply(argVals, control);
-	}
+    /**
+     * Apply this operator to arguments.
+     *
+     * <p>Implementations will typically begin by evaluating each of the given <code>args</code>,
+     * but that is not a firm requirement.  For instance, an implementation may optimize by skipping
+     * evaluation of some arguments if their values are not needed.
+     *
+     * @param tool the evaluation tool
+     * @param args the arguments
+     * @param c the context
+     * @param s0 the current state
+     * @param s1 the next state (null when evaluating invariants or the initial predicate)
+     * @param control the {@link tlc2.tool.EvalControl} mode
+     * @param cm the current cost model (or null)
+     * @return the result of evaluation
+     */
+    public Value eval(final Tool tool, final ExprOrOpArgNode[] args, final Context c, final TLCState s0,
+                      final TLCState s1, final int control, final CostModel cm) {
+        if (args.length == 0) {
+            return eval(Tool.EmptyArgs, control);
+        }
+
+        final Value[] argVals = new Value[args.length];
+        // evaluate the operator's arguments:
+        for (int i = 0; i < args.length; i++) {
+            argVals[i] = tool.eval(args[i], c, s0, s1, control, cm);
+        }
+        return eval(argVals, control);
+    }
+
+    /**
+     * Apply this operator to already-evaluated arguments.
+     *
+     * @param args the arguments
+     * @param control the {@link tlc2.tool.EvalControl} mode
+     * @return the result of evaluation
+     */
+    public abstract Value eval(Value[] args, int control);
+
+    /**
+     * @deprecated use {@link #eval(Value[], int)}; this override will vanish when {@link Applicable} is removed
+     */
+    @Deprecated
+    @Override
+    public Value apply(Value[] args, int control) throws EvalException {
+        return eval(args, control);
+    }
+
+    /**
+     * @deprecated use {@link #eval(Value[], int)}; this override will vanish when {@link Applicable} is removed
+     */
+    @Deprecated
+    @Override
+    public Value apply(Value arg, int control) throws EvalException {
+        return eval(new Value[] { arg }, control);
+    }
+
+    /**
+     * @deprecated
+     *   Operators do not have a domain; all implementations of this method throw an exception.  If you
+     *   meant to use this as a function, use {@link FunctionValue} instead.
+     */
+    @Deprecated
+    @Override
+    public Value getDomain() throws EvalException {
+        try {
+            Assert.fail("Attempted to compute the domain of the operator " + this + ".", getSource());
+            return SetEnumValue.EmptySet;   // make compiler happy
+        } catch (RuntimeException | OutOfMemoryError e) {
+            if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
+            else { throw e; }
+        }
+    }
+
+    /**
+     * @deprecated
+     *   Operators do not have a domain; all implementations of this method throw an exception.  If you
+     *   meant to use this as a function, use {@link FunctionValue} instead.
+     */
+    @Deprecated
+    @Override
+    public Value select(Value arg) throws EvalException {
+        // NOTE 2023/11/8: Yes, this is meant to be a convenience override for apply(), and there is an
+        // obvious default implementation.  However, prior to the OpValue/FunctionValue split, ALL
+        // operator-ish implementations of this method threw an exception, so we should preserve that
+        // behavior to discourage use of this method.
+        try {
+            throw new WrongInvocationException("It is a TLC bug: Attempted to call OpValue.select().");
+        } catch (RuntimeException | OutOfMemoryError e) {
+            if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
+            else { throw e; }
+        }
+    }
+
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Sat 23 February 2008 at 10:15:47 PST by lamport
 //      modified on Fri Aug 10 15:09:07 PDT 2001 by yuanyu
@@ -38,7 +39,7 @@ import util.Assert;
 import util.TLAConstants;
 import util.UniqueString;
 
-public class RecordValue extends Value implements Applicable {
+public class RecordValue extends Value implements FunctionValue {
   private static final UniqueString BLI = UniqueString.of("beginLine");
   private static final UniqueString BCOL = UniqueString.of("beginColumn");
   private static final UniqueString ELI = UniqueString.of("endLine");

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/TupleValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/TupleValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:09 PST by lamport
 //      modified on Fri Aug 10 15:10:22 PDT 2001 by yuanyu
@@ -28,7 +29,7 @@ import tlc2.value.Values;
 import util.Assert;
 import util.UniqueString;
 
-public class TupleValue extends Value implements Applicable, ITupleValue {
+public class TupleValue extends Value implements FunctionValue, ITupleValue {
   public final Value[] elems;          // the elements of this tuple.
   public static final TupleValue EmptyTuple = new TupleValue(new Value[0]);
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2023, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:13 PST by lamport
 //      modified on Wed Dec  5 23:18:07 PST 2001 by yuanyu
@@ -272,18 +273,22 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
 
   /**
    * This method selects the component of this value. The component is
-   * specified by path.
+   * specified by <code>path</code>. For instance, <code>val.select([1, "a"])</code>
+   * is equivalent to the TLA+ <code>val[1].a</code>.
+   *
+   * @return the selected value, or null if reading some component of the path cannot
+   *         be done because the value is not in the function's domain
    */
   public final Value select(Value[] path) {
     try {
       Value result = this;
       for (int i = 0; i < path.length; i++) {
-        if (!(result instanceof Applicable)) {
+        if (!(result instanceof FunctionValue)) {
           Assert.fail("Attempted to apply EXCEPT construct to the value " +
                 Values.ppr(result.toString()) + ".", getSource());
         }
         Value elem = path[i];
-        result = ((Applicable)result).select(elem);
+        result = ((FunctionValue)result).select(elem);
         if (result == null) return null;
       }
       return result;


### PR DESCRIPTION
This is a refactoring-only change, and therefore very low-priority. But, it fixes a longstanding and (to me) irritating lack of type safety surrounding functions and operators.

----

The `Applicable` interface is widely used, but it is "confused" because functions and operators both implement it, even though those entities have very different capabilities and cannot be interchanged in TLA+.

This commit adds a new `FunctionValue` interface so that TLC's code can distinguish between operators (`OpValue`) and functions.  Despite adding a new interface, the split actually REDUCES the number of non-comment lines of code in TLC.

A few qualitative notes about why I think this is a good refactor:

 1. Operator values have to implement `getDomain()` even though they do not have a domain.  Therefore, knowing that a value is `Applicable` is not enough to prove at compile-time that it supports every `Applicable` method.

 2. Similarly, all operator values have to implement `select()`, but all of them throw an exception.

 3. Code blocks that cast objects to `Applicable` are overly reliant on SANY's checks to ensure that the correct kind of value flows there.

 4. Operators and functions behave differently when called with more than 1 argument: operators can have arity > 1, but functions have to wrap the arguments in a tuple.

Note that `Applicable` has been retained because it is still widely used in the community modules.  I hope that once the community modules switch to using `FunctionValue` and `OpValue` correctly, we can completely remove `Applicable` and the other now-deprecated methods.

I have documented the key methods of `FunctionValue` and `OpValue` as well as I can; `Applicable` has no documentation I could find.