### PR TITLE
Fix `OffHeapDiskFPSetTest.testWriteIndex()` on Java 21

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/OffHeapDiskFPSetTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/OffHeapDiskFPSetTest.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2016 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2024, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -323,8 +324,19 @@ public class OffHeapDiskFPSetTest {
 		}
 
 		@Override
-		public int read() throws IOException {
+		public int read() {
 			return 0;
+		}
+
+		@Override
+		public int read(byte[] b) {
+			return read(b, 0, b.length);
+		}
+
+		@Override
+		public int read(byte[] b, int off, int len) {
+			Arrays.fill(b, off, off + len, (byte)0);
+			return len;
 		}
 	}
 }


### PR DESCRIPTION
Related to #835, but not a complete fix.

----

In Java 21 the various `RandomAccessFile` read methods like `readLong()` are now implemented using bulk array reads, not single-byte reads.  Therefore, `DummyRandomAccessFile` needs to implement those methods if it is to function as intended.
