### PR TITLE
Use Java 11 but not specific version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11.0.3
+        java-version: 11
 
       ## 
       ## Speed-up build with a cached ~/.m2/repository (300+ MB).

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 11.0.3
+        java-version: 11
 
       ##
       ## Build TLC tla2tools.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11.0.3
+        java-version: 11
     - name: Check tla+.jj grammar/code sync
       run: |
         ant -f tlatools/org.lamport.tlatools/customBuild.xml generate
@@ -76,7 +76,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11.0.3
+        java-version: 11
     - name: Build & Test Eclipse Toolbox with Maven
       run: |
         ${{ matrix.MVN_COMMAND }}                                                                     \
@@ -113,7 +113,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: adopt
-        java-version: 11.0.3
+        java-version: 11
     - name: Build tla2tools.jar
       run: ant -f tlatools/org.lamport.tlatools/customBuild.xml compile compile-test dist
     - name: Download dependencies


### PR DESCRIPTION
Github actions has stopped serving the specific version of Java we use (11.0.3) which breaks our CI. To fix this we just use a non-specific version of Java 11 for everything.