### PR TITLE
Support Unicode in `pcal.trans`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -132,7 +132,6 @@ jobs:
           --ts_path "$DEPS_DIR/tree-sitter-tlaplus"     \
           --manifest_path "$EXAMPLES_DIR/manifest.json"
     - name: Translate PlusCal
-      if: (!matrix.unicode)
       run: |
         python $SCRIPT_DIR/translate_pluscal.py         \
           --tools_jar_path "$DIST_DIR/tla2tools.jar"    \

--- a/tlatools/org.lamport.tlatools/src/pcal/ParseAlgorithm.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/ParseAlgorithm.java
@@ -106,6 +106,7 @@
 ***************************************************************************/
 package pcal;
 
+import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Vector;
 
@@ -842,7 +843,8 @@ public class ParseAlgorithm
        pv.col  = lastTokCol ;
        pv.line = lastTokLine ;
        if (   PeekAtAlgToken(1).equals("=")
-           || PeekAtAlgToken(1).equals("\\in"))
+           || PeekAtAlgToken(1).equals("\\in")
+           || PeekAtAlgToken(1).equals("∈"))
          { pv.isEq = GobbleEqualOrIf() ;
            pv.val = GetExpr() ; 
            endLoc = pv.val.getOrigin().getEnd() ;
@@ -1415,7 +1417,7 @@ public class ParseAlgorithm
          ******************************************************************/
        result.ass = new Vector() ;
        result.ass.addElement(GetSingleAssign()) ;
-       while (PeekAtAlgToken(1).equals("||"))
+       while (PeekAtAlgToken(1).equals("||") || PeekAtAlgToken(1).equals("‖"))
          { String throwAway = GetAlgToken() ;
            try {
            result.ass.addElement(GetSingleAssign()) ;
@@ -1440,7 +1442,7 @@ public class ParseAlgorithm
          * PeekAtAlgToken(1), so LAT[0] contains the next token.           *
          ******************************************************************/
        result.lhs = GetLhs() ;
-       GobbleThis(":=") ; 
+       GobbleThis(":=", "≔") ; 
        result.rhs = GetExpr() ;
        if (result.rhs.tokens.size() == 0)
          { ParsingError("Empty right-hand side of assignment at ") ;} ;
@@ -3416,10 +3418,10 @@ public class ParseAlgorithm
        return ;
      }
 
-   public static void GobbleThis(String str) throws ParseAlgorithmException
+   public static void GobbleThis(String str, String... alternate) throws ParseAlgorithmException
      { /********************************************************************
-       * If the next token is not str, then report an error.  Otherwise,   *
-       * just move past the token.  However, if str is a semicolon and     *
+       * If the next token is not str or in alternate, then report error.  *
+       * Else just move past the token. However, if str is a semicolon and *
        * the next token indicates that the input is missing an obviously   *
        * unnecessary semicolon, then don't report an error--for example,   *
        * if the next token is "end".  If the missing semicolon should      *
@@ -3486,7 +3488,7 @@ public class ParseAlgorithm
              };                   
          } ;
        String tok = GetAlgToken(); 
-       if (! tok.equals(str) )
+       if (! tok.equals(str) && ! Arrays.stream(alternate).anyMatch(tok::equals) )
          { ParsingError("Expected \"" + str + "\" but found \""
                             + tok + "\"") ; } ;
      }
@@ -3511,7 +3513,7 @@ public class ParseAlgorithm
      { String tok = GetAlgToken() ;
        if (tok.equals("="))
          { return true ; } ;
-       if (tok.equals("\\in"))
+       if (tok.equals("\\in") || tok.equals("∈"))
          { return false ; }
        ParsingError("Expected \"=\" or \"\\in\"  but found \""
                                  + tok + "\"") ; 

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalBuiltInSymbols.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalBuiltInSymbols.java
@@ -155,28 +155,35 @@ public final class PcalBuiltInSymbols
         add("WF_", "{\\WF}",        Symbol.SUBSCRIPTED, 0);
         add("SF_", "{\\SF}",        Symbol.SUBSCRIPTED, 0);
         add(">>_", "{\\rangle}",    Symbol.RIGHT_PAREN, 0);
+        add("⟩_",  "{\\rangle}",    Symbol.RIGHT_PAREN, 0);
         add("]_",  "]",             Symbol.RIGHT_PAREN, 0);
 
         add("(",   "(",           Symbol.LEFT_PAREN, 0);
         add("[",   "[",           Symbol.LEFT_PAREN, 0);
         add("{",   "\\{",         Symbol.LEFT_PAREN, 0);
         add("<<",  "{\\langle}",  Symbol.LEFT_PAREN, 0);
+        add("⟨",   "{\\langle}",  Symbol.LEFT_PAREN, 0);
 
         add(")",   ")",           Symbol.RIGHT_PAREN, 0);
         add("}",   "\\}",         Symbol.RIGHT_PAREN, 0);
         add("]",   "]",           Symbol.RIGHT_PAREN, 0);
         add(">>",  "{\\rangle}",  Symbol.RIGHT_PAREN, 0);
+        add("⟩",   "{\\rangle}",  Symbol.RIGHT_PAREN, 0);
 
         add("\\A",         "\\A\\,",          Symbol.PREFIX, 0);
+        add("∀",           "\\A\\,",          Symbol.PREFIX, 0);
         add("\\forall",    "\\forall\\,",     Symbol.PREFIX, 0);
         add("\\E",         "\\E\\,",          Symbol.PREFIX, 0);
+        add("∃",           "\\E\\,",          Symbol.PREFIX, 0);
         add("\\exists",    "\\exists\\,",     Symbol.PREFIX, 0);
         add("\\AA",        "{\\AA}",         Symbol.PREFIX, 0);
         add("\\EE",        "{\\EE}",         Symbol.PREFIX, 0);
         add("~",           "{\\lnot}",       Symbol.PREFIX, 0);
+        add("¬",           "{\\lnot}",       Symbol.PREFIX, 0);
         add("\\lnot",      "{\\lnot}",       Symbol.PREFIX, 0);
         add("\\neg",       "{\\neg}",        Symbol.PREFIX, 0);
         add("<>",          "{\\Diamond}",    Symbol.PREFIX, 0);
+        add("◇",           "{\\Diamond}",    Symbol.PREFIX, 0);
         add("CHOOSE",      "{\\CHOOSE}",     Symbol.PREFIX, 0);
         add("ENABLED",     "{\\ENABLED}",    Symbol.PREFIX, 0);
         add("UNCHANGED",   "{\\UNCHANGED}",  Symbol.PREFIX, 0);
@@ -184,41 +191,59 @@ public final class PcalBuiltInSymbols
         add("UNION",       "{\\UNION}",      Symbol.PREFIX, 0);
         add("DOMAIN",      "{\\DOMAIN}",     Symbol.PREFIX, 0);
 
-        add("'",    "\\.{'}",            Symbol.POSTFIX, 0);
-        add("^+",   "\\.{\\mbox{}^+}",   Symbol.POSTFIX, 0);
-        add("^*",   "\\.{\\mbox{}^*}",   Symbol.POSTFIX, 0);
+        add("'",    "\\.{'}",                Symbol.POSTFIX, 0);
+        add("^+",   "\\.{\\mbox{}^+}",       Symbol.POSTFIX, 0);
+        add("⁺",    "\\.{\\mbox{}^+}",       Symbol.POSTFIX, 0);
+        add("^*",   "\\.{\\mbox{}^*}",       Symbol.POSTFIX, 0);
         add("^#",   "\\.{\\mbox{}^{\\#}}",   Symbol.POSTFIX, 0);
 
 
         add("=>",           "\\.{\\implies}",    Symbol.INFIX, 1);
+        add("⇒",            "\\.{\\implies}",    Symbol.INFIX, 1);
         add("\\cdot",       "\\.{\\cdot}",       Symbol.INFIX, 2);
-        add("<=>",          "\\.{\\equiv}",      Symbol.INFIX, 3);
+        add("⋅",            "\\.{\\cdot}",       Symbol.INFIX, 2);
+        add("<=>",          "\\.{\\iff}",        Symbol.INFIX, 3);
+        add("⇔",            "\\.{\\iff}",        Symbol.INFIX, 3);
         add("\\equiv",      "\\.{\\equiv}",      Symbol.INFIX, 4);
+        add("≡",            "\\.{\\equiv}",      Symbol.INFIX, 4);
         add("~>",           "\\.{\\leadsto}",    Symbol.INFIX, 5);
+        add("↝",            "\\.{\\leadsto}",    Symbol.INFIX, 5);
         add("-+->",         "\\.{\\whileop}",    Symbol.INFIX, 6);
+        add("⇸",            "\\.{\\whileop}",    Symbol.INFIX, 6);
 
         add("\\subseteq",   "\\.{\\subseteq}",   Symbol.INFIX, 7); 
+        add("⊆",            "\\.{\\subseteq}",   Symbol.INFIX, 7); 
         add("\\subset",     "\\.{\\subset}",     Symbol.INFIX, 7); 
+        add("⊂",            "\\.{\\subset}",     Symbol.INFIX, 7); 
         add("\\supset",     "\\.{\\supset}",     Symbol.INFIX, 7); 
+        add("⊃",            "\\.{\\supset}",     Symbol.INFIX, 7); 
         add("\\supseteq",   "\\.{\\supseteq}",   Symbol.INFIX, 7); 
+        add("⊇",            "\\.{\\supseteq}",   Symbol.INFIX, 7); 
 
         add("\\ll",         "\\.{\\ll}",         Symbol.INFIX, 8);
+        add("≪",            "\\.{\\ll}",         Symbol.INFIX, 8);
         add("\\gg",         "\\.{\\gg}",         Symbol.INFIX, 8);
+        add("≫",            "\\.{\\gg}",         Symbol.INFIX, 8);
           /*****************************************************************
           * \ll and \gg not aligned with = and < because they are wider,   *
-          * and they're not used enough to bother accomodating.            *
+          * and they're not used enough to bother accommodating.           *
           *****************************************************************/
           
         add("\\",           "\\.{\\,\\backslash\\,}",  Symbol.INFIX, 9);
         add("\\cap",        "\\.{\\cap}",        Symbol.INFIX, 10);
         add("\\intersect",  "\\.{\\cap}",        Symbol.INFIX, 11);
+        add("∩",            "\\.{\\cap}",        Symbol.INFIX, 11);
         add("\\cup",        "\\.{\\cup}",        Symbol.INFIX, 12);
         add("\\union",      "\\.{\\cup}",        Symbol.INFIX, 13);
+        add("∪",            "\\.{\\cup}",        Symbol.INFIX, 13);
         add("/\\",          "\\.{\\land}",       Symbol.INFIX, 14);
+        add("∧",            "\\.{\\land}",       Symbol.INFIX, 14);
         add("\\/",          "\\.{\\lor}",        Symbol.INFIX, 15);
+        add("∨",            "\\.{\\lor}",        Symbol.INFIX, 15);
         add("\\land",       "\\.{\\land}",       Symbol.INFIX, 16);
         add("\\lor",        "\\.{\\lor}",        Symbol.INFIX, 17);
         add("\\X",          "\\.{\\times}",      Symbol.INFIX, 18);
+        add("×",            "\\.{\\times}",      Symbol.INFIX, 18);
         add("-",            "\\.{-}",            Symbol.INFIX, 19);
         add("+",            "\\.{+}",            Symbol.INFIX, 19);
         add("*",            "\\.{*}",            Symbol.INFIX, 20);
@@ -226,6 +251,7 @@ public final class PcalBuiltInSymbols
         add("^",            "\\.{\\ct}",         Symbol.INFIX, 22);
         add("|",            "\\.{\\,|\\,}",      Symbol.INFIX, 23);
         add("||",           "\\.{\\,||\\,}",     Symbol.INFIX, 24);
+        add("‖",            "\\.{\\,||\\,}",     Symbol.INFIX, 24);
         add("&",            "\\.{\\,\\&\\,}",    Symbol.INFIX, 25);
         add("&&",           "\\.{\\,\\&\\&\\,}", Symbol.INFIX, 26);
         add("++",           "\\.{\\pp}",         Symbol.INFIX, 27);
@@ -234,96 +260,144 @@ public final class PcalBuiltInSymbols
         add("//",           "\\.{\\slsl}",       Symbol.INFIX, 29);
         add("^^",           "\\.{\\ct\\ct}",     Symbol.INFIX, 30);
         add("|-",           "\\.{\\vdash}",      Symbol.INFIX, 31);
+        add("⊢",            "\\.{\\vdash}",      Symbol.INFIX, 31);
         add("|=",           "\\.{\\models}",     Symbol.INFIX, 32);
+        add("⊨",            "\\.{\\models}",     Symbol.INFIX, 32);
         add("-|",           "\\.{\\dashv}",      Symbol.INFIX, 33);
+        add("⊣",            "\\.{\\dashv}",      Symbol.INFIX, 33);
         add("=|",           "\\.{\\eqdash}",     Symbol.INFIX, 34);
+        add("⫤",           "\\.{\\eqdash}",     Symbol.INFIX, 34);
         add("<:",           "\\.{\\ltcolon}",    Symbol.INFIX, 35);
         add(":>",           "\\.{\\colongt}",    Symbol.INFIX, 35);
         add(":=",           "\\.{:=}",           Symbol.INFIX, 35);
+        add("≔",            "\\.{:=}",           Symbol.INFIX, 35);
         add("::=",          "\\.{::=}",          Symbol.INFIX, 36);
+        add("⩴",            "\\.{::=}",          Symbol.INFIX, 36);
 
         add("(+)",          "\\.{\\oplus}",      Symbol.INFIX, 37); 
+        add("⊕",            "\\.{\\oplus}",      Symbol.INFIX, 37); 
         add("(-)",          "\\.{\\ominus}",     Symbol.INFIX, 37); 
+        add("⊖",            "\\.{\\ominus}",     Symbol.INFIX, 37); 
         add("\\oplus",      "\\.{\\oplus}",      Symbol.INFIX, 37); 
         add("\\ominus",     "\\.{\\ominus}",     Symbol.INFIX, 37); 
 
         add("(.)",          "\\.{\\odot}",       Symbol.INFIX, 38);
+        add("⊙",            "\\.{\\odot}",       Symbol.INFIX, 38);
         add("\\odot",       "\\.{\\odot}",       Symbol.INFIX, 38);
 
         add("(/)",          "\\.{\\oslash}",     Symbol.INFIX, 39);
+        add("⊘",            "\\.{\\oslash}",     Symbol.INFIX, 39);
         add("\\oslash",     "\\.{\\oslash}",     Symbol.INFIX, 39);
 
         add("(\\X)",        "\\.{\\otimes}",     Symbol.INFIX, 40);
+        add("⊗",            "\\.{\\otimes}",     Symbol.INFIX, 40);
         add("\\otimes",     "\\.{\\otimes}",     Symbol.INFIX, 40);
 
         add("\\uplus",      "\\.{\\uplus}",      Symbol.INFIX, 41);
+        add("⊎",            "\\.{\\uplus}",      Symbol.INFIX, 41);
         add("\\sqcap",      "\\.{\\sqcap}",      Symbol.INFIX, 42);
+        add("⊓",            "\\.{\\sqcap}",      Symbol.INFIX, 42);
         add("\\sqcup",      "\\.{\\sqcup}",      Symbol.INFIX, 43);
+        add("⊔",            "\\.{\\sqcup}",      Symbol.INFIX, 43);
         add("\\div",        "\\.{\\div}",        Symbol.INFIX, 44);
+        add("÷",            "\\.{\\div}",        Symbol.INFIX, 44);
         add("\\star",       "\\.{\\star}",       Symbol.INFIX, 45);
+        add("⋆",            "\\.{\\star}",       Symbol.INFIX, 45);
 
         add("\\o",          "\\.{\\circ}",       Symbol.INFIX, 46);
+        add("∘",            "\\.{\\circ}",       Symbol.INFIX, 46);
         add("\\circ",       "\\.{\\circ}",       Symbol.INFIX, 46);
 
         add("\\bigcirc",    "\\.{\\bigcirc}",    Symbol.INFIX, 47);
+        add("◯",            "\\.{\\bigcirc}",    Symbol.INFIX, 47);
         add("\\bullet",     "\\.{\\bullet}",     Symbol.INFIX, 48);
+        add("●",            "\\.{\\bullet}",     Symbol.INFIX, 48);
 
         add("\\in",         "\\.{\\in}",         Symbol.INFIX, 49);
+        add("∈",            "\\.{\\in}",         Symbol.INFIX, 49);
         add("\\notin",      "\\.{\\notin}",      Symbol.INFIX, 49);
+        add("∉",            "\\.{\\notin}",      Symbol.INFIX, 49);
         add("=",            "\\.{=}",            Symbol.INFIX, 49);
         add("#",            "\\.{\\neq}",        Symbol.INFIX, 49);
         add("/=",           "\\.{\\neq}",        Symbol.INFIX, 49);
+        add("≠",            "\\.{\\neq}",        Symbol.INFIX, 49);
         add("<",            "\\.{<}",            Symbol.INFIX, 49);
         add(">",            "\\.{>}",            Symbol.INFIX, 49);
         add("=<",           "\\.{\\leq}",        Symbol.INFIX, 49);
         add("<=",           "\\.{\\leq}",        Symbol.INFIX, 49);
+        add("≤",            "\\.{\\leq}",        Symbol.INFIX, 49);
         add(">=",           "\\.{\\geq}",        Symbol.INFIX, 49);
+        add("≥",            "\\.{\\geq}",        Symbol.INFIX, 49);
         add("\\prec",       "\\.{\\prec}",       Symbol.INFIX, 49);
+        add("≺",            "\\.{\\prec}",       Symbol.INFIX, 49);
         add("\\succ",       "\\.{\\succ}",       Symbol.INFIX, 49);
+        add("≻",            "\\.{\\succ}",       Symbol.INFIX, 49);
         add("\\preceq",     "\\.{\\preceq}",     Symbol.INFIX, 49);
+        add("⪯",            "\\.{\\preceq}",     Symbol.INFIX, 49);
         add("\\succeq",     "\\.{\\succeq}",     Symbol.INFIX, 49);
+        add("⪰",            "\\.{\\succeq}",     Symbol.INFIX, 49);
         add("\\sim",        "\\.{\\sim}",        Symbol.INFIX, 49);
+        add("∼",            "\\.{\\sim}",        Symbol.INFIX, 49);
         add("\\simeq",      "\\.{\\simeq}",      Symbol.INFIX, 49);
+        add("≃",            "\\.{\\simeq}",      Symbol.INFIX, 49);
         add("\\approx",     "\\.{\\approx}",     Symbol.INFIX, 49);
+        add("≈",            "\\.{\\approx}",     Symbol.INFIX, 49);
         add("\\doteq",      "\\.{\\doteq}",      Symbol.INFIX, 49);
+        add("≐",            "\\.{\\doteq}",      Symbol.INFIX, 49);
 
         add("\\asymp",      "\\.{\\asymp}",      Symbol.INFIX, 50);
+        add("≍",            "\\.{\\asymp}",      Symbol.INFIX, 50);
 
         add("\\sqsubset",   "\\.{\\sqsubset}",   Symbol.INFIX, 51);
+        add("⊏",            "\\.{\\sqsubset}",   Symbol.INFIX, 51);
         add("\\sqsupset",   "\\.{\\sqsupset}",   Symbol.INFIX, 51);
+        add("⊐",            "\\.{\\sqsupset}",   Symbol.INFIX, 51);
         add("\\sqsubseteq", "\\.{\\sqsubseteq}", Symbol.INFIX, 51);
+        add("⊑",            "\\.{\\sqsubseteq}", Symbol.INFIX, 51);
         add("\\sqsupseteq", "\\.{\\sqsupseteq}", Symbol.INFIX, 51);
+        add("⊒",            "\\.{\\sqsupseteq}", Symbol.INFIX, 51);
 
         add("\\propto",     "\\.{\\propto}",     Symbol.INFIX, 52);
+        add("∝",            "\\.{\\propto}",     Symbol.INFIX, 52);
         add(":",            "\\.{:}",            Symbol.PUNCTUATION, 53);
         add("->",           "\\.{\\rightarrow}", Symbol.INFIX, 54);
+        add("→",            "\\.{\\rightarrow}", Symbol.INFIX, 54);
         add("|->",          "\\.{\\mapsto}",     Symbol.INFIX, 55);
+        add("↦",            "\\.{\\mapsto}",     Symbol.INFIX, 55);
         add("<-",           "\\.{\\leftarrow}",  Symbol.INFIX, 56);
+        add("←",            "\\.{\\leftarrow}",  Symbol.INFIX, 56);
         add("==",           "\\.{\\defeq}",      Symbol.INFIX, 57);
+        add("≜",            "\\.{\\defeq}",      Symbol.INFIX, 57);
 
         add("ELSE",         "\\.{\\ELSE}",       Symbol.PREFIX, 58);
         add("THEN",         "\\.{\\THEN}",       Symbol.PREFIX, 58);
         add("LET",          "\\.{\\LET}",        Symbol.PREFIX, 59);
         add("IN",          "\\.{\\IN}",          Symbol.PREFIX, 59);
         add("[]",          "{\\Box}",            Symbol.PREFIX, 60);
+        add("□",           "{\\Box}",            Symbol.PREFIX, 60);
 
         add("..",           "\\.{\\dotdot}",     Symbol.INFIX, 0);
+        add("‥",            "\\.{\\dotdot}",     Symbol.INFIX, 0);
         add("...",          "\\.{\\dots}",       Symbol.INFIX, 0);
+        add("…",            "\\.{\\dots}",       Symbol.INFIX, 0);
         add("$",            "\\.{\\,\\$\\,}",    Symbol.INFIX, 0);
         add("$$",           "\\.{\\,\\$\\$\\,}", Symbol.INFIX, 0);
         add("?",            "\\.{?}",            Symbol.INFIX, 0);
         add("??",           "\\.{\\,??\\,}",     Symbol.INFIX, 0);
+        add("⁇",            "\\.{\\,??\\,}",     Symbol.INFIX, 0);
         add("%",            "\\.{\\%}",          Symbol.INFIX, 0);
         add("%%",           "\\.{\\,\\%\\%\\,}", Symbol.INFIX, 0);
         add("##",           "\\.{\\,\\#\\#\\,}", Symbol.INFIX, 0);
         add("@@",           "\\.{\\,@@\\,}",     Symbol.INFIX, 0);
         add("!!",           "\\.{!!}",           Symbol.INFIX, 0);
+        add("‼",            "\\.{!!}",           Symbol.INFIX, 0);
         add("\\times",      "\\.{\\times}",      Symbol.INFIX, 0);
         add("\\leq",        "\\.{\\leq}",        Symbol.INFIX, 0);
         add("\\geq",        "\\.{\\geq}",        Symbol.INFIX, 0);
         add("\\mod",        "\\.{\\%}",          Symbol.INFIX, 0);
         add("\\wr",         "\\.{\\wr}",         Symbol.INFIX, 0);
-        add("\\cong",       "\\.{\\cong}",       Symbol.INFIX, 0);
+        add("≀",            "\\.{\\wr}",         Symbol.INFIX, 0);
+        add("≅",            "\\.{\\cong}",       Symbol.INFIX, 0);
         add("!",            "!",                 Symbol.INFIX, 0);
 
         add(";",   ";",     Symbol.PUNCTUATION, 0);

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
@@ -207,7 +207,7 @@ public class PcalTranslate {
                 TLAToken tok = ((TLAToken) line.elementAt(j));
                 tok.column = nextCol;
                 nextCol = nextCol + tok.getWidth();
-                if (tok.type == TLAToken.BUILTIN && tok.string.equals("|->")) {
+                if (tok.type == TLAToken.BUILTIN && (tok.string.equals("|->") || tok.string.equals("↦"))) {
                     tok.column = tok.column + 1;
                     if (tok.column < 16) tok.column = 16;
                     nextCol = tok.column + 5;

--- a/tlatools/org.lamport.tlatools/src/pcal/TLAExpr.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/TLAExpr.java
@@ -1217,6 +1217,8 @@ public class TLAExpr
                                (result, 2)).string.equals(":") 
                            || this.tokenAt(this.stepCoord
                                (result, 2)).string.equals("|->") 
+                           || this.tokenAt(this.stepCoord
+                               (result, 2)).string.equals("↦") 
                          )
                      )
                    { result = this.stepCoord(result, 3); }

--- a/tlatools/org.lamport.tlatools/src/pcal/Tokenize.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/Tokenize.java
@@ -726,7 +726,9 @@ public class Tokenize
                    * Set inQuantifier if necessary.                        *
                    ********************************************************/
                    if (    (   token.equals("\\A")
-                            || token.equals("\\E"))
+                            || token.equals("∀")
+                            || token.equals("\\E")
+                            || token.equals("∃"))
                         && (parenDepth == 0))
                      { inQuantifier = true ;} ;
                    if (    inQuantifier
@@ -790,10 +792,12 @@ public class Tokenize
                 || tok.equals("do")
                 || tok.equals("then")
                 || tok.equals(":=")
+                || tok.equals("≔")
                 || tok.equals("begin")
                 || tok.equals("variable")
                 || tok.equals("variables")
                 || tok.equals("||")
+                || tok.equals("‖")
 
          // The following are added to improve error reporting
          // and to make possible the omission of some final ";"s. 
@@ -934,6 +938,13 @@ public class Tokenize
                   else if (Misc.IsLetter(nextChar))
                     { addNextChar();
                       state = ID;  
+                    }
+                  else if ('ℕ' == nextChar
+                        || 'ℤ' == nextChar
+                        || 'ℝ' == nextChar)
+                    { addNextChar();
+                      TokenOut(Token.IDENT);
+                      gotoStart();
                     }
                   else if (Misc.IsDigit(nextChar))
                     { addNextChar();


### PR DESCRIPTION
These changes build on top of https://github.com/tlaplus/tlaplus/pull/909. They make the PlusCal translator correctly parse Unicode input. However, it will still always output generated TLA+ code in ASCII.

For testing, all PlusCal modules in the tlaplus/examples repo are converted to Unicode then translated.

Closes #928