### PR TITLE
Use skip parameter for tlaplus/examples CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -76,9 +76,13 @@ jobs:
           --manifest_path examples/manifest.json
     - name: Smoke-test large tlaplus/examples models
       run: |
+        # SimKnuthYao requires certain number of states to have been generated
+        # before termination or else it fails. This makes it not amenable to
+        # smoke testing.
         python examples/.github/scripts/smoke_test_large_models.py          \
           --tools_jar_path tlatools/org.lamport.tlatools/dist/tla2tools.jar \
           --tlapm_lib_path tlapm/library                                    \
           --community_modules_jar_path CommunityModules-deps.jar            \
-          --manifest_path examples/manifest.json
+          --manifest_path examples/manifest.json                            \
+          --skip specifications/KnuthYao/SimKnuthYao.cfg
 


### PR DESCRIPTION
The CI will not pass until these changes are merged: https://github.com/tlaplus/Examples/pull/96

Probably best to re-run the PR CI for these changes after merging the tlaplus/examples changes but before merging these.