### PR TITLE
Statically initialize operators table

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/configuration/ConfigConstants.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/configuration/ConfigConstants.java
@@ -10,19 +10,10 @@
 
 package tla2sany.configuration;
 
-interface ConfigConstants {
-  int nada = 0;
-  int infixOP = 1;
-  int prefixOP = 2;
-  int postfixOP = 3;
-  int preINfixOP = 4;
+import tla2sany.parser.Operator;
+import tla2sany.parser.Operators;
 
-  int leftAssoc = 10;
-  int rightAssoc = 11;
-  int noAssoc = 12;
-
-  int EOF = 0;
-  int SINGLE_LINE = 4;
+public interface ConfigConstants {
   int CONSTANT = 7;
   int OPERATOR = 8;
   int INFIX = 9;
@@ -35,14 +26,9 @@ interface ConfigConstants {
   int RIGHTASSOC = 16;
   int NOASSOC = 17;
   int BUILTIN = 18;
-  int OPCHAR = 19;
-  int LETTER = 20;
   int OPID = 21;
   int NUMBER = 22;
   int RESTRICTED = 23;
-
-  int DEFAULT = 0;
-  int IN_COMMENT = 1;
 
   String[] tokenImage = {
     "<EOF>",
@@ -73,141 +59,10 @@ interface ConfigConstants {
 
   String defaultConfig =
     /***********************************************************************
-    * This is used in config/Configuration.java to create Operator         *
-    * objects for each operator, which are put in the hashtable            *
-    * Operators.BuiltinTable.                                              *
+    * This is used in config/Configuration.java to create OpDefNode        *
+    * objects for each built-in operator, which are put in the             *
+    * Context.initialContext table.                                        *
     ***********************************************************************/
-    "operator [ 160 160 Left postfix \n" +
-    "operator . 170 170 Left infix \n" +
-    "operator ' 150 150 None postfix\n" +
-    "operator ^ 140 140 None infix\n" +  // None, verified.
-    "operator / 130 130 None infix\n" +
-    "operator * 130 130 Left infix\n" +
-    "operator - 110 110 Left infix\n" +
-    "operator -. 120 120 None prefix\n" +
-    "operator + 100 100 Left infix\n" +
-    "operator = 50 50 None infix\n" +
-    "operator \\lnot 40 40 Left prefix \n" +
-    "synonym  ~ \\lnot\n" +
-    "synonym \\neg \\lnot\n" +
-    "operator \\land 30 30 Left infix\n" +
-    "synonym  /\\ \\land\n" +
-    "operator \\lor 30 30 Left infix\n" +
-    "synonym  \\/ \\lor\n" +
-    "operator ~> 20 20 None infix\n" +
-    "operator => 10 10  None infix\n" +
-    //\n" +
-    "operator [] 40 150 None prefix \n" +
-    "operator <> 40 150 None prefix \n" +
-    "operator ENABLED 40 150 None prefix \n" +
-    "operator UNCHANGED 40 150 None prefix \n" +
-    "operator SUBSET 100 130 None prefix \n" +
-    "operator UNION 100 130 None prefix \n" +
-    "operator DOMAIN 100 130 None prefix \n" +
-    //\n" +
-    "operator ^+ 150 150 None postfix\n" +
-    "operator ^* 150 150 None postfix\n" +
-    "operator ^# 150 150 None postfix\n" +
-    //\n" +
-    "operator \\cdot 50 140  Left infix\n" +
-    //\n" +
-    "operator \\equiv 20 20  None infix\n" +
-    "synonym <=> \\equiv\n" +
-    //\n" +
-    "operator -+-> 20 20 None infix\n" +
-    "operator /= 50 50 None infix\n" +
-    "synonym # /=\n" +
-    "operator \\subseteq 50 50 None infix\n" +
-    "operator \\in 50 50 None infix\n" +
-    "operator \\notin 50 50 None infix\n" +
-    "operator < 50 50 None infix\n" +
-    "operator \\leq 50 50 None infix\n" +
-    "synonym <= \\leq\n" +
-    "synonym =< \\leq\n" +
-    "operator > 50 50 None infix\n" +
-    "operator \\geq 50 50 None infix\n" +
-    "synonym >= \\geq\n" +
-    //\n" +
-    "operator \\times 100 130 Left nfix\n" +
-    "synonym  \\X \\times\n" +
-    "operator \\ 80 80 None infix\n" +
-    "operator \\intersect 80 80 Left infix\n" +
-    "synonym \\cap \\intersect \n" +
-    "operator \\union 80 80 Left infix\n" +
-    "synonym \\cup \\union\n" +
-    //\n" +
-    "operator ... 90 90 None infix\n" +
-    "operator .. 90 90 None infix\n" +
-    "operator | 100 110 Left infix\n" +
-    "operator || 100 110 Left infix\n" +
-    "operator && 130 130 Left infix\n" +
-    "operator & 130 130 Left infix\n" +
-    "operator $$ 90 130 Left infix\n" +
-    "operator $ 90 130 Left infix\n" +  
-    "operator ?? 90 130 Left infix\n" +
-    //"operator ? 90 130 Left infix\n" +  // Removed requested by Leslie (16 Feb. 01)
-    "operator %% 100 110 Left infix\n" +
-    "operator % 100 110 None infix\n" +
-    "synonym \\mod %\n" +
-    "operator ## 90 130 Left infix\n" +
-    "operator ++ 100 100 Left infix\n" +
-    "operator -- 110 110 Left infix\n" +
-    "operator ** 130 130 Left infix\n" +
-    "operator // 130 130 None infix\n" +
-    "operator ^^ 140 140 None infix\n" +
-    "operator @@ 60 60 Left infix\n" +
-    "operator !! 90 130 None infix\n" +
-    "operator |- 50 50 None infix\n" +
-    "operator |= 50 50 None infix\n" +
-    "operator -| 50 50 None infix\n" +
-    "operator =| 50 50 None infix\n" +
-    "operator <: 70 70 None infix\n" +
-    "operator :> 70 70 None infix\n" +
-    "operator := 50 50 None infix\n" +
-    "operator ::= 50 50 None infix\n" +
-// \n" +
-    "operator \\oplus 100 100 Left infix\n" +
-    "synonym (+) \\oplus\n" +
-    "operator \\ominus 110 110 Left infix\n" +
-    "synonym (-) \\ominus\n" +
-    "operator \\odot 130 130 Left infix\n" +
-    "synonym (.) \\odot\n" +
-    "operator \\oslash 130 130 None infix\n" +
-    "synonym (/) \\oslash\n" +
-    "operator \\otimes 130 130 Left infix\n" +
-    "synonym (\\X) \\otimes\n" +
-// \n" +
-    "operator \\uplus 90 130 Left infix\n" +
-    "operator \\sqcap 90 130 Left infix\n" +
-    "operator \\sqcup 90 130 Left infix\n" +
-    "operator \\div 130 130 None infix\n" +
-    "operator \\wr 90 140 None infix\n" +
-    "operator \\star 130 130 Left infix\n" +
-    "operator \\o 130 130 Left infix\n" +
-    "synonym  \\circ \\o \n" +
-    "operator \\bigcirc 130 130 Left infix\n" +
-    "operator \\bullet 130 130 Left infix\n" +
-    "operator \\prec 50 50 None infix\n" +
-    "operator \\succ 50 50 None infix\n" +
-    "operator \\preceq 50 50 None infix\n" +
-    "operator \\succeq 50 50 None infix\n" +
-    "operator \\sim 50 50 None infix\n" +
-    "operator \\simeq 50 50 None infix\n" +
-    "operator \\ll 50 50 None infix\n" +
-    "operator \\gg 50 50 None infix\n" +
-    "operator \\asymp 50 50 None infix\n" +
-    "operator \\subset 50 50 None infix\n" + // subseteq is builtin
-    "operator \\supset 50 50 None infix\n" +
-    "operator \\supseteq 50 50 None infix\n" +
-    "operator \\approx 50 50 None infix\n" +
-    "operator \\cong 50 50 None infix\n" +
-    "operator \\sqsubset 50 50 None infix\n" +
-    "operator \\sqsubseteq 50 50 None infix\n" +
-    "operator \\sqsupset 50 50 None infix\n" +
-    "operator \\sqsupseteq 50 50 None infix\n" +
-    "operator \\doteq 50 50 None infix\n" +
-    "operator \\propto 50 50 None infix\n" +
-    //\n" +
     "builtin STRING    $$_string     constant\n" +
     "builtin FALSE     $$_false      constant\n" +
     "builtin TRUE      $$_true       constant\n" +
@@ -291,5 +146,138 @@ interface ConfigConstants {
     "builtin $Suffices                $$_null   1\n"   
 
   ;
+  
+  /**
+   * Canonical operators & symbols with their defining characteristics:
+   * symbol text, low precedence, high precedence, associativity, fix type.
+   */
+  Operator[] CanonicalOperators = {
+    new Operator("[",             160, 160, Operators.assocLeft, Operators.postfix),
+    new Operator(".",             170, 170, Operators.assocLeft, Operators.infix),
+    new Operator("'",             150, 150, Operators.assocNone, Operators.postfix),
+    new Operator("^",             140, 140, Operators.assocNone, Operators.infix),
+    new Operator("/",             130, 130, Operators.assocNone, Operators.infix),
+    new Operator("*",             130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("-",             110, 110, Operators.assocLeft, Operators.infix),
+    new Operator("-.",            120, 120, Operators.assocNone, Operators.prefix),
+    new Operator("+",             100, 100, Operators.assocLeft, Operators.infix),
+    new Operator("=",             50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\lnot",        40,  40,  Operators.assocLeft, Operators.prefix),
+    new Operator("\\land",        30,  30,  Operators.assocLeft, Operators.infix),
+    new Operator("\\lor",         30,  30,  Operators.assocLeft, Operators.infix),
+    new Operator("~>",            20,  20,  Operators.assocNone, Operators.infix),
+    new Operator("=>",            10,  10,  Operators.assocNone, Operators.infix),
+    new Operator("[]",            40,  150, Operators.assocNone, Operators.prefix),
+    new Operator("<>",            40,  150, Operators.assocNone, Operators.prefix),
+    new Operator("ENABLED",       40,  150, Operators.assocNone, Operators.prefix),
+    new Operator("UNCHANGED",     40,  150, Operators.assocNone, Operators.prefix),
+    new Operator("SUBSET",        100, 130, Operators.assocNone, Operators.prefix),
+    new Operator("UNION",         100, 130, Operators.assocNone, Operators.prefix),
+    new Operator("DOMAIN",        100, 130, Operators.assocNone, Operators.prefix),
+    new Operator("^+",            150, 150, Operators.assocNone, Operators.postfix),
+    new Operator("^*",            150, 150, Operators.assocNone, Operators.postfix),
+    new Operator("^#",            150, 150, Operators.assocNone, Operators.postfix),
+    new Operator("\\cdot",        50,  140, Operators.assocLeft, Operators.infix),
+    new Operator("\\equiv",       20,  20,  Operators.assocNone, Operators.infix),
+    new Operator("-+->",          20,  20,  Operators.assocNone, Operators.infix),
+    new Operator("/=",            50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\subseteq",    50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\in",          50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\notin",       50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("<",             50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\leq",         50,  50,  Operators.assocNone, Operators.infix),
+    new Operator(">",             50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\geq",         50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\times",       100, 130, Operators.assocLeft, Operators.nfix),
+    new Operator("\\",            80,  80,  Operators.assocNone, Operators.infix),
+    new Operator("\\intersect",   80,  80,  Operators.assocLeft, Operators.infix),
+    new Operator("\\union",       80,  80,  Operators.assocLeft, Operators.infix),
+    new Operator("...",           90,  90,  Operators.assocNone, Operators.infix),
+    new Operator("..",            90,  90,  Operators.assocNone, Operators.infix),
+    new Operator("|",             100, 110, Operators.assocLeft, Operators.infix),
+    new Operator("||",            100, 110, Operators.assocLeft, Operators.infix),
+    new Operator("&&",            130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("&",             130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("$$",            90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("$",             90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("??",            90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("%%",            100, 110, Operators.assocLeft, Operators.infix),
+    new Operator("%",             100, 110, Operators.assocNone, Operators.infix),
+    new Operator("##",            90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("++",            100, 100, Operators.assocLeft, Operators.infix),
+    new Operator("--",            110, 110, Operators.assocLeft, Operators.infix),
+    new Operator("**",            130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("//",            130, 130, Operators.assocNone, Operators.infix),
+    new Operator("^^",            140, 140, Operators.assocNone, Operators.infix),
+    new Operator("@@",            60,  60,  Operators.assocLeft, Operators.infix),
+    new Operator("!!",            90,  130, Operators.assocNone, Operators.infix),
+    new Operator("|-",            50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("|=",            50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("-|",            50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("=|",            50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("<:",            70,  70,  Operators.assocNone, Operators.infix),
+    new Operator(":>",            70,  70,  Operators.assocNone, Operators.infix),
+    new Operator(":=",            50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("::=",           50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\oplus",       100, 100, Operators.assocLeft, Operators.infix),
+    new Operator("\\ominus",      110, 110, Operators.assocLeft, Operators.infix),
+    new Operator("\\odot",        130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("\\oslash",      130, 130, Operators.assocNone, Operators.infix),
+    new Operator("\\otimes",      130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("\\uplus",       90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("\\sqcap",       90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("\\sqcup",       90,  130, Operators.assocLeft, Operators.infix),
+    new Operator("\\div",         130, 130, Operators.assocNone, Operators.infix),
+    new Operator("\\wr",          90,  140, Operators.assocNone, Operators.infix),
+    new Operator("\\star",        130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("\\o",           130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("\\bigcirc",     130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("\\bullet",      130, 130, Operators.assocLeft, Operators.infix),
+    new Operator("\\prec",        50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\succ",        50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\preceq",      50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\succeq",      50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\sim",         50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\simeq",       50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\ll",          50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\gg",          50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\asymp",       50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\subset",      50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\supset",      50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\supseteq",    50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\approx",      50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\cong",        50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\sqsubset",    50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\sqsubseteq",  50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\sqsupset",    50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\sqsupseteq",  50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\doteq",       50,  50,  Operators.assocNone, Operators.infix),
+    new Operator("\\propto",      50,  50,  Operators.assocNone, Operators.infix),
+  };
+  
+  /*
+   * Different ways of writing the same operator. The zeroeth item is the
+   * canonical way.
+   */
+  String[][] OperatorSynonyms = new String[][] {
+    new String[] {"\\lnot", "~", "\\neg"},
+    new String[] {"\\land", "/\\"},
+    new String[] {"\\lor", "\\/"},
+    new String[] {"\\equiv", "<=>"},
+    new String[] {"/=", "#"},
+    new String[] {"\\leq", "<=", "=<"},
+    new String[] {"\\geq", ">="},
+    // The \mod synonym doesn't seem to be recognized in other parts of the
+    // code but keeping it here because it was in the original config.
+    new String[] {"%", "\\mod"},
+    new String[] {"\\times", "\\X"},
+    new String[] {"\\intersect", "\\cap"},
+    new String[] {"\\union", "\\cup"},
+    new String[] {"\\o", "\\circ"},
+    new String[] {"\\oplus", "(+)"},
+    new String[] {"\\ominus", "(-)"},
+    new String[] {"\\odot", "(.)"},
+    new String[] {"\\oslash", "(/)"},
+    new String[] {"\\otimes", "(\\X)"},
+  };
 }
-

--- a/tlatools/org.lamport.tlatools/src/tla2sany/configuration/Configuration.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/configuration/Configuration.java
@@ -187,7 +187,8 @@ public final class Configuration implements ConfigConstants {
    } else {
      op = new Operator( UniqueString.uniqueStringOf(t.image), low, high, assoc, kind );
    }
-   Operators.addOperator( UniqueString.uniqueStringOf(s), op );
+   // This is initialized statically now.
+   //Operators.addOperator( UniqueString.uniqueStringOf(s), op );
   }
 
   static final public void OpSynonym() throws ParseException {
@@ -195,8 +196,9 @@ public final class Configuration implements ConfigConstants {
     jj_consume_token(SYNONYM);
     t1 = jj_consume_token(OPID);
     t2 = jj_consume_token(OPID);
-    Operators.addSynonym( UniqueString.uniqueStringOf(t1.image), 
-                          UniqueString.uniqueStringOf(t2.image) );
+    // This is initialized statically now.
+    //Operators.addSynonym( UniqueString.uniqueStringOf(t1.image), 
+    //                      UniqueString.uniqueStringOf(t2.image) );
   }
 
   static final public void OpNull(String s) throws ParseException {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/Operator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/Operator.java
@@ -35,6 +35,10 @@ public class Operator implements tla2sany.st.SyntaxTreeConstants {
     Id = id; Low = l; High = h; Associativity = a; Fix = f;
   }
 
+  public Operator(String id, int l, int h, int a, int f) {
+    this(UniqueString.uniqueStringOf(id), l, h, a, f);
+  }
+  
   public String toString() {
   switch ( Fix ) {
     case 0 /* Operators.nofix   */ : return Id.toString() + ", nofix";

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/Operators.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/Operators.java
@@ -1,3 +1,5 @@
+// Copyright (c) 2003 Compaq Corporation.  All rights reserved.
+
 package tla2sany.parser;
 
 import tla2sany.configuration.ConfigConstants;
@@ -16,49 +18,49 @@ public class Operators {
    * The operator has no defined associativity. This is the case for prefix
    * and postfix operators.
    */
-  static public final int assocNone = 0;
+  public static final int assocNone = 0;
   
   /**
    * The operator is left-associative, like ((1 + 2) + 3).
    */
-  static public final int assocLeft = 1;
+  public static final int assocLeft = 1;
   
   /**
    * The operator is right-associative, like (1 + (2 + 3)).
    * Currently, no TLA+ operators are right-associative.
    */
-  static public final int assocRight = 2;
+  public static final int assocRight = 2;
 
   /**
    * The operator has no -fix information associated with it.
    * It is unknown what type of operator this could refer to.
    */
-  static public final int nofix = 0;
+  public static final int nofix = 0;
   
   /**
    * Indicates a prefix operator, like SUBSET S.
    */
-  static public final int prefix = 1;
+  public static final int prefix = 1;
   
   /**
    * Indicates a postfix operator, like x'.
    */
-  static public final int postfix = 2;
+  public static final int postfix = 2;
   
   /**
    * Indicates an infix operator, like 1 + 2.
    */
-  static public final int infix = 3;
+  public static final int infix = 3;
   
   /**
    * Indicates an n-fix operator, currently only A \X B \X C \X D.
    */
-  static public final int nfix = 4;
+  public static final int nfix = 4;
   
   /**
    * The table holding the data for all operators defined in the language.
    */
-  static private final Hashtable<UniqueString, Operator> DefinitionTable =
+  private static final Hashtable<UniqueString, Operator> DefinitionTable =
       new Hashtable<UniqueString, Operator>();
   
   /**
@@ -92,7 +94,7 @@ public class Operators {
    * @param name The operator name.
    * @return Details about the requested operator.
    */
-  static public Operator getOperator(UniqueString name) {
+  public static Operator getOperator(UniqueString name) {
     return DefinitionTable.get(name);
   }
 
@@ -104,7 +106,7 @@ public class Operators {
    * @param op The operator to convert.
    * @return The mixfix form of the given operator.
    */
-  static public Operator getMixfix(Operator op) {
+  public static Operator getMixfix(Operator op) {
      if (op.isPrefix()) return op;
      else {
        UniqueString id = op.getIdentifier().concat(".");
@@ -118,7 +120,7 @@ public class Operators {
    * @param name The name of the operator to check for existence.
    * @return Whether the operator exists.
    */
-  static public boolean existsOperator(UniqueString name) {
+  public static boolean existsOperator(UniqueString name) {
     return DefinitionTable.containsKey(name);
   }
 
@@ -133,7 +135,7 @@ public class Operators {
   * @param name Name of the synonym to resolve.                            *
   * @return Name of the synonym to resolve.                                *
   *************************************************************************/
-  static public UniqueString resolveSynonym(UniqueString name) {
+  public static UniqueString resolveSynonym(UniqueString name) {
     Operator op = DefinitionTable.get(name);
     return null == op ? name : op.getIdentifier();
   }
@@ -141,7 +143,7 @@ public class Operators {
   /**
    * Useful for debugging purposes.
    */
-  static public void printTable() {
+  public static void printTable() {
     System.out.println("printing Operators table");
     Enumeration<UniqueString> Enum = DefinitionTable.keys();
     while( Enum.hasMoreElements() ) { System.out.println("-> " + ((UniqueString)Enum.nextElement()).toString() ); }

--- a/tlatools/org.lamport.tlatools/test/tla2sany/ParseCorpusTest.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/ParseCorpusTest.java
@@ -68,9 +68,14 @@ public class ParseCorpusTest {
 					//continue;
 				}
 				System.out.println(corpusTest.name);
-				String testSummary = String.format("\n%s\n%s\n%s", corpusTestFile.path, corpusTest.name, corpusTest.tlaplusInput);
-				InputStream input = new ByteArrayInputStream(corpusTest.tlaplusInput.getBytes(StandardCharsets.UTF_8));
-				TLAplusParser parser = new TLAplusParser(input, StandardCharsets.UTF_8.name());
+				byte[] inputBytes = corpusTest.tlaplusInput.getBytes(StandardCharsets.UTF_8);
+				InputStream inputStream = new ByteArrayInputStream(inputBytes);
+				TLAplusParser parser = new TLAplusParser(inputStream, StandardCharsets.UTF_8.name());
+				String testSummary = String.format(
+						"%s/%s\n%s",
+						corpusTestFile.path,
+						corpusTest.name,
+						corpusTest.tlaplusInput);
 				Assert.assertTrue(testSummary, parser.parse());
 				System.out.println(String.format("Expect: %s", corpusTest.expectedAst));
 				AstNode actual = SanyTranslator.toAst(parser);
@@ -91,7 +96,7 @@ public class ParseCorpusTest {
 	public void testAllNodesUsed() {
 		List<AstNode.Kind> unused = AstNode.Kind.getUnused();
 		System.out.println(String.format("Total unused node kinds: %d", unused.size()));
-		System.out.println(AstNode.Kind.getUnused());
+		System.out.println(unused);
 		Assert.assertEquals(0, unused.size());
 	}
 }


### PR DESCRIPTION
### What these changes do
`Operators.DefinitionTable` is one of three separate tables that must be initialized before SANY will parse anything (the others are `Context.initialContext` and `BuiltInLevel.LevelData`). Prior to these changes, `Operators.DefinitionTable` was initialized by calling `Configuration.Load` which used the JavaCC-generated parser in `tla2sany/configuration` to parse a string in `tla2sany/configuration/ConfigConstants.java` containing precedence & associativity info for all the TLA+ operator symbols, then loading those symbols into the table. This changes that operation into a simple loop in a `static` block over a static array of `Operator` objects.

### Benefits of these changes

1. Partially (but not completely) removes the necessity of calling `Configuration.load` before using SANY, in line with the goal of #891 
2. Enables defining unicode operator symbols, which the ancient JavaCC-generated parser code did not support reading from a string
3. Moves toward being able to delete the Configuration parser entirely, which would close issue #246 and PR #259 in addition to getting rid of a lot of fairly pointless code

### Reasons to believe these changes will not break anything

1. The `Operators.DefinitionTable` in particular is heavily covered by the operator precedence tests from #894 and corpus tests of #886
2. The changes are very contained and easy to understand, just loading some objects into a table.
3. The Operator objects were not transcribed by hand and thus prone to error; I auto-generated the code by putting the following snippet in the `Operators.addOperator` method then running the original JavaCC parser method:

```java
String assoc = null; 
switch (op.Associativity) { 
  case Operators.assocNone: assoc = "Operators.assocNone"; break; 
  case Operators.assocLeft: assoc = "Operators.assocLeft"; break; 
  case Operators.assocRight: assoc = "Operators.assocRight"; break; 
  default: assert(false); 
} 
String fix = null; 
switch (op.Fix) { 
  case Operators.nofix: fix = "Operators.nofix"; break; 
  case Operators.prefix: fix = "Operators.prefix"; break; 
  case Operators.infix: fix = "Operators.infix"; break; 
  case Operators.postfix: fix = "Operators.postfix"; break; 
  case Operators.nfix: fix = "Operators.nfix"; break; 
  default: assert(false); 
} 
String rep = String.format( 
  "    new Operator(%-16s %-4s %-4s %s, %s),", 
  "\"" + name.toString().replace("\\", "\\\\") + "\",", 
  String.valueOf(op.Low) + ",", 
  String.valueOf(op.High) + ",", 
  assoc, 
  fix 
  ); 
System.out.println(rep);
```