### PR TITLE
ISSUE_TEMPLATE: moving "Steps to reproduce" to go before Expected/Actual

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-<!--- 
+<!---
 Hi!
 Have you tried searching for your issue on the following forums?
 If you have any questions, please ask them there.
@@ -20,25 +20,25 @@ Thanks!
 -->
 
 ## Description
-<!--- 
-Provide a more detailed introduction to the issue itself, and why you consider it to be a bug. 
+<!---
+Provide a more detailed introduction to the issue itself, and why you consider it to be a bug.
 
 If you need to share a specification, either:
  - Paste it in your description between the <details> </details> tags if it's too long;
  - Send a link to a Gist, GitHub reposity, Pastebin, etc.;
 -->
 
-## Expected Behavior
-<!--- Tell us what should happen -->
-
-## Actual Behavior
-<!--- Tell us what happens instead -->
-
 ## Steps to Reproduce
 1.
 2.
 3.
 4.
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Actual Behavior
+<!--- Tell us what happens instead -->
 
 ## Steps Taken to Fix
 <!--- When this problem came up, what did you try before reporting it? -->


### PR DESCRIPTION
Having created some reports to TLA+ it always feels weird to me to see how in the issue template the "Expected behavior" goes *before* "Steps to reproduce".

Take [this report](https://github.com/tlaplus/tlaplus/issues/929) for example: when I read from top to bottom, I see paragraph "Expected behavior" starting with `You succeed` — and I think to myself "Mhm? Succeed in what?". This is confusing. That's because paragraphs "Expected/Actual" describe whatever happens from the "Steps" *(whereas "Description" paragraph usually provides some general information: usecase, why, when; basically creates context for "minimal steps" further below)*. But since "Steps" are located after the "expected result", this breaks reader's flow and creates confusion.

So, how about moving "Steps to reproduce" to go before Expected/Actual?
