### PR TITLE
Fixes issue 789

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -450,6 +450,10 @@ public class TLC {
 							System.setProperty(Simulator.class.getName() + ".rlaction", Boolean.TRUE.toString());
 						}
 					}
+                    if(traceNum == Long.MAX_VALUE && traceFile != null) {
+                        printErrorMsg("Error: You need to specify a 'num' argument when using the 'file' argument, for example: '\"num=5,file=test.txt\"'.");
+                        return false;
+                    }
 				}
 			} else if (args[index].equals("-modelcheck")) {
 				index++;

--- a/tlatools/org.lamport.tlatools/test/tlc2/TLCTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/TLCTest.java
@@ -122,7 +122,20 @@ public class TLCTest {
 				TLAConstants.Files.MODEL_CHECK_FILE_BASENAME }));
 		assertTrue(TLCGlobals.setBound == Integer.MAX_VALUE);
 	}
-	
+
+	@Test
+	public void testHandleParametersSimulateFileNum() {
+		TLC tlc = new TLC();
+		assertTrue(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "num=5,file=test.txt"}));
+		// reset static field
+		tlc.setTraceNum(Long.MAX_VALUE);
+		assertFalse(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "file=test.txt"}));
+		// reset static fields.
+		tlc.setTraceNum(Long.MAX_VALUE);
+		assertFalse(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "num=10"}));
+    }
+
+
 	@Test
 	public void testRuntimeConversion() {
 		assertEquals("59s", TLC.convertRuntimeToHumanReadable(59000L));


### PR DESCRIPTION
When `file=` argument is specified, a `num` argument is required. Fixes #789 
I'm not sure if this is still needed, but I was trying to find a simple bugfix.