### PR TITLE
Support enabling action and variable coverage independently of more expensive formula and value coverage.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLCGlobals.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLCGlobals.java
@@ -262,4 +262,30 @@ public class TLCGlobals
 			return "unknown";
 		}
 	}
+	
+	public static final class Coverage {
+		
+		private static final int coverage = Integer.getInteger(TLCGlobals.class.getName() + ".coverage", 0);
+
+		public static boolean isVariableEnabled() {
+			if (isCoverageEnabled()) {
+				return true;
+			}
+			return (coverage & 2) > 0;
+		}
+
+		public static boolean isActionEnabled() {
+			if (isCoverageEnabled()) {
+				return true;
+			}
+			return (coverage & 1) > 0;
+		}
+
+		public static boolean isEnabled() {
+			if (isCoverageEnabled()) {
+				return true;
+			}
+			return coverage > 0;
+		}
+	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/AbstractChecker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/AbstractChecker.java
@@ -110,7 +110,7 @@ public abstract class AbstractChecker
         
         this.startTime = startTime;
 
-        if (TLCGlobals.isCoverageEnabled()) {
+        if (TLCGlobals.isCoverageEnabled() || TLCGlobals.Coverage.isEnabled()) {
         	CostModelCreator.create(this.tool);
         }
         

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
@@ -46,7 +46,7 @@ import util.UniqueString;
 public class ModelChecker extends AbstractChecker
 {
 
-	protected static final boolean coverage = TLCGlobals.isCoverageEnabled();
+	protected static final boolean ActionCoverage = TLCGlobals.Coverage.isActionEnabled();
 	/**
 	 * If the state/ dir should be cleaned up after a successful model run
 	 */
@@ -473,7 +473,7 @@ public class ModelChecker extends AbstractChecker
 		    // be in the trace in case either invariant or implied action
 		    // checks want to print the trace. 
 			worker.writeState(curState, fp, succState);
-			if (coverage) {
+			if (ActionCoverage) {
 				action.cm.incSecondary();
 			}
 		}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
@@ -82,7 +82,7 @@ import util.UniqueString;
  */
 public class SimulationWorker extends IdThread implements INextStateFunctor {
 
-	protected static final boolean coverage = TLCGlobals.isCoverageEnabled();
+	protected static final boolean coverage = TLCGlobals.Coverage.isActionEnabled();
 
 	// This worker's local source of randomness.
 	private final RandomGenerator localRng;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -143,7 +143,7 @@ public class Simulator {
 		// UniqueString#InternTable for every lookup. See AbstractChecker too.
 		this.config = createConfig();
 		
-		if (TLCGlobals.isCoverageEnabled()) {
+		if (TLCGlobals.isCoverageEnabled() || TLCGlobals.Coverage.isEnabled()) {
         	CostModelCreator.create(this.tool);
         }
 		

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
@@ -38,7 +38,8 @@ import util.WrongInvocationException;
 
 public final class Worker extends IdThread implements IWorker, INextStateFunctor {
 
-	protected static final boolean coverage = TLCGlobals.isCoverageEnabled();
+	protected static final boolean coverage = TLCGlobals.Coverage.isActionEnabled();
+	protected static final boolean variableCoverage = TLCGlobals.Coverage.isVariableEnabled();
 	private static final int INITIAL_CAPACITY = 16;
 	
 	/**
@@ -475,7 +476,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 				// nor implied actions are violated. It is thus eligible
 				// for further processing by other workers.
 				this.squeue.sEnqueue(succState);
-				if (coverage) { 
+				if (variableCoverage) { 
 					for (final OpDeclNode odn : TLCState.vars) {
 						odn.count(succState.lookup(odn.getName()));
 					}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/coverage/CostModelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/coverage/CostModelNode.java
@@ -39,8 +39,8 @@ public abstract class CostModelNode implements CostModel {
 	// order when reporting coverage. Thus, use LinkedHashMap here.
 	protected final Map<SemanticNode, CostModelNode> children = new LinkedHashMap<>();
 
-	protected final CounterStatistic stats = CounterStatistic.getInstance(() -> TLCGlobals.isCoverageEnabled());
-	protected final CounterStatistic secondary = CounterStatistic.getInstance(() -> TLCGlobals.isCoverageEnabled());
+	protected final CounterStatistic stats = CounterStatistic.getInstance(() -> TLCGlobals.isCoverageEnabled() || TLCGlobals.Coverage.isEnabled());
+	protected final CounterStatistic secondary = CounterStatistic.getInstance(() -> TLCGlobals.isCoverageEnabled() || TLCGlobals.Coverage.isEnabled());
 	
 	// ---------------- Statistics ---------------- //
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ActionItemList.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ActionItemList.java
@@ -11,7 +11,7 @@ import tlc2.tool.coverage.CostModel;
 import tlc2.util.Context;
 
 class ActionItemList implements IActionItemList {
-	protected static final boolean coverage = TLCGlobals.isCoverageEnabled();
+	protected static final boolean coverage = TLCGlobals.Coverage.isActionEnabled();
 	/**
    * We assume that this.pred is null iff the list is empty.
    */

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -525,6 +525,8 @@ public abstract class Tool
 		if (acts.isEmpty()) {
 			if (coverage) {
 				cm.incInvocations();
+			}
+			if (TLCGlobals.Coverage.isActionEnabled()) {
 				cm.getRoot().incInvocations();
 			}
 			states.addElement(ps.copy().setAction(acts.getAction()));


### PR DESCRIPTION
Action and variable coverage will not be reported on the command-line as like TLC's other coverage information, but exclusively as part of `TLCGet("spec")`.

[Feature][TLC]