### PR TITLE
Add TLC hook to periodically evaluate a constant-level expression.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
@@ -70,6 +70,7 @@ public class ModelConfig implements ValueConstants, Serializable {
     private static final String Props = "PROPERTIES";
     private static final String Alias = "ALIAS";
     private static final String PostCondition = "POSTCONDITION";
+    private static final String Periodic = "_PERIODIC";
     private static final String RLReward = "_RL_REWARD";
     public static final String CheckDeadlock = "CHECK_DEADLOCK";
 
@@ -80,7 +81,7 @@ public class ModelConfig implements ValueConstants, Serializable {
      */
     public final static String[] ALL_KEYWORDS = { Constant, Constants, Constraint, Constraints, ActionConstraint,
             ActionConstraints, Invariant, Invariants, Init, Next, View, Symmetry, Spec, Prop, Props, Alias,
-            PostCondition, RLReward, CheckDeadlock };
+            PostCondition, Periodic, RLReward, CheckDeadlock };
 
     private Hashtable configTbl;
     private Hashtable<String, String> overrides;
@@ -135,6 +136,7 @@ public class ModelConfig implements ValueConstants, Serializable {
         this.configTbl.put(Props, temp);
         this.configTbl.put(Alias, "");
         this.configTbl.put(PostCondition, "");
+        this.configTbl.put(Periodic, "");
         this.configTbl.put(RLReward, "");
         this.configTbl.put(CheckDeadlock, "undef");
         
@@ -270,6 +272,21 @@ public class ModelConfig implements ValueConstants, Serializable {
                     {
                         throw new ConfigFileException(EC.CFG_TWICE_KEYWORD, new String[] { String.valueOf(loc),
                                 PostCondition });
+                    }
+                    tt = getNextToken(tmgr);
+                } else if (tval.equals(Periodic))
+                {
+                    tt = getNextToken(tmgr);
+                    if (tt.kind == TLAplusParserConstants.EOF)
+                    {
+                        throw new ConfigFileException(EC.CFG_MISSING_ID, new String[] { String.valueOf(loc),
+                        		Periodic });
+                    }
+                    String old = (String) this.configTbl.put(Periodic, tt.image);
+                    if (old.length() != 0)
+                    {
+                        throw new ConfigFileException(EC.CFG_TWICE_KEYWORD, new String[] { String.valueOf(loc),
+                        		Periodic });
                     }
                     tt = getNextToken(tmgr);
                 } else if (tval.equals(RLReward))
@@ -732,6 +749,11 @@ public class ModelConfig implements ValueConstants, Serializable {
     public synchronized final String getPostCondition()
     {
         return (String) this.configTbl.get(PostCondition);
+    }
+
+    public synchronized final String getPeriodic()
+    {
+        return (String) this.configTbl.get(Periodic);
     }
 
 	public synchronized final String getRLReward() {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
@@ -182,6 +182,10 @@ abstract class Spec
 	public final ExprNode getRLReward() {
 		return specProcessor.getRLReward();
 	}
+
+	public final ExprNode getPeriodic() {
+		return specProcessor.getPeriodic();
+	}
 	
     /* Get the initial state predicate of the specification.  */
 	public final Vect<Action> getInitStateSpec() {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -139,6 +139,7 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
     private ExprNode[] modelConstraints; // Model constraints
     private ExprNode[] actionConstraints; // Action constraints
     private ExprNode rlReward;
+    private ExprNode periodic;
     private ExprNode[] assumptions; // Assumpt	ions
     private boolean[] assumptionIsAxiom; // assumptionIsAxiom[i] is true iff assumptions[i]
                                            // is an AXIOM.  Added 26 May 2010 by LL
@@ -1047,6 +1048,8 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
         processActionConstraints();
         
         processRLReward();
+        
+        processPeriodic();
     }
 
     /** 
@@ -1533,6 +1536,25 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
         }
 	}
     
+	private void processPeriodic() {
+        String name = this.config.getPeriodic();
+        if (name.length() != 0)
+        {        	
+        	Object type = this.snapshot.get(name);
+        	if (type == null)
+        	{
+        		Assert.fail(EC.TLC_CONFIG_SPECIFIED_NOT_DEFINED, new String[] { "periodic", name });
+        	}
+        	OpDefNode def = (OpDefNode) type;
+        	if (def.getArity() != 0)
+        	{
+        		Assert.fail(EC.TLC_CONFIG_ID_REQUIRES_NO_ARG, new String[] { "periodic", name });
+        		
+        	}
+        	periodic = def.getBody();
+        }
+	}
+  
 	private void processActionConstraints() {
 	    Vect names = this.config.getActionConstraints();
 	    this.actionConstraints = new ExprNode[names.size()];
@@ -1927,6 +1949,10 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
 
 	public ExprNode getRLReward() {
 		return rlReward;
+	}
+
+	public ExprNode getPeriodic() {
+		return periodic;
 	}
 
 	public ExprNode[] getAssumptions() {


### PR DESCRIPTION
This hook can be set up using the (provisional) `_PERIODIC` keyword within the configuration file.

[Feature][TLC]