### PR TITLE
Fix org.lamport.tlatools build errors in Eclipse

### DIFF
--- a/tlatools/org.lamport.tlatools/.classpath
+++ b/tlatools/org.lamport.tlatools/.classpath
@@ -26,11 +26,15 @@
 	<classpathentry kind="lib" path="lib/jline/jline-builtins-3.25.0.jar"/>
 	<classpathentry kind="lib" path="lib/jline/jline-reader-3.25.0.jar"/>
 	<classpathentry kind="lib" path="lib/jline/jline-terminal-3.25.0.jar"/>
-	<classpathentry kind="lib" path="lib/jpf.jar"/>
 	<classpathentry kind="lib" path="lib/jmh/jmh-core-1.21.jar"/>
 	<classpathentry kind="lib" path="lib/jmh/commons-math3-3.2.jar"/>
 	<classpathentry kind="lib" path="lib/gson/gson-2.8.6.jar"/>
 	<classpathentry kind="lib" path="lib/lsp/org.eclipse.lsp4j.debug_0.21.1.v20230829-0012.jar"/>
 	<classpathentry kind="lib" path="lib/lsp/org.eclipse.lsp4j.jsonrpc_0.21.1.v20230829-0012.jar"/>
+	<classpathentry kind="lib" path="lib/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="lib/jpf.jar"/>
+	<classpathentry kind="lib" path="lib/easymock-3.3.1.jar"/>
+	<classpathentry kind="lib" path="lib/aspectjtools-1.9.2.jar"/>
+	<classpathentry kind="lib" path="lib/hamcrest-core-1.3.jar"/>
 	<classpathentry kind="output" path="class"/>
 </classpath>


### PR DESCRIPTION
When opening `tlatools/org.lamport.tlatools` in eclipse, users are presented with around 100 build errors. There are four causes:
- Unable to resolve modules from JUnit; fixed by adding `lib/junit-4.12.jar` and `lib/hamcrest-core-1.3.jar` to `.classpath` file
- Unable to resolve modules from EasyMock; fixed by adding `lib/easymock-3.3.1.jar` to `.classpath` file
- Unable to resolve modules from AspectJ; fixed by adding `lib/aspectjtools-1.9.2.jar` to `.classpath` file
- "`@Ignore` annotation cannot be applied to a class" error in `test/tlc2/tool/suite/Test61.java`; this is actually because the file `lib/jpf.jar` contains an old `org.junit.Ignore` class (probably accidentally) which eclipse was finding before the one in `lib/junit-4.12.jar`; moving `lib/junit-4.12.jar` above `lib/jpf.jar` in the `.classpath` file fixed this