### PR TITLE
Make pcal.trans unicode-safe

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,9 +93,10 @@ jobs:
           - unicode: true
           - unicode: false
     env:
-      EXAMPLES_DIR: examples
-      SCRIPT_DIR: examples/.github/scripts
-      DEPS_DIR: examples/deps
+      EXAMPLES_DIR: "examples"
+      SCRIPT_DIR: "examples/.github/scripts"
+      DEPS_DIR: "examples/deps"
+      DIST_DIR: "tlatools/org.lamport.tlatools/dist"
     steps:
     - name: Clone tlaplus/tlaplus
       uses: actions/checkout@v4
@@ -146,11 +147,11 @@ jobs:
             "specifications/SpecifyingSystems/RealTime/MCRealTimeHourClock.tla"
           )
         fi
-        python "$SCRIPT_DIR/parse_modules.py"                               \
-          --tools_jar_path tlatools/org.lamport.tlatools/dist/tla2tools.jar \
-          --tlapm_lib_path "$DEPS_DIR/tlapm/library"                        \
-          --community_modules_jar_path "$DEPS_DIR/community/modules.jar"    \
-          --manifest_path "$EXAMPLES_DIR/manifest.json"                     \
+        python "$SCRIPT_DIR/parse_modules.py"                             \
+          --tools_jar_path "$DIST_DIR/tla2tools.jar"                      \
+          --tlapm_lib_path "$DEPS_DIR/tlapm/library"                      \
+          --community_modules_jar_path "$DEPS_DIR/community/modules.jar"  \
+          --manifest_path "$EXAMPLES_DIR/manifest.json"                   \
           --skip "${SKIP[@]}"
     - name: Model-check small tlaplus/examples models
       run: |
@@ -160,21 +161,21 @@ jobs:
           # This redefines Real so cannot be shimmed
           SKIP+=("specifications/SpecifyingSystems/RealTime/MCRealTimeHourClock.cfg")
         fi
-        python "$SCRIPT_DIR/check_small_models.py"                          \
-          --tools_jar_path tlatools/org.lamport.tlatools/dist/tla2tools.jar \
-          --tlapm_lib_path "$DEPS_DIR/tlapm/library"                        \
-          --community_modules_jar_path "$DEPS_DIR/community/modules.jar"    \
-          --manifest_path "$EXAMPLES_DIR/manifest.json"                     \
+        python "$SCRIPT_DIR/check_small_models.py"                        \
+          --tools_jar_path "$DIST_DIR/tla2tools.jar"                      \
+          --tlapm_lib_path "$DEPS_DIR/tlapm/library"                      \
+          --community_modules_jar_path "$DEPS_DIR/community/modules.jar"  \
+          --manifest_path "$EXAMPLES_DIR/manifest.json"                   \
           --skip "${SKIP[@]}"
     - name: Smoke-test large tlaplus/examples models
       run: |
         # SimKnuthYao requires certain number of states to have been generated
         # before termination or else it fails. This makes it not amenable to
         # smoke testing.
-        python "$SCRIPT_DIR/smoke_test_large_models.py"                     \
-          --tools_jar_path tlatools/org.lamport.tlatools/dist/tla2tools.jar \
-          --tlapm_lib_path "$DEPS_DIR/tlapm/library"                        \
-          --community_modules_jar_path "$DEPS_DIR/community/modules.jar"    \
-          --manifest_path "$EXAMPLES_DIR/manifest.json"                     \
+        python "$SCRIPT_DIR/smoke_test_large_models.py"                   \
+          --tools_jar_path "$DIST_DIR/tla2tools.jar"                      \
+          --tlapm_lib_path "$DEPS_DIR/tlapm/library"                      \
+          --community_modules_jar_path "$DEPS_DIR/community/modules.jar"  \
+          --manifest_path "$EXAMPLES_DIR/manifest.json"                   \
           --skip "specifications/KnuthYao/SimKnuthYao.cfg"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -131,6 +131,12 @@ jobs:
         python "$SCRIPT_DIR/unicode_number_set_shim.py" \
           --ts_path "$DEPS_DIR/tree-sitter-tlaplus"     \
           --manifest_path "$EXAMPLES_DIR/manifest.json"
+    - name: Translate PlusCal
+      if: (!matrix.unicode)
+      run: |
+        python $SCRIPT_DIR/translate_pluscal.py         \
+          --tools_jar_path "$DIST_DIR/tla2tools.jar"    \
+          --manifest_path "$EXAMPLES_DIR/manifest.json"
     - name: Parse tlaplus/examples modules
       run: |
         # Need to have a nonempty list to pass as a skip parameter

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalBuiltInSymbols.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalBuiltInSymbols.java
@@ -87,8 +87,8 @@ public final class PcalBuiltInSymbols
       { return prefixHashTable.containsKey(str) ;
       } ;
 
-    public static boolean IsStringChar(char ch)
-      { return stringCharTable.containsKey("" + ch) ;
+    public static boolean IsStringChar(String ch)
+      { return stringCharTable.containsKey(ch) ;
       } ;
 
     private static void buildStringCharTable() 

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalCharReader.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalCharReader.java
@@ -36,12 +36,12 @@ class PcalCharReader
   { /***********************************************************************
     * The variables representing the state of the object.                  *
     ***********************************************************************/
-    private Vector vec ;
+    private Vector<String> vec ;
       /*********************************************************************
       * This is the vector providing the input characters.                 *
       *********************************************************************/
 
-    private String currentLine = null ;
+    private int[] currentLine = null ;
       /*********************************************************************
       * The current line of input, or null if at the end of the input.     *
       *********************************************************************/
@@ -72,7 +72,17 @@ class PcalCharReader
       * and the next getNextChar should return a space generated from      *
       * that tab.                                                          *
       *********************************************************************/
-
+    
+    /**
+     * Converts a string into a list of codepoints.
+     * 
+     * @param input The string to convert.
+     * @return A list of the codepoints comprising the string.
+     */
+    private static int[] stringToCodepoints(String input) {
+        return input.codePoints().toArray();
+    }
+    
     /***********************************************************************
     * The methods.                                                         *
     ***********************************************************************/
@@ -92,7 +102,7 @@ class PcalCharReader
       *********************************************************************/
       { return vcolumn ; } ;
 
-    public char getNextChar()
+    public int getNextChar()
       /*********************************************************************
       * Returns the next character in the input stream and updates the     *
       * line and column numbers.  However, it replaces each '\t' (tab) in  *
@@ -131,13 +141,13 @@ class PcalCharReader
         * return '\n' after updating the line and column and reading in    *
         * the next line.                                                   *
         *********************************************************************/
-        if (currentLine.length() == column) 
+        if (currentLine.length == column) 
           { line        = line + 1 ;
             column      = 0 ;
             vcolumn     = 0 ;
             if (line >= vec.size())
                  {currentLine = null ;}
-            else {currentLine = (String) vec.elementAt(line) ;} ;
+            else {currentLine = stringToCodepoints(vec.elementAt(line)) ;} ;
             return '\n' ;
            } ;
   
@@ -146,7 +156,7 @@ class PcalCharReader
         * converting a tab to space.  Update column and vcolumn, and       *
         * return the next character.                                       *
         *******************************************************************/
-        char readChar = currentLine.charAt(column) ;
+        int readChar = currentLine[column] ;
         column = column + 1;
         vcolumn = vcolumn + 1;
         if (readChar == '\t')
@@ -178,7 +188,7 @@ class PcalCharReader
                   "move past beginning of reader");
              } ;
            line = line - 1 ;
-           currentLine = (String) vec.elementAt(line) ;
+           currentLine = stringToCodepoints(vec.elementAt(line)) ;
            column = 0 ;
            vcolumn = 0 ;
 
@@ -186,8 +196,8 @@ class PcalCharReader
            * Need to move forward from the first character of the line in  *
            * case there are tabs.                                          *
            ****************************************************************/
-           while (column < currentLine.length() - 1)
-             { char c = getNextChar() ; }
+           while (column < currentLine.length - 1)
+             { getNextChar() ; }
          }
         else
          { column = column - 1;
@@ -205,7 +215,7 @@ class PcalCharReader
       ***************************************************************/
       { 
 // System.out.println("Peek called at line = " + line + ", col = " + column);
-        char next = getNextChar() ;
+        int next = getNextChar() ;
         while (   (next == ' ')
                || (next == '\n'))
            { next = getNextChar() ;} ;
@@ -213,10 +223,10 @@ class PcalCharReader
           { return "\t" ;} ;
         backspace() ;
 // System.out.println("Peek returns `" +  currentLine.substring(column) + "' at line = " + line + ", col = " + column);
-        return currentLine.substring(column) + "\n" ;
+        return new String(currentLine, column, currentLine.length - column) + '\n' ;
       }
       
-    public PcalCharReader(Vector vector, int firstLine, int firstCol,
+    public PcalCharReader(Vector<String> vector, int firstLine, int firstCol,
                             int lastLine, int lastCol) 
       /*********************************************************************
       * The class constructor.  The only tricky part is setting vcolumn    *
@@ -246,6 +256,6 @@ class PcalCharReader
         * Set currentLine.                                                 *
         *******************************************************************/
         if (firstLine < vector.size())
-          { this.currentLine = (String) vector.elementAt(firstLine) ; } ;
+          { this.currentLine = stringToCodepoints(vector.elementAt(firstLine)) ; } ;
       } ;
   }     

--- a/tlatools/org.lamport.tlatools/src/pcal/Tokenize.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/Tokenize.java
@@ -444,7 +444,7 @@ public class Tokenize
           * line.                                                          *
           *****************************************************************/
 
-    private static char nextChar ;
+    private static int nextChar ;
           /*****************************************************************
           * nextChar is the next input character to be processed.          *
           *****************************************************************/
@@ -593,7 +593,7 @@ public class Tokenize
       * Appends nextChar to token, sets nextChar to the next character in  *
       * the input stream, and sets ncol to its column.                     *
       *********************************************************************/
-      { token = token + nextChar ;
+      { token = token + Character.toString(nextChar) ;
         skipNextChar() ;
       } ;
 
@@ -963,7 +963,7 @@ public class Tokenize
                       startNewLine() ;
                       gotoStart(); 
                     }
-                  else if (PcalBuiltInSymbols.IsBuiltInPrefix("" + nextChar))
+                  else if (PcalBuiltInSymbols.IsBuiltInPrefix(Character.toString(nextChar)))
                     { addNextChar();
                       state = BUILT_IN ;
                     }
@@ -1087,7 +1087,7 @@ public class Tokenize
                    break;
 
                 case BUILT_IN :
-                  if (PcalBuiltInSymbols.IsBuiltInPrefix(token + nextChar))
+                  if (PcalBuiltInSymbols.IsBuiltInPrefix(token + Character.toString(nextChar)))
                     { addNextChar();
                       // state = BUILT_IN;
                     }
@@ -1236,7 +1236,7 @@ public class Tokenize
                       TokenOut(Token.STRING) ;
                       gotoStart();
                     }
-                  else if (PcalBuiltInSymbols.IsStringChar(nextChar))
+                  else if (PcalBuiltInSymbols.IsStringChar(Character.toString(nextChar)))
                     { addNextChar();
                       state = STRING ;
                     }

--- a/tlatools/org.lamport.tlatools/src/pcal/Tokenize.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/Tokenize.java
@@ -432,13 +432,13 @@ public class Tokenize
     * Note: This use of static fields makes the class totally thread       *
     * unsafe.                                                              *
     ***********************************************************************/
-    private static Vector vspec = null ;
+    private static Vector<Vector<TLAToken>> vspec = null ;
           /*****************************************************************
           * vspec is a vector of vectors in which the TokenizedSpec is     *
           * constructed.  At the end, it is turned into an array.          *
           *****************************************************************/
 
-    private static Vector linev = new Vector(30, 30) ;
+    private static Vector<TLAToken> linev = new Vector<TLAToken>(30, 30) ;
           /*****************************************************************
           * Vector linev contains the tokens found so far on the current   *
           * line.                                                          *
@@ -835,7 +835,7 @@ public class Tokenize
       * whenever a \n character is removed from the input stream.          *
       *********************************************************************/
       { vspec.addElement(linev)    ;
-        linev = new Vector(30, 30) ;
+        linev = new Vector<TLAToken>(30, 30) ;
         col = 0 ;
       }
 
@@ -852,7 +852,7 @@ public class Tokenize
         return exp ; }
 
     public static String GetAlgorithmToken(PcalCharReader charReader) throws TokenizerException
-      { TLAExpr exp = InnerTokenize(charReader, false) ;
+      { InnerTokenize(charReader, false) ;
         return Delimiter ; }
 
     public static TLAExpr InnerTokenize(PcalCharReader charReader, 
@@ -876,7 +876,7 @@ public class Tokenize
         col  = ncol ;
         parseExpression = isExpr ;
         prevToken = " ";
-        vspec = new Vector(4) ;
+        vspec = new Vector<Vector<TLAToken>>(4) ;
           // Changed by LL on 13 Dec 2011 from new Vector(1000, 1000) ;
           // I don't know why such a large vector was being used
         reader = charReader ;
@@ -885,7 +885,7 @@ public class Tokenize
            * (private) methods.                                            *
            ****************************************************************/
 
-        linev = new Vector() ;
+        linev = new Vector<TLAToken>() ;
           /*****************************************************************
           * I don't know where linev is initialized, but adding this       *
           * initialization doesn't seem to make any difference.            *

--- a/tlatools/org.lamport.tlatools/src/pcal/trans.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/trans.java
@@ -3,11 +3,11 @@ package pcal;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
@@ -1295,8 +1295,7 @@ class trans {
     * each element of inputVec written on a new line.                      *
     ***********************************************************************/
     {
-    	// TODO use Apache Commons for this
-        try (final BufferedWriter fileW = new BufferedWriter(new FileWriter(fileName))) {
+        try (final BufferedWriter fileW = Files.newBufferedWriter(Path.of(fileName))) {
             // I have no idea what Java does if you try to write a new version
             // of a read-only file. On Windows, it's happy to write it. Who
             // the hell knows what it does on other operating systems? So, something
@@ -1327,27 +1326,19 @@ class trans {
     * element is a line of the file.                                       *
     ***********************************************************************/
     {
-        final List<String> inputVec = new ArrayList<>(100);
-    	// TODO use Apache Commons for this
-        try (final BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName)))) {
-            String nextLine = bufferedReader.readLine();
-            while (nextLine != null) {
-                inputVec.add(nextLine);
-                nextLine = bufferedReader.readLine();
-            }
-        } catch (FileNotFoundException e) {
+        try {
+            return Files.readAllLines(Path.of(fileName));
+        } catch (NoSuchFileException e) {
             /**************************************************************
             * Input file could not be found.                              *
             **************************************************************/
-            throw new FileToStringVectorException("Input file " + fileName + " not found.");
+            throw new FileToStringVectorException("Input file " + fileName + " not found");
         } catch (IOException e) {
             /*********************************************************
             * Error while reading input file.                        *
             *********************************************************/
             throw new FileToStringVectorException("Error reading file " + fileName + ".");
         }
-        
-        return inputVec;
     }
 
     /********************* PROCESSING THE COMMAND LINE ***********************/
@@ -1702,7 +1693,7 @@ class trans {
                     {
                         throw new NumberFormatException();
                     }
-                    int a = new Integer(args[nextArg]).intValue();
+                    int a = Integer.parseInt(args[nextArg]);
                     if (a < 60)
                     {
                         throw new NumberFormatException();
@@ -1807,12 +1798,8 @@ class trans {
         {
             // cut the extension
             PcalParams.TLAInputFile = file.getPath().substring(0, file.getPath().lastIndexOf("."));
-            if (!file.exists())
-            {
-                return CommandLineError("Input file " + file.getPath() + " does not exist.");
-            }
-        } else
-        {
+        }// else
+        //{
             // aborted version 1.31 code
             // file = new File(PcalParams.TLAInputFile + ".pcal");
             // if (file.exists())
@@ -1820,14 +1807,14 @@ class trans {
             // PcalParams.fromPcalFile = true;
             // } else
             // {
-            file = new File(PcalParams.TLAInputFile + TLAConstants.Files.TLA_EXTENSION);
-            if (!file.exists())
-            {
-                return CommandLineError("Input file " + PcalParams.TLAInputFile + ".pcal and " + file.getPath()
-                        + ".tla not found");
-            }
+            // file = new File(PcalParams.TLAInputFile + TLAConstants.Files.TLA_EXTENSION);
+            // if (!file.exists())
+            // {
+            //    return CommandLineError("Input file " + PcalParams.TLAInputFile + ".pcal and " + file.getPath()
+            //            + ".tla not found");
             // }
-        }
+            // }
+        //}
         // file = new File(PcalParams.TLAInputFile + (PcalParams.fromPcalFile?".pcal":TLAConstants.FILE_TLA_EXTENSION));
         // if (!file.exists())
         // {

--- a/tlatools/org.lamport.tlatools/src/tla2tex/Misc.java
+++ b/tlatools/org.lamport.tlatools/src/tla2tex/Misc.java
@@ -142,7 +142,6 @@ public final class Misc
   * breaking the string at spaces into separate lines.                     *
   *************************************************************************/
   { String restOfString = str ;
-    String nextLine = "" ;
     boolean done = false ;
     boolean cut = false ;
     while (   (!done) 
@@ -356,6 +355,35 @@ public final class Misc
     return newStr ;
    } ;
 
+    /**
+     * Determines whether the given codepoint is ASCII.
+     * 
+     * @param c The codepoint to check.
+     * @return Whether the given codepoint is ASCII.
+     */
+    public static boolean IsAscii(int c) {
+        // This would be the "proper" way to do it but is inefficient because
+        // it linearly searches through all defined Unicode blocks. It would
+        // be nice if the UnicodeBlock class defined a contains() method. If
+        // such an API is added in a future Java standard library version,
+        // switch to using it instead.
+        // return Character.UnicodeBlock.BASIC_LATIN == Character.UnicodeBlock.of(c);
+        return c >= 0 && c < 128;
+    }
+
+    /**
+     * Converts the given codepoint to an ASCII char. Does not check or throw
+     * exception if the given codepoint is not a valid ASCII char; will
+     * instead overflow into some random char value. Call IsAscii(c) before
+     * calling this function.
+     * 
+     * @param c The codepoint to convert.
+     * @return The codepoint as an ASCII char.
+     */
+    public static char AsAscii(int c) {
+        return (char)c;
+    }
+
     public static boolean IsLetter(char c) 
       /*********************************************************************
       * True iff c is a letter or '_'.                                     *
@@ -364,7 +392,16 @@ public final class Misc
                  || ( ('A' <= c ) && (c <= 'Z') )
                  || ( c == '_' ) ;} ;
 
-                 
+    /**
+     * IsLetter function implemented for Unicode codepoints.
+     * 
+     * @param c The codepoint to check.
+     * @return Whether the given codepoint is a letter.
+     */
+    public static boolean IsLetter(int c) {
+        return IsAscii(c) && IsLetter(AsAscii(c));
+    }
+
     public static boolean hasLetter(String str) {
        boolean notFound = true ;
        int i = 0 ;
@@ -383,6 +420,16 @@ public final class Misc
       *********************************************************************/
       { return ('0' <= c ) && (c <= '9'); } ;
 
+    /**
+     * IsDigit function implemented for Unicode codepoints.
+     * 
+     * @param c The codepoint to check.
+     * @return Whether the given codepoint is a digit.
+     */
+    public static boolean IsDigit(int c) {
+        return IsAscii(c) && IsDigit(AsAscii(c));
+    }
+
     public static boolean IsSpace(char c) 
       /*********************************************************************
       * True iff c is a space character--that is, one of the following:    *
@@ -390,6 +437,15 @@ public final class Misc
       *********************************************************************/
       { return  (c == ' ')  | (c == '\f') | (c == '\r') ; } ;
 
+    /**
+     * IsSpace function implemented for Unicode codepoints.
+     * 
+     * @param c The codepoint to check.
+     * @return Whether the given codepoint is a space.
+     */
+    public static boolean IsSpace(int c) {
+        return IsAscii(c) && IsSpace(AsAscii(c));
+    }
 
   public static boolean isBlank(String str) 
     /***********************************************************************


### PR DESCRIPTION
This PR does not add Unicode support to PlusCal. It simply ensures that PlusCal code reads & writes files encoding with UTF-8 (done by default across Java's `nio` API) and uses codepoints (represented as `int`s in Java) instead of `char`s when tokenizing the input.

Prior to these changes running `pcal.trans` on a file with Unicode symbols on Windows would result in garbled output.

Added a step to the PR CI which runs `pcal.trans` against all PlusCal files in the tlaplus/examples repo.