### PR TITLE
Mitigate state-space explosion during trace validation

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -62,13 +62,13 @@ import tlc2.value.IMVPerm;
 import tlc2.value.IValue;
 import tlc2.value.ValueConstants;
 import tlc2.value.Values;
-import tlc2.value.impl.FunctionValue;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.Enumerable;
 import tlc2.value.impl.Enumerable.Ordering;
 import tlc2.value.impl.FcnLambdaValue;
 import tlc2.value.impl.FcnParams;
 import tlc2.value.impl.FcnRcdValue;
+import tlc2.value.impl.FunctionValue;
 import tlc2.value.impl.IntValue;
 import tlc2.value.impl.LazySupplierValue;
 import tlc2.value.impl.LazyValue;
@@ -2707,12 +2707,7 @@ public abstract class Tool
 					for (int i = 0; i < sz; i++) {
 						t = iss.elementAt(i);
 						
-						Value res = this.eval(args[0], c, s0, t, control, cm);
-						if (!((BoolValue) res).val) {
-							continue;
-						}
-						
-						res = this.eval(args[1], c, t, s1, control, cm);
+						final Value res = this.eval(args[1], c, t, s1, control, cm);
 						if (((BoolValue) res).val) {
 							return BoolValue.ValTrue;
 						}


### PR DESCRIPTION
* https://github.com/tlaplus/CommunityModules/commit/fa56512a37421631ee140e86429e095c532a6904 as minor optimization to mitigate state-space explosion coming from https://github.com/microsoft/CCF/pull/5948#discussion_r1463037681
* DFS mode for trace validation to mitigate state-space explosion coming from https://github.com/microsoft/CCF/pull/5948#discussion_r1463037681
  * Marrying DFS and `\cdot`
* Support `-continue` when checking Action Constraints (refinement checking)
* Check invariants during trace validation (proposed in https://github.com/microsoft/CCF/pull/5933)



https://github.com/microsoft/CCF/issues/5057#issuecomment-1910837290