### PR TITLE
Flush writes to disk before asserting facts about the disk files

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/AbstractDiskGraph.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/AbstractDiskGraph.java
@@ -1,4 +1,5 @@
 // Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:33:36 PST by lamport
 //      modified on Sat Dec 29 22:15:18 PST 2001 by yuanyu
 
@@ -538,6 +539,20 @@ public abstract class AbstractDiskGraph {
 		this.makeNodePtrTbl(nodePtrRAFPos);
 		this.nodeRAF.seek(nodeRAFPos);
 		this.nodePtrRAF.seek(nodePtrRAFPos);
+	}
+
+	/**
+	 * Flush any in-memory buffered data to the disk.
+	 *
+	 * <p>This method has essentially no visible effect, since any disk files are private to this object and flushing
+	 * writes should not affect reads from those files.  However, there are some tests that call this method to make
+	 * assertions about the data being written to disk.
+	 *
+	 * @throws IOException if an I/O error occurs
+	 */
+	public void flushWritesToDiskFiles() throws IOException {
+		this.nodeRAF.flush();
+		this.nodePtrRAF.flush();
 	}
 
 	public abstract void reset() throws IOException;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/ILiveCheck.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/ILiveCheck.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2024, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -114,6 +115,17 @@ public interface ILiveCheck {
 	void beginChkpt() throws IOException;
 
 	void commitChkpt() throws IOException;
+
+	/**
+	 * Flush any in-memory buffered data to the disk.  This is a no-op for implementations that are entirely in-memory.
+	 *
+	 * <p>This method has essentially no visible effect, since any disk files are private to this object and flushing
+	 * writes should not affect reads from those files.  However, there are some tests that call this method to make
+	 * assertions about the data being written to disk.
+	 *
+	 * @throws IOException if an I/O error occurs
+	 */
+	void flushWritesToDiskFiles() throws IOException;
 
 	void recover() throws IOException;
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/LiveCheck.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/LiveCheck.java
@@ -1,4 +1,5 @@
 // Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:33:44 PST by lamport
 //      modified on Thu Jan 10 18:41:04 PST 2002 by yuanyu
 
@@ -402,6 +403,13 @@ public class LiveCheck implements ILiveCheck {
 		for (int i = 0; i < checker.length; i++) {
 			MP.printMessage(EC.TLC_AAAAAAA);
 			checker[i].getDiskGraph().recover();
+		}
+	}
+
+	@Override
+	public void flushWritesToDiskFiles() throws IOException {
+		for (ILiveChecker c : checker) {
+			c.getDiskGraph().flushWritesToDiskFiles();
 		}
 	}
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/LiveCheck1.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/LiveCheck1.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2024, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:33:44 PST by lamport
 //      modified on Fri Jan  4 00:30:06 PST 2002 by yuanyu
 
@@ -989,6 +990,11 @@ public class LiveCheck1 implements ILiveCheck {
 	 * @see tlc2.tool.liveness.ILiveCheck#recover()
 	 */
 	public void recover() throws IOException {
+		// Intentional no op - LiveCheck1 has no disk files.
+	}
+
+	@Override
+	public void flushWritesToDiskFiles() {
 		// Intentional no op - LiveCheck1 has no disk files.
 	}
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/NoOpLiveCheck.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/NoOpLiveCheck.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2015 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2024, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -141,6 +142,10 @@ public class NoOpLiveCheck implements ILiveCheck {
 	 * @see tlc2.tool.liveness.ILiveCheck#recover()
 	 */
 	public void recover() throws IOException {
+	}
+
+	@Override
+	public void flushWritesToDiskFiles() {
 	}
 
 	/* (non-Javadoc)

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CommonTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CommonTestCase.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016 Microsoft Research. All rights reserved. 
- * Copyright (c) 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -208,6 +209,14 @@ public abstract class CommonTestCase {
 	 * @param ptrsSize
 	 */
 	protected void assertNodeAndPtrSizes(final long nodesSize, final long ptrsSize) {
+		// Make sure the liveness checker has flushed all its data to disk to ensure that
+		// the nodes_0 and ptrs_0 files really include everything written so far.
+		try {
+			TLCGlobals.mainChecker.liveCheck.flushWritesToDiskFiles();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+
 		final String metadir = TLCGlobals.mainChecker.metadir;
 		assertNotNull(metadir);
 		


### PR DESCRIPTION
Discovered while working on #835.

I am not in love with this fix, and I am open to other ideas. But, it seemed to be the most straightforward way to fix the problem.

----

This commit fixes a latent issue in the test suite.

`CommonTestCase.assertNodeAndPtrSizes` makes assertions about the on-disk state of some files that are internal to `AbstractDiskGraph`. These checks are useful, but today they only pass because of two brittle implementation details:

 - `BufferedRandomAccessFile` flushes writes to disk when seeking backward in the file.
 - Backward seeks are very common.

The checks will break if we optimize `BufferedRandomAccessFile` to flush less often or if we change how `AbstractDiskGraph` reads/writes its internal files.

To make the tests less brittle, this commit introduces a new method that instructs the liveness checker to flush writes to disk immediately.  The new method is only called by the tests, and it is called before making assertions about on-disk state.