### PR TITLE
Parallelize unit tests

### DIFF
--- a/.github/scripts/parse-unit-test-output.py
+++ b/.github/scripts/parse-unit-test-output.py
@@ -3,7 +3,9 @@ This script parses the Ant unit test output and identifies tests which have
 failed. It then retrieves their error messages from the surefire runner log
 directory. It also prints out the longest-running unit tests, for possible
 action by maintainers. Finally, it detects whether any tests ran multiple
-times by accident.
+times by accident. Since the Ant JUnit target defines tests to run using an
+overlapping collection of include/exclude statements matching sets of files,
+it is certainly possible this could happen.
 
 The first argument should be a path to a file containing the captured output
 of the Ant unit tests. The second argument should be a path to the surefire

--- a/.github/scripts/parse-unit-test-output.py
+++ b/.github/scripts/parse-unit-test-output.py
@@ -2,28 +2,19 @@
 This script parses the Ant unit test output and identifies tests which have
 failed. It then retrieves their error messages from the surefire runner log
 directory. It also prints out the longest-running unit tests, for possible
-action by maintainers.
+action by maintainers. Finally, it detects whether any tests ran multiple
+times by accident.
 
 The first argument should be a path to a file containing the captured output
 of the Ant unit tests. The second argument should be a path to the surefire
 runner log directory.
 """
 
+from collections import Counter
 from dataclasses import dataclass
 import re
 import sys
 import xml.etree.ElementTree as ET
-
-example = '[junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.209 sec, Thread: 7, Class: pcal.CallGotoUnlabeledTest'
-pattern = re.compile(
-    '\[junit\] Tests run: (?P<run_count>\d+), '
-    + 'Failures: (?P<failure_count>\d+), '
-    + 'Errors: (?P<error_count>\d+), '
-    + 'Skipped: (?P<skip_count>\d+), '
-    + 'Time elapsed: (?P<runtime>\d+\.\d+) sec, '
-    + 'Thread: (?P<thread_id>\d+), '
-    + 'Class: (?P<test_name>.+)'
-)
 
 @dataclass
 class TestReport:
@@ -35,7 +26,38 @@ class TestReport:
     thread_id: int
     name: str
 
-def match_to_report(match):
+sequential_sample = '    [junit] Running tlc2.tool.distributed.DieHardDistributedTLCTest\n    [junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.053 sec'
+sequential_pattern = re.compile(
+    '\[junit\] Running (?P<test_name>[\w\.]+)$\s*'
+    + '\[junit\] Tests run: (?P<run_count>\d+), '
+    + 'Failures: (?P<failure_count>\d+), '
+    + 'Errors: (?P<error_count>\d+), '
+    + 'Skipped: (?P<skip_count>\d+), '
+    + 'Time elapsed: (?P<runtime>\d+\.\d+) sec',
+    flags=re.MULTILINE
+)
+def sequential_match_to_report(match):
+    return TestReport(
+        int(match.group('run_count')),
+        int(match.group('failure_count')),
+        int(match.group('error_count')),
+        int(match.group('skip_count')),
+        float(match.group('runtime')),
+        1,
+        match.group('test_name').strip()
+    )
+
+parallel_sample = '[junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.209 sec, Thread: 7, Class: pcal.CallGotoUnlabeledTest'
+parallel_pattern = re.compile(
+    '\[junit\] Tests run: (?P<run_count>\d+), '
+    + 'Failures: (?P<failure_count>\d+), '
+    + 'Errors: (?P<error_count>\d+), '
+    + 'Skipped: (?P<skip_count>\d+), '
+    + 'Time elapsed: (?P<runtime>\d+\.\d+) sec, '
+    + 'Thread: (?P<thread_id>\d+), '
+    + 'Class: (?P<test_name>[\w\.]+)'
+)
+def parallel_match_to_report(match):
     return TestReport(
         int(match.group('run_count')),
         int(match.group('failure_count')),
@@ -43,29 +65,42 @@ def match_to_report(match):
         int(match.group('skip_count')),
         float(match.group('runtime')),
         int(match.group('thread_id')),
-        match.group('test_name')
+        match.group('test_name').strip()
     )
 
 reports = []
 with open(sys.argv[1], 'r') as f:
-    reports = [
-        match_to_report(match)
-        for line in f
-        if (match := pattern.search(line)) is not None
+    text = f.read()
+    reports += [
+        parallel_match_to_report(match)
+        for match in re.finditer(parallel_pattern, text)
+    ]
+    reports += [
+        sequential_match_to_report(match)
+        for match in re.finditer(sequential_pattern, text)
     ]
 
 reports = sorted(reports, key=lambda report: report.runtime, reverse=True)
 failures = [report.name for report in reports if report.failure_count > 0]
+duplicates = [k for k, v in Counter(report.name for report in reports).items() if v > 1]
 
 print(f'Test count: {len(reports)}')
 print(f'Failure count: {len(failures)}')
-print('Longest-running tests:')
-for report in reports[slice(20)]:
-    print(f'{report.runtime:5.1f} sec | {report.name}')
+print(f'Tests run multiple times: {len(duplicates)}')
+if any(duplicates):
+    for duplicate in duplicates:
+        print(duplicate)
+
+print('\nLongest-running tests:')
+for i, report in enumerate(reports[slice(20)]):
+    print(f'{i+1:2d} | {report.runtime:5.1f} sec | {report.name}')
 
 def node_text(node):
     text = node.text
     return text.strip() if text is not None else None
+
+if not any(failures):
+    exit(0)
 
 print('\nFailures:\n')
 for test_name in failures:

--- a/.github/scripts/parse-unit-test-output.py
+++ b/.github/scripts/parse-unit-test-output.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+example = '[junit] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.209 sec, Thread: 7, Class: pcal.CallGotoUnlabeledTest'
+pattern = re.compile(
+    '\[junit\] Tests run: (?P<run_count>\d+), '
+    + 'Failures: (?P<failure_count>\d+), '
+    + 'Errors: (?P<error_count>\d+), '
+    + 'Skipped: (?P<skip_count>\d+), '
+    + 'Time elapsed: (?P<runtime>\d+\.\d+) sec, '
+    + 'Thread: (?P<thread_id>\d+), '
+    + 'Class: (?P<test_name>.+)'
+)
+
+@dataclass
+class TestReport:
+    run_count: int
+    failure_count: int
+    error_count: int
+    skip_count: int
+    runtime: float
+    thread_id: int
+    name: str
+
+def match_to_report(match):
+    return TestReport(
+        int(match.group('run_count')),
+        int(match.group('failure_count')),
+        int(match.group('error_count')),
+        int(match.group('skip_count')),
+        float(match.group('runtime')),
+        int(match.group('thread_id')),
+        match.group('test_name')
+    )
+
+reports = []
+with open(sys.argv[1], 'r') as f:
+    reports = [
+        match_to_report(match)
+        for line in f
+        if (match := pattern.search(line)) is not None
+    ]
+
+reports = sorted(reports, key=lambda report: report.runtime, reverse=True)
+
+print(f'Test count: {len(reports)}')
+
+def node_text(node):
+    text = node.text
+    return text.strip() if text is not None else None
+
+print('Failures:\n')
+failures = [report.name for report in reports if report.failure_count > 0]
+for test_name in failures:
+    print(f'TEST CLASS: {test_name}')
+    tree = ET.parse(f'{sys.argv[2]}/TEST-{test_name}.xml')
+    tree = next(tree.iter('testsuite'))
+    for test_case in tree.iter('testcase'):
+        print(f'TEST NAME: {test_case.attrib["name"]}')
+        for failure in test_case.iter('failure'):
+            print(f'FAILURE:\n{node_text(failure)}')
+    for output in tree.iter('system-out'):
+        print(f'SYSTEM.OUT:\n{node_text(output)}')
+    for err_output in tree.iter('system-err'):
+        print(f'SYSTEM.ERR:\n{node_text(err_output)}')
+    print()
+
+print('Longest-running tests:')
+for report in reports[slice(20)]:
+    print(f'{report.runtime:5.1f} sec | {report.name}')
+

--- a/.github/scripts/parse-unit-test-output.py
+++ b/.github/scripts/parse-unit-test-output.py
@@ -55,15 +55,19 @@ with open(sys.argv[1], 'r') as f:
     ]
 
 reports = sorted(reports, key=lambda report: report.runtime, reverse=True)
+failures = [report.name for report in reports if report.failure_count > 0]
 
 print(f'Test count: {len(reports)}')
+print(f'Failure count: {len(failures)}')
+print('Longest-running tests:')
+for report in reports[slice(20)]:
+    print(f'{report.runtime:5.1f} sec | {report.name}')
 
 def node_text(node):
     text = node.text
     return text.strip() if text is not None else None
 
-print('Failures:\n')
-failures = [report.name for report in reports if report.failure_count > 0]
+print('\nFailures:\n')
 for test_name in failures:
     print(f'TEST CLASS: {test_name}')
     tree = ET.parse(f'{sys.argv[2]}/TEST-{test_name}.xml')
@@ -77,8 +81,4 @@ for test_name in failures:
     for err_output in tree.iter('system-err'):
         print(f'SYSTEM.ERR:\n{node_text(err_output)}')
     print()
-
-print('Longest-running tests:')
-for report in reports[slice(20)]:
-    print(f'{report.runtime:5.1f} sec | {report.name}')
 

--- a/.github/scripts/parse-unit-test-output.py
+++ b/.github/scripts/parse-unit-test-output.py
@@ -1,3 +1,14 @@
+"""
+This script parses the Ant unit test output and identifies tests which have
+failed. It then retrieves their error messages from the surefire runner log
+directory. It also prints out the longest-running unit tests, for possible
+action by maintainers.
+
+The first argument should be a path to a file containing the captured output
+of the Ant unit tests. The second argument should be a path to the surefire
+runner log directory.
+"""
+
 from dataclasses import dataclass
 import re
 import sys

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,9 +19,7 @@ jobs:
         java-version: 11.0.3
     - name: Build & Test Tools
       run: |
-        ant -f tlatools/org.lamport.tlatools/customBuild.xml  \
-          compile compile-test test dist                      \
-          2>&1 | tee test-output.txt
+        ant -f tlatools/org.lamport.tlatools/customBuild.xml compile compile-test test dist 2>&1 | tee test-output.txt
         echo "export BUILD_UT_EXIT_CODE=$?" >> $GITHUB_ENV
     - name: Summarize Unit Tests
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         python .github/scripts/parse-unit-test-output.py        \
           test-output.txt                                       \
-          tlatools/org.lamport.tlatools/target/surefire-report
+          tlatools/org.lamport.tlatools/target/surefire-reports
         exit $BUILD_UT_EXIT_CODE
     - name: Clone tlaplus/CommunityModules
       uses: actions/checkout@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,17 @@ jobs:
         distribution: adopt
         java-version: 11.0.3
     - name: Build & Test Tools
-      run: ant -f tlatools/org.lamport.tlatools/customBuild.xml -Dtest.halt=true compile compile-test test dist
+      run: |
+        ant -f tlatools/org.lamport.tlatools/customBuild.xml  \
+          compile compile-test test dist                      \
+          2>&1 | tee test-output.txt
+        echo "export BUILD_UT_EXIT_CODE=$?" >> $GITHUB_ENV
+    - name: Summarize Unit Tests
+      run: |
+        python .github/scripts/parse-unit-test-output.py        \
+          test-output.txt                                       \
+          tlatools/org.lamport.tlatools/target/surefire-report
+        exit $BUILD_UT_EXIT_CODE
     - name: Clone tlaplus/CommunityModules
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,6 +19,7 @@ jobs:
         java-version: 11.0.3
     - name: Build & Test Tools
       run: |
+        set -o pipefail
         ant -f tlatools/org.lamport.tlatools/customBuild.xml compile compile-test test dist 2>&1 | tee test-output.txt
         echo "export BUILD_UT_EXIT_CODE=$?" >> $GITHUB_ENV
     - name: Summarize Unit Tests

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -463,14 +463,14 @@
 
 	<!-- Executes accompanying unit tests -->
 	<target name="test" unless="test.skip">
-    <property runtime="runtime"/>
+		<property runtime="runtime"/>
 		<!-- run junit tests -->
 		<mkdir dir="${test.reports}" />
 		<!-- forkmode used to be "perBatch" on Java 1.8 using the util.IsolatedTestCaseRunner.
 		     This concept broken with Java11 for unknown reasons which is why forkmode has been
 		     changed to perTest to run each test in a separate VM.  This is slower compared to
 		     running all tests in a single VM. -->
-    <junit printsummary="yes" haltonfailure="${test.halt}" showoutput="no" haltonerror="${test.halt}"  forkmode="perTest" fork="yes" threads="${runtime.availableProcessors}">
+		<junit printsummary="yes" haltonfailure="${test.halt}" showoutput="no" haltonerror="${test.halt}"  forkmode="perTest" fork="yes" threads="${runtime.availableProcessors}">
 			<!-- enable all assertions -->
 			<jvmarg value="-ea"/>
 			<jvmarg value="-XX:MaxDirectMemorySize=512k"/>

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -572,12 +572,40 @@
 			<sysproperty key="tlc2.tool.fp.FPSet.impl" value="tlc2.tool.fp.OffHeapDiskFPSet"/>
 			<sysproperty key="util.FileUtil.milliseconds" value="true"/>
 			<sysproperty key="tlc2.tool.distributed.TLCWorker.threadCount" value="1"/>
+			<batchtest fork="yes" todir="${test.reports}">
+				<fileset dir="${test.dir}">
+					<!-- Put longer-running tests first -->
+					<include name="tlc2/tool/suite/Test27.java" />
+					<include name="tlc2/tool/fp/OffHeapDiskFPSetTest.java" />
+					<include name="tlc2/tool/liveness/CodePlexBug08EWD840FL2Test.java" />
+					<include name="tlc2/value/impl/SetOfRcrdValueTest.java" />
+					<include name="tlc2/tool/InliningTest.java" />
+					<include name="tlc2/tool/suite/Test19.java" />
+					<include name="pcal/FastMutexWithGoto2Test.java" />
+					<include name="tlc2/tool/BugzillaBug279Test.java" />
+					<include name="tlc2/tool/liveness/CodePlexBug08EWD840FL1Test.java" />
+					<include name="tlc2/value/impl/SetOfFcnsValueTest.java" />
+				</fileset>
+			</batchtest>
 			<!-- The tests below can be tricked into running in a single VM by fiddling with the classloader 
 			     to reload and thus initialize all classes for each tests. -->
 			<batchtest fork="yes" todir="${test.reports}">
 				<fileset dir="${test.dir}">
+					<!-- Include all files under tests dir with Test in name -->
 					<include name="**/*Test*.java" />
 					
+					<!-- Skip longer-running tests, these already ran above -->
+					<exclude name="tlc2/tool/suite/Test27.java" />
+					<exclude name="tlc2/tool/fp/OffHeapDiskFPSetTest.java" />
+					<exclude name="tlc2/tool/liveness/CodePlexBug08EWD840FL2Test.java" />
+					<exclude name="tlc2/value/impl/SetOfRcrdValueTest.java" />
+					<exclude name="tlc2/tool/InliningTest.java" />
+					<exclude name="tlc2/tool/suite/Test19.java" />
+					<exclude name="pcal/FastMutexWithGoto2Test.java" />
+					<exclude name="tlc2/tool/BugzillaBug279Test.java" />
+					<exclude name="tlc2/tool/liveness/CodePlexBug08EWD840FL1Test.java" />
+					<exclude name="tlc2/value/impl/SetOfFcnsValueTest.java" />
+
 					<!-- Produce bogus crash with Quarantine runner. -->
 					<exclude name="tlc2/tool/distributed/TLCSetTest.java" />
 					<exclude name="tlc2/tool/distributed/DistributedDoInitFunctorEvalExceptionTest.java" />
@@ -652,12 +680,6 @@
 			<batchtest fork="yes" todir="${test.reports}">
 				<fileset dir="${test.dir}">
 					<include name="tlc2/tool/UserModuleOverrideTest.java" />
-				</fileset>
-			</batchtest>
-			<batchtest fork="yes" todir="${test.reports}">
-				<fileset dir="${test.dir}">
-					<include name="tlc2/TLCTest.java"/>
-					<include name="tlc2/tool/fp/OffHeapDiskFPSetTest.java"/>
 				</fileset>
 			</batchtest>
 		</junit>

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -463,13 +463,14 @@
 
 	<!-- Executes accompanying unit tests -->
 	<target name="test" unless="test.skip">
+    <property runtime="runtime"/>
 		<!-- run junit tests -->
 		<mkdir dir="${test.reports}" />
 		<!-- forkmode used to be "perBatch" on Java 1.8 using the util.IsolatedTestCaseRunner.
 		     This concept broken with Java11 for unknown reasons which is why forkmode has been
 		     changed to perTest to run each test in a separate VM.  This is slower compared to
 		     running all tests in a single VM. -->
-		<junit printsummary="yes" haltonfailure="${test.halt}" showoutput="no" haltonerror="${test.halt}"  forkmode="perTest" fork="yes">
+    <junit printsummary="yes" haltonfailure="${test.halt}" showoutput="no" haltonerror="${test.halt}"  forkmode="perTest" fork="yes" threads="${runtime.availableProcessors}">
 			<!-- enable all assertions -->
 			<jvmarg value="-ea"/>
 			<jvmarg value="-XX:MaxDirectMemorySize=512k"/>

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -481,6 +481,19 @@
 			<classpath>
 				<pathelement location="lib/junit-4.12.jar" />
 				<pathelement location="lib/hamcrest-core-1.3.jar" />
+				<pathelement location="lib/cglib-nodep-3.1.jar" />
+				<pathelement location="lib/objenesis-2.1.jar" />
+				<pathelement location="lib/easymock-3.3.1.jar" />
+				<pathelement location="lib/javax.mail/mailapi-1.6.3.jar" />
+				<pathelement location="lib/jline/jline-terminal-3.25.0.jar" />
+				<pathelement location="lib/jline/jline-console-3.25.0.jar" />
+				<pathelement location="lib/jline/jline-builtins-3.25.0.jar" />
+				<pathelement location="lib/jline/jline-reader-3.25.0.jar" />
+				<pathelement location="lib/gson/gson-2.8.6.jar" />
+				<pathelement location="lib/lsp/org.eclipse.lsp4j.debug_0.21.1.v20230829-0012.jar"/>
+				<pathelement location="lib/lsp/org.eclipse.lsp4j.jsonrpc_0.21.1.v20230829-0012.jar"/>
+				<pathelement location="lib/lsp/org.eclipse.lsp4j.jsonrpc.debug_0.21.1.v20230829-0012.jar"/>
+				<pathelement location="test-model/UserModuleOverrideFromJar.jar" />
 				<pathelement path="${class.dir}" />
 				<pathelement path="${test.class.dir}" />
 				<pathelement path="test-model/" />

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -461,8 +461,51 @@
 		</copy>
 	</target>
 
-	<!-- Executes accompanying unit tests -->
-	<target name="test" unless="test.skip">
+	<!-- Unit tests which due to their nature cannot be run in parallel. -->
+	<target name="sequential-test" unless="test.skip">
+		<property runtime="runtime"/>
+		<mkdir dir="${test.reports}" />
+		<junit
+			printsummary="yes"
+			showoutput="no"
+			haltonfailure="${test.halt}"
+			haltonerror="${test.halt}"
+			failureproperty="sequential-test.failed"
+			forkmode="perTest"
+			fork="yes"
+			threads="1"
+		>
+			<jvmarg value="-ea"/>
+			<jvmarg value="-XX:MaxDirectMemorySize=512k"/>
+			<jvmarg value="-XX:+UseParallelGC"/>
+			<classpath>
+				<pathelement location="lib/junit-4.12.jar" />
+				<pathelement location="lib/hamcrest-core-1.3.jar" />
+				<pathelement path="${class.dir}" />
+				<pathelement path="${test.class.dir}" />
+				<pathelement path="test-model/" />
+			</classpath>
+			<formatter type="xml" />
+			<sysproperty key="basedir" value="${basedir}/"/>
+			<sysproperty key="tlc2.tool.fp.FPSet.impl" value="tlc2.tool.fp.OffHeapDiskFPSet"/>
+			<sysproperty key="util.FileUtil.milliseconds" value="true"/>
+			<sysproperty key="tlc2.tool.distributed.TLCWorker.threadCount" value="${runtime.availableProcessors}"/>
+			<!-- Distributed TLC tests must be run sequentially because they bind
+					 exclusively to a port on the system. -->
+			<batchtest fork="yes" todir="${test.reports}">
+				<fileset dir="${test.dir}">
+					<include name="tlc2/tool/distributed/**/*Test*.java" />
+					<!-- These fail for some reason. -->
+					<exclude name="**/DistributedTLCTestCase.java" />
+					<exclude name="**/TLCServerTestCase.java" />
+				</fileset>
+			</batchtest>
+		</junit>
+		<fail message="Sequential unit test failures." if="sequential-test.failed" />
+	</target>
+
+	<!-- Executes unit tests in parallel. -->
+	<target name="test" unless="test.skip" depends="sequential-test">
 		<property runtime="runtime"/>
 		<!-- run junit tests -->
 		<mkdir dir="${test.reports}" />
@@ -470,7 +513,16 @@
 		     This concept broken with Java11 for unknown reasons which is why forkmode has been
 		     changed to perTest to run each test in a separate VM.  This is slower compared to
 		     running all tests in a single VM. -->
-		<junit printsummary="yes" haltonfailure="${test.halt}" showoutput="no" haltonerror="${test.halt}"  forkmode="perTest" fork="yes" threads="${runtime.availableProcessors}">
+		<junit
+			printsummary="yes"
+			showoutput="no"
+			haltonfailure="${test.halt}"
+			haltonerror="${test.halt}"
+			failureproperty="unit-test.failed"
+			forkmode="perTest"
+			fork="yes"
+			threads="${runtime.availableProcessors}"
+		>
 			<!-- enable all assertions -->
 			<jvmarg value="-ea"/>
 			<jvmarg value="-XX:MaxDirectMemorySize=512k"/>
@@ -506,7 +558,7 @@
 			<sysproperty key="basedir" value="${basedir}/"/>
 			<sysproperty key="tlc2.tool.fp.FPSet.impl" value="tlc2.tool.fp.OffHeapDiskFPSet"/>
 			<sysproperty key="util.FileUtil.milliseconds" value="true"/>
-			<sysproperty key="tlc2.tool.distributed.TLCWorker.threadCount" value="4"/>
+			<sysproperty key="tlc2.tool.distributed.TLCWorker.threadCount" value="1"/>
 			<!-- The tests below can be tricked into running in a single VM by fiddling with the classloader 
 			     to reload and thus initialize all classes for each tests. -->
 			<batchtest fork="yes" todir="${test.reports}">
@@ -523,6 +575,8 @@
 					<exclude name="tlc2/tool/UserModuleOverrideTest.java" />
 					<exclude name="tlc2/tool/UserModuleOverrideFromJarTest.java" />
 					<exclude name="tlc2/tool/UserModuleOverrideAnnotationTest.java" />
+					<!-- Bind to a port on the system so cannot be run in parallel. -->
+					<exclude name="tlc2/tool/distributed/**/*Test*.java" />
 					
 					<exclude name="**/PCalTest.java" />
 					<exclude name="**/SANYTest.java" />
@@ -536,8 +590,6 @@
 					<exclude name="**/TraceExpressionSpecSafetyTest.java" />
 					<exclude name="**/SuiteTestCase.java" />
 					<exclude name="**/SuiteETestCase.java" />
-					<exclude name="**/DistributedTLCTestCase.java" />
-					<exclude name="**/TLCServerTestCase.java" />
 					<exclude name="**/SuccessfulSimulationTestCase.java" />
 					<exclude name="**/AbstractExampleTestCase.java" />
 					<exclude name="**/AbstractCoverageTest.java" />
@@ -591,16 +643,6 @@
 			</batchtest>
 			<batchtest fork="yes" todir="${test.reports}">
 				<fileset dir="${test.dir}">
-					<include name="tlc2/tool/distributed/TLCSetTest.java" />
-				</fileset>
-			</batchtest>
-			<batchtest fork="yes" todir="${test.reports}">
-				<fileset dir="${test.dir}">
-					<include name="tlc2/tool/distributed/DistributedDoInitFunctorEvalExceptionTest.java" />
-				</fileset>
-			</batchtest>
-			<batchtest fork="yes" todir="${test.reports}">
-				<fileset dir="${test.dir}">
 					<include name="tlc2/TLCTest.java"/>
 					<include name="tlc2/tool/fp/OffHeapDiskFPSetTest.java"/>
 				</fileset>
@@ -609,6 +651,7 @@
 
 		<!-- remove copied class.dir -->
 		<delete dir="${ws.class.dir}" deleteonexit="true"/>
+		<fail message="Unit test failures." if="unit-test.failed" />
 	</target>
 
 	<!-- Executes a given set of unit test. -->

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/ModelCheckerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/ModelCheckerTestCase.java
@@ -135,7 +135,7 @@ public abstract class ModelCheckerTestCase extends CommonTestCase {
 			final List<String> args = new ArrayList<String>(6);
 			
 			args.add("-metadir");
-			args.add(getClass().getCanonicalName());
+			args.add(TLCGlobals.metaRoot + FileUtil.separator + getClass().getCanonicalName());
 			
 			// *Don't* check for deadlocks. All tests are interested in liveness
 			// checks which are shielded away by deadlock checking. TLC finds a

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/ModelCheckerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/ModelCheckerTestCase.java
@@ -134,6 +134,9 @@ public abstract class ModelCheckerTestCase extends CommonTestCase {
 			// is placed in TEST_MODEL
 			final List<String> args = new ArrayList<String>(6);
 			
+			args.add("-metadir");
+			args.add(getClass().getCanonicalName());
+			
 			// *Don't* check for deadlocks. All tests are interested in liveness
 			// checks which are shielded away by deadlock checking. TLC finds a
 			// deadlock (if it exists) before it finds most liveness violations.

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
@@ -49,11 +49,6 @@ public class SimulationWorkerTest extends CommonTestCase {
 		ToolIO.setUserDir(BASE_PATH + File.separator + "simulation" + File.separator + "BasicMultiTrace");
 	}
 	
-	@After
-	public void tearDown() throws Exception{
-        FileUtil.deleteDir(TLCGlobals.metaRoot, true);
-	}
-	
 	/**
 	 * Return a value from a TLCState as a string.
 	 */

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulatorTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulatorTest.java
@@ -45,11 +45,6 @@ public class SimulatorTest extends CommonTestCase {
 		FP64.Init();
 	}
 	
-	@After
-	public void tearDown() throws Exception{
-        FileUtil.deleteDir(TLCGlobals.metaRoot, true);
-	}
-	
 	/**
 	 * The number of threads to run the Simulator with. Can be overridden by
 	 * sub-classes that want to test with different values.


### PR DESCRIPTION
This was actually easier than expected (edit: it was not easier than expected). Somehow I missed that the JUnit task has a `threads` parameter. I guess this is a newer addition which is why not a lot of documentation mentions it. Now the unit test target will run with number of threads equal to available cores on the machine. Decent improvement, unit tests finish in less than 10 minutes now which puts them below the time of the tlaplus/examples integration tests! There were a few small changes I had to make to some tests to ensure they don't interfere with each other with operations on the `states` metadir.

I also added a useful python script to run during the CI after the tests; it:
- Prints the total number of tests and total number of failed tests
- Prints out any tests that were run multiple times by mistake
- Prints out the top-20 longest-running tests and their runtimes
- If any tests failed, fetches all the error info from the xml file in the surefire runner directory and prints it to console

I made the following changes to the ant build:
- Added a separate sequential unit test target that runs before the parallelized unit test target, for tests which cannot be parallelized for whatever reason (exclusively bind to a system network port or something).
- Ensure all unit tests run even if some fail by not passing in the `-Dtest.halt=true` parameter; previously the tests would stop at the first failure, which IMO is not as useful for debugging. This necessitated adding a conditional `fail` target under the test targets, which activates when `failureproperty` is set in the `junit` target. This ensures the CI still fails with nonzero exit code upon any failures.
- Moved the longest-running tests first so their execution is covered by the concurrent execution of other tests and doesn't singlehandedly cause the unit tests to run for an additional minute or whatever.

I ran this workflow locally on my 8-thread workstation over 10 times so I have fairly high confidence there aren't any other concurrency failures lurking.

Closes #901