### PR TITLE
Wrong coverage reported for conditional such as IF-THEN-ELSE

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/coverage/CostModelCreator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/coverage/CostModelCreator.java
@@ -51,7 +51,9 @@ import tla2sany.semantic.SymbolNode;
 import tlc2.output.EC;
 import tlc2.output.MP;
 import tlc2.tool.Action;
+import tlc2.tool.BuiltInOPs;
 import tlc2.tool.ITool;
+import tlc2.tool.ToolGlobals;
 import tlc2.tool.coverage.ActionWrapper.Relation;
 import tlc2.util.Context;
 import tlc2.util.ObjLongTable;
@@ -353,6 +355,10 @@ public class CostModelCreator extends ExplorerVisitor {
 				return;
 			}
 			final CostModelNode pop = stack.pop();
+			int opcode = BuiltInOPs.getOpCode(((OpApplNode) exploreNode).getOperator().getName());
+			if (opcode == ToolGlobals.OPCODE_ite) {
+				((OpApplNodeWrapper)pop).setChildrenITE();
+			}
 			assert pop.getNode() == exploreNode;
 		} else if (exploreNode instanceof OpDefNode) {
 			final boolean removed = opDefNodes.remove((OpDefNode) exploreNode);


### PR DESCRIPTION
tlc2.tool.coverage.OpApplNodeWrapper.print(int, Calculate) contracts consistent sub-trees into the parent node if the parent and the sub-tree have the same costs, or the sub-tree has zero cost.  Evidently, this is a wrong in the case of ITE when the true or false branch has zero cost. Essentially, the traversal of the cost model has to force reporting the children of an ITE node if the child stats are inconsistent.

TODO:
- Diagnose and fix test failures
  - Constant definitions report into a dummy CostModel, and, thus their nested ITEs show up with zero coverage (even the conditional)
- Unify OpApplNodeWrapper#ite and OpApplNodeWrapper#prime?
- Support other conditionals such as CASE

Part of Github issue #845
https://github.com/tlaplus/tlaplus/issues/845

[Bug][TLC]