### PR TITLE
Fixed miscellaneous javac compiler warnings

### DIFF
--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -143,14 +143,16 @@
 	<!-- Compiles the TLA+ tools code -->
 	<target name="compile" depends="clean, generate">
 		<echo>
-			================================================================
-			= The following warnings about sun.misc.Unsafe can be ignored. = 
-			= OffHeapDiskFPSet has been written using Unsafe to best use   =
-			= a computer's memory. If Unsafe is removed from the JVM,      =
-			= OffHeapDiskFPSet won't work anymore.                         =
-			================================================================
+			==================================================================
+			= This code uses sun.misc.Unsafe for manual memory management in =
+			= the class src/tlc2/tool/fp/LongArray.java. This unsafe API is  =
+			= marked as internal meaning it can change without warning.      =
+			= Ordinarily this would result in a lot of compiler warnings,    =
+			= but to reduce noise these have been explicitly silenced. If    =
+			= the build fails after upgrading Java, it might be because this =
+			= API has been changed.                                          =
+			==================================================================
 		</echo>
-		<!-- compile -->
 		<mkdir dir="${class.dir}" />
 		<javac
 			includeantruntime="false"
@@ -161,7 +163,12 @@
 			release="${java.release}"
 			encoding="UTF-8"
 		>
-			<!-- compilerarg value="-Xlint:deprecation"/-->
+			<!--
+				Suppress sun.misc.Unsafe warnings. These warnings cannot be suppressed
+				using in-file annotations like ordinary warnings, so we must completely
+				ignore all warnings from the file here.
+			-->
+			<compilerarg line="-XDignore.symbol.file=src/tlc2/tool/fp/LongArray.java" />
 			<classpath refid="project.classpath" />
 			<classpath>
 				<pathelement location="lib/javax.mail/mailapi-1.6.3.jar" />

--- a/tlatools/org.lamport.tlatools/javacc/tla+.jj
+++ b/tlatools/org.lamport.tlatools/javacc/tla+.jj
@@ -915,7 +915,7 @@ private int levelOfProofStepLexeme(Token tok){
   String im = tok.image ;
   if (im.substring(1,2).equals("*")) {return -1;} ;
   if (im.substring(1,2).equals("+")) {return -2;} ;
-  return new Integer(im.substring(1, im.indexOf('>'))).intValue() ;
+  return Integer.parseInt(im.substring(1, im.indexOf('>'))) ;
     /***********************************************************************
     * The ".intValue()" added by SZ because Java 1.4 doesn't support       *
     * auto-boxing.                                                         *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
@@ -324,9 +324,9 @@ public class Explorer {
 		// "mt" command, which defaults to 2
 		if (ntokens < 2 || (icmd2 != null && icmd2.intValue() < 0)) {
 			if (firstToken.toLowerCase().startsWith("mt")) {
-				icmd2 = new Integer(2);
+				icmd2 = 2;
 			} else {
-				icmd2 = new Integer(4);
+				icmd2 = 4;
 			}
 		}
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/TLAplusParser.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/TLAplusParser.java
@@ -822,7 +822,7 @@ private int levelOfProofStepLexeme(Token tok){
   String im = tok.image ;
   if (im.substring(1,2).equals("*")) {return -1;} ;
   if (im.substring(1,2).equals("+")) {return -2;} ;
-  return new Integer(im.substring(1, im.indexOf('>'))).intValue() ;
+  return Integer.parseInt(im.substring(1, im.indexOf('>'))) ;
     /***********************************************************************
     * The ".intValue()" added by SZ because Java 1.4 doesn't support       *
     * auto-boxing.                                                         *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelConstants.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelConstants.java
@@ -14,12 +14,11 @@ public interface LevelConstants {
   static final int MinLevel      = 0;
   static final int MaxLevel      = 3;
 
-  static final Integer[] Levels = {new Integer(ConstantLevel),
-				   new Integer(VariableLevel),
-				   new Integer(ActionLevel),
-				   new Integer(TemporalLevel)};
+  static final Integer[] Levels = {ConstantLevel,
+				   VariableLevel,
+				   ActionLevel,
+				   TemporalLevel};
   
-  static final HashSet EmptySet = new HashSet();
   static final SetOfLevelConstraints EmptyLC = new SetOfLevelConstraints();
   static final SetOfArgLevelConstraints EmptyALC = new SetOfArgLevelConstraints();
 }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfArgLevelConstraints.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfArgLevelConstraints.java
@@ -36,13 +36,13 @@ class SetOfArgLevelConstraints extends HashMap<ParamAndPosition, Integer> implem
     Integer old = this.get(pap);
 
     int oldLevel = (old == null) ? MinLevel : old.intValue();
-    super.put(pap, new Integer(Math.max(newLevel, oldLevel)));
+    super.put(pap, Math.max(newLevel, oldLevel));
     return old;
   }
 
   public final Integer put(SymbolNode param, int position, int level) {
     ParamAndPosition pap = new ParamAndPosition(param, position);
-    return this.put(pap, new Integer(level));
+    return this.put(pap, level);
   }
 
   /**

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfLevelConstraints.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SetOfLevelConstraints.java
@@ -32,7 +32,7 @@ class SetOfLevelConstraints extends HashMap<SymbolNode, Integer> implements Leve
     Integer old = this.get(param);
 
     int oldLevel = (old == null) ? MaxLevel : old.intValue();
-    super.put(param, new Integer(Math.min(newLevel, oldLevel)));
+    super.put(param, Math.min(newLevel, oldLevel));
     return old;
   }
   

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Subst.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Subst.java
@@ -155,7 +155,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
           * check it first, which is why we need the iteration number      *
           * argument of this method.                                       *
           *****************************************************************/
-	Integer mlevel = new Integer(subDef.getMaxLevel(alp.i));
+	int mlevel = subDef.getMaxLevel(alp.i);
 	Iterator<SymbolNode> iter1 = paramSet(alp.param, subs).iterator();
 	while (iter1.hasNext()) {
 	  res.put(iter1.next(), mlevel);
@@ -203,7 +203,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
             /***************************************************************
             * Must invoke levelCheck before invoking getLevel              *
             ***************************************************************/
-	  Integer subLevel = new Integer(subParam.getLevel());
+	  int subLevel = subParam.getLevel();
 	  res.put(pap, subLevel);
 	}
       }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/xml/SymbolContext.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/xml/SymbolContext.java
@@ -52,7 +52,7 @@ public class SymbolContext {
   }
 
   public void put(SymbolNode nd, Document doc) {
-    Integer k = new Integer(nd.myUID);
+    int k = nd.myUID;
     if (!keys.contains(k)) {
       // first add the key as it might be mentioned again inside the definition
       keys.add(k);
@@ -62,7 +62,7 @@ public class SymbolContext {
   }
 
   public void put(TheoremNode nd, Document doc) {
-    Integer k = new Integer(nd.myUID);
+    int k = nd.myUID;
     if (!keys.contains(k)) {
       // first add the key as it might be mentioned again inside the definition
       keys.add(k);
@@ -72,7 +72,7 @@ public class SymbolContext {
   }
 
   public void put(AssumeNode nd, Document doc) {
-    Integer k = new Integer(nd.myUID);
+    int k = nd.myUID;
     if (!keys.contains(k)) {
       // first add the key as it might be mentioned again inside the definition
       keys.add(k);

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TransitiveClosure.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TransitiveClosure.java
@@ -51,7 +51,7 @@ public class TransitiveClosure implements ValueConstants
             Integer num = fps.get(elem1);
             if (num == null)
             {
-                fps.put(elem1, new Integer(cnt));
+                fps.put(elem1, cnt);
                 elemList.addElement(elem1);
                 cnt++;
             } else
@@ -62,7 +62,7 @@ public class TransitiveClosure implements ValueConstants
             num = fps.get(elem2);
             if (num == null)
             {
-                fps.put(elem2, new Integer(cnt));
+                fps.put(elem2, cnt);
                 elemList.addElement(elem2);
                 cnt++;
             } else

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/distributed/TLCApp.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/distributed/TLCApp.java
@@ -93,14 +93,14 @@ public class TLCApp extends DistApp {
 	 * @see tlc2.tool.distributed.DistApp#getCheckDeadlock()
 	 */
 	public final Boolean getCheckDeadlock() {
-		return new Boolean(this.checkDeadlock);
+		return this.checkDeadlock;
 	}
 
 	/* (non-Javadoc)
 	 * @see tlc2.tool.distributed.DistApp#getPreprocess()
 	 */
 	public final Boolean getPreprocess() {
-		return new Boolean(this.preprocess);
+		return this.preprocess;
 	}
 
 	/* (non-Javadoc)

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Future;
  * command-line.  As we do not want to expose JVM parameters to them, we keep
  * sun.misc.Unsafe for now.
  */
-import sun.misc.Unsafe; // jdk.internal.misc.Unsafe;
 import tlc2.output.EC;
 import util.Assert;
 import util.TLCRuntime;
@@ -43,10 +42,9 @@ import util.TLCRuntime;
  * In 2012 this poses a too hard limit on the usable memory, hence we trade
  * generality for performance.
  */
-@SuppressWarnings("restriction")
 public final class LongArray {
 
-	private final Unsafe unsafe;
+	private final sun.misc.Unsafe unsafe;
 	
 	/**
 	 * The base address of this direct memory allocated with Unsafe.

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/AbstractDiskGraph.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/AbstractDiskGraph.java
@@ -607,7 +607,7 @@ public abstract class AbstractDiskGraph {
 					record.read(this.nodeRAF);
 					Integer inArcCounter = nodes2count.get(record);
 					if (inArcCounter == null) {
-						inArcCounter = new Integer(0);
+						inArcCounter = 0;
 					}
 					nodes2count.put(record, inArcCounter + 1);
 				}


### PR DESCRIPTION
These are generally trivial. I blanket-silenced the `sun.misc.Unsafe` warnings using a `javac` parameter. I would like to add `-Werror` to prevent further warnings from being introduced but am blocked on #921