### PR TITLE
'constrained' states not added to e.g. dot output if TLC runs under TLA+

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/DebugTool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/DebugTool.java
@@ -673,6 +673,17 @@ public class DebugTool extends Tool {
 		public SetOfStates getStates() {
 			return functor.getStates();
 		}
+
+		@Override
+		public TLCState addUnsatisfiedState(TLCState curState, Action action, TLCState succState, SemanticNode pred,
+				Context c) {
+			return this.functor.addUnsatisfiedState(curState, action, succState, pred, c);
+		}
+
+		@Override
+		public TLCState addUnsatisfiedState(TLCState state, SemanticNode pred, Context c) {
+			return this.functor.addUnsatisfiedState(state, pred, c);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
debugger.

Related to git commit c2713def38aa1d3255a6c2fe2aa037253e00e361

Have DebugTool implement INotInModelFunctor.

[Bug][TLC]