### PR TITLE
In `OffHeapDiskFPSet`, invalidate buffered data after concurrent flush

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/DiskFPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/DiskFPSet.java
@@ -1,5 +1,7 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
 package tlc2.tool.fp;
 
 import java.io.EOFException;
@@ -1094,7 +1096,7 @@ public abstract class DiskFPSet extends FPSet implements FPSetStatistic {
 			// create temporary file
 			File tmpFile = new File(tmpFilename);
 			tmpFile.delete();
-			RandomAccessFile tmpRAF = new BufferedRandomAccessFile(tmpFile, "rw");
+			BufferedRandomAccessFile tmpRAF = new BufferedRandomAccessFile(tmpFile, "rw");
 			tmpRAF.setLength((getTblCnt() + fileCnt) * FPSet.LongSize);
 
 			// merge
@@ -1128,7 +1130,7 @@ public abstract class DiskFPSet extends FPSet implements FPSetStatistic {
 			poolIndex = 0;
 		}
 		
-		protected abstract void mergeNewEntries(BufferedRandomAccessFile[] inRAFs, RandomAccessFile outRAF) throws IOException;
+		protected abstract void mergeNewEntries(BufferedRandomAccessFile[] inRAFs, BufferedRandomAccessFile outRAF) throws IOException;
 		
 	}
 	

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LSBDiskFPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LSBDiskFPSet.java
@@ -1,4 +1,5 @@
 // Copyright (c) 2012 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
 
 package tlc2.tool.fp;
 
@@ -77,7 +78,7 @@ public class LSBDiskFPSet extends HeapBasedDiskFPSet {
 		 * @see tlc2.tool.fp.DiskFPSet.Flusher#mergeNewEntries(java.io.RandomAccessFile, java.io.RandomAccessFile)
 		 */
 		@Override
-		protected void mergeNewEntries(BufferedRandomAccessFile[] inRAFs, RandomAccessFile outRAF) throws IOException {
+		protected void mergeNewEntries(BufferedRandomAccessFile[] inRAFs, BufferedRandomAccessFile outRAF) throws IOException {
 			final int buffLen = buff.length;
 
 			// Precompute the maximum value of the new file

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/MSBDiskFPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/MSBDiskFPSet.java
@@ -1,4 +1,5 @@
 // Copyright (c) 2012 Markus Alexander Kuppe. All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
 
 package tlc2.tool.fp;
 
@@ -101,7 +102,7 @@ public class MSBDiskFPSet extends HeapBasedDiskFPSet {
 		/* (non-Javadoc)
 		 * @see tlc2.tool.fp.DiskFPSet#mergeNewEntries(long[], int, java.io.RandomAccessFile, java.io.RandomAccessFile)
 		 */
-		protected void mergeNewEntries(BufferedRandomAccessFile[] inRAFs, RandomAccessFile outRAF) throws IOException {
+		protected void mergeNewEntries(BufferedRandomAccessFile[] inRAFs, BufferedRandomAccessFile outRAF) throws IOException {
 			final long buffLen = getTblCnt();
 			final TLCIterator itr = new TLCIterator(tbl);
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/BufferedRandomAccessFile.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/BufferedRandomAccessFile.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:26:26 PST by lamport
 //      modified on Mon Jun 19 14:28:04 PDT 2000 by yuanyu
 package tlc2.util;
@@ -147,6 +148,22 @@ public final class BufferedRandomAccessFile extends java.io.RandomAccessFile {
       this.maxHi = BuffSz;
       this.hitEOF = false;
       this.diskPos = 0L;
+    }
+
+    /**
+     * Invalidate any buffered data so that subsequent reads will go to disk.  Clients will typically call this when
+     * they know that the on-disk contents have been altered through a different file descriptor and they need to
+     * observe those writes through this one.
+     *
+     * <p>If this object has any buffered writes, this call will flush them to disk ({@link #flush()}).
+     *
+     * @throws IOException if an I/O error occurs flushing buffered writes
+     */
+    public void invalidateBufferedData() throws IOException {
+        flush();
+
+        // This assignment invalidates any buffered data: lo==hi means there are 0 buffered bytes.
+        this.hi = this.lo;
     }
     
     /* overrides RandomAccessFile.close() */

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/BufferedRandomAccessFile.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/BufferedRandomAccessFile.java
@@ -162,8 +162,13 @@ public final class BufferedRandomAccessFile extends java.io.RandomAccessFile {
     public void invalidateBufferedData() throws IOException {
         flush();
 
-        // This assignment invalidates any buffered data: lo==hi means there are 0 buffered bytes.
-        this.hi = this.lo;
+        // To preserve this class's invariants, we can't just clear the buffer; we also need to refill the
+        // buffer from disk.
+        if (this.diskPos != this.lo) {
+            super.seek(this.lo);
+            this.diskPos = this.lo;
+        }
+        this.hi = this.lo + fillBuffer();
     }
     
     /* overrides RandomAccessFile.close() */


### PR DESCRIPTION
Discovered while investigating #835.

----

This commit fixes a latent cache inconsistency bug in `OffHeapDiskFPSet`.  There are no symptoms today, but problems will arise if we change almost anything in the implementation of `BufferedRandomAccessFile` or `DiskFPSet`.

Most implementations of `DiskFPSet.Flusher` write directly to the output file through the provided output file descriptor `outRAF`.  But, the concurrent flushing algorithm in `OffHeapDiskFPSet` actually writes to the output file through newly-allocated file descriptors.  As a result, any buffered data in `outRAF` will be incorrect following a flush because the on-disk data was modified through different file descriptors.

Today there are some subtleties in the implementation of `BufferedRandomAccessFile` that prevent this from causing problems.  It so happens that when the concurrent flush finishes, there is no buffered data in `outRAF` to worry about.  However, that state of affairs is extremely brittle since there is no mechanism to enforce it.

To fix the latent bug, this commit adds a new method that invalidates the cache in a `BufferedRandomAccessFile`.  The concurrent flush method calls it at the end of execution to ensure that subsequent reads can see the data that was written.