### PR TITLE
Fix java 11 warnings

### DIFF
--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -475,6 +475,8 @@
 			release="${java.release}"
 			encoding="UTF-8"
 		>
+			<!-- Treat all warnings as errors. -->
+			<compilerarg value="-Werror" />
 			<classpath refid="project.classpath" />
 			<classpath>
 				<pathelement location="lib/junit-4.12.jar" />

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -143,15 +143,15 @@
 	<!-- Compiles the TLA+ tools code -->
 	<target name="compile" depends="clean, generate">
 		<echo>
-			==================================================================
-			= This code uses sun.misc.Unsafe for manual memory management in =
-			= the class src/tlc2/tool/fp/LongArray.java. This unsafe API is  =
-			= marked as internal meaning it can change without warning.      =
-			= Ordinarily this would result in a lot of compiler warnings,    =
-			= but to reduce noise these have been explicitly silenced. If    =
-			= the build fails after upgrading Java, it might be because this =
-			= API has been changed.                                          =
-			==================================================================
+==================================================================
+= This code uses sun.misc.Unsafe for manual memory management in =
+= the class src/tlc2/tool/fp/LongArray.java. This unsafe API is  =
+= marked as internal meaning it can change without warning. Java =
+= emits a lot of warnings about this and makes it essentially    =
+= impossible to silence them, so just ignore them. The unsafe    =
+= API is in the process of being standardized in newer versions  =
+= of Java and we will switch to that as soon as possible.        =
+==================================================================
 		</echo>
 		<mkdir dir="${class.dir}" />
 		<javac
@@ -163,12 +163,6 @@
 			release="${java.release}"
 			encoding="UTF-8"
 		>
-			<!--
-				Suppress sun.misc.Unsafe warnings. These warnings cannot be suppressed
-				using in-file annotations like ordinary warnings, so we must completely
-				ignore all warnings from the file here.
-			-->
-			<compilerarg line="-XDignore.symbol.file=src/tlc2/tool/fp/LongArray.java" />
 			<classpath refid="project.classpath" />
 			<classpath>
 				<pathelement location="lib/javax.mail/mailapi-1.6.3.jar" />

--- a/tlatools/org.lamport.tlatools/src/pcal/PCalUnrecoverableErrorRuntimeException.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PCalUnrecoverableErrorRuntimeException.java
@@ -7,6 +7,7 @@ package pcal;
  * @version $Id$
  * @deprecated TODO this should be re-factored and not used further 
  */
+@Deprecated
 public class PCalUnrecoverableErrorRuntimeException extends RuntimeException
 {
 

--- a/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/PcalTranslate.java
@@ -295,6 +295,7 @@ public class PcalTranslate {
     /**
      * @deprecated method not used
      */
+    @Deprecated
     private static AST.If IfForLabelIf (TLAExpr test,
                                         Vector unlabThen,
                                         String nextThen,

--- a/tlatools/org.lamport.tlatools/src/tla2sany/configuration/ASCII_CharStream.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/configuration/ASCII_CharStream.java
@@ -194,7 +194,7 @@ public final class ASCII_CharStream
    * @deprecated 
    * @see #getEndColumn
    */
-
+  @Deprecated
   static public final int getColumn() {
      return bufcolumn[bufpos];
   }
@@ -203,7 +203,7 @@ public final class ASCII_CharStream
    * @deprecated 
    * @see #getEndLine
    */
-
+  @Deprecated
   static public final int getLine() {
      return bufline[bufpos];
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
@@ -615,6 +615,7 @@ public class ParseUnit {
   * modified accordingly.                                                  *
   * @deprecated not used (no local references)
   *************************************************************************/
+  @Deprecated
   private void getInstanceInLet(TreeNode treeNode, ModuleRelatives currentRelatives) {
     TreeNode[] children = treeNode.heirs();  
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -118,6 +118,7 @@ public class SpecObj
      * @deprecated please use the {@link SpecObj#SpecObj(String, FilenameToStream)} 
      * with <code>null</code> as a second argument
      */
+    @Deprecated
     public SpecObj(String pfn)
     {
         this(pfn, null);

--- a/tlatools/org.lamport.tlatools/src/tla2sany/utilities/Assert.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/utilities/Assert.java
@@ -9,6 +9,7 @@ package tla2sany.utilities;
  * 
  * @deprecated Use {@linkplain util.Assert} instead of this class
  */
+@Deprecated
 public class Assert
 {
 
@@ -16,6 +17,7 @@ public class Assert
     /**
      * @deprecated Use {@linkplain util.Assert#check(boolean, int, String[])} instead of this method
      */
+    @Deprecated
     public final static void assertion(boolean b)
     {
         // if (!b) {
@@ -28,6 +30,7 @@ public class Assert
     /**
      * @deprecated Use {@linkplain util.Assert#fail(int, String[])} instead of this method
      */
+    @Deprecated
     public final static void fail(String msg)
     {
         // ToolIO.err.println("Error: " + msg);

--- a/tlatools/org.lamport.tlatools/src/tlc2/model/TypedSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/model/TypedSet.java
@@ -340,6 +340,7 @@ public class TypedSet {
      * @return true if on of the values (taking the type into account) is a digit
      * @deprecated
      */
+    @Deprecated
     public boolean hasANumberOnlyValue()
     {
         if (hasType())

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/FPSetConfiguration.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/FPSetConfiguration.java
@@ -117,6 +117,7 @@ public class FPSetConfiguration implements Serializable {
 	 *             only accepts a ratio rather than an absolute memory value
 	 * @param fpMemSize
 	 */
+	@Deprecated
 	public void setMemory(long fpMemSize) {
 		Assert.check(fpMemSize >= 0, EC.GENERAL);
 		this.memoryInBytes = fpMemSize;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/MemFPSet1.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/MemFPSet1.java
@@ -24,6 +24,7 @@ import util.FileUtil;
  * @deprecated not used currently
  * @version $Id$
  */
+@Deprecated
 public final class MemFPSet1 extends FPSet {
   private String metadir;
   private String filename;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
@@ -774,6 +774,7 @@ public class ModelConfig implements ValueConstants, Serializable {
      * @param args
      * @deprecated
      */
+    @Deprecated
     public static void main(String[] args)
     {
         try

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/BigSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/BigSet.java
@@ -15,6 +15,7 @@ import util.Set;
  * @deprecated currently not used
  * @version $Id$
  */
+@Deprecated
 public class BigSet {
   private static int MaxSize = 10000;
   // four rehashings give ~(>) 13440 els., and .75*13440 ~ 10000
@@ -33,6 +34,7 @@ public class BigSet {
   /**
    * @deprecated currently not used
    */
+  @Deprecated
   public BigSet(String file) {
     this(MaxSize, InitialSize, file); 
   }
@@ -40,6 +42,7 @@ public class BigSet {
   /**
    * @deprecated currently not used
    */
+  @Deprecated
   public BigSet(int maxSize, String file) {
     this(maxSize, InitialSize, file);
   }
@@ -47,6 +50,7 @@ public class BigSet {
   /**
    * @deprecated currently not used
    */
+  @Deprecated
   public BigSet(int maxSize, int initialSize, String file) {
     this.maxSize = maxSize;
     this.initialSize = initialSize;

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/SymmetryTableauLiveCheckTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/SymmetryTableauLiveCheckTest.java
@@ -289,7 +289,7 @@ public class SymmetryTableauLiveCheckTest {
 	private ILiveCheck getLiveCheckWithTwoNodeTableauSymmetry(final TLCState s, final TLCState sSymmetric, final TLCState t) throws IOException {
 		final TBGraphNode node2 = EasyMock.createMock(TBGraphNode.class);
 		// consistency
-		final Capture<TLCState> capture = new Capture<TLCState>();
+		final Capture<TLCState> capture = Capture.newInstance();
 		EasyMock.expect(node2.isConsistent(EasyMock.capture(capture), (ITool) EasyMock.anyObject())).andAnswer(new IAnswer<Boolean>() {
 			public Boolean answer() throws Throwable {
 				final TLCState value = capture.getValue();
@@ -309,7 +309,7 @@ public class SymmetryTableauLiveCheckTest {
 		
 		final TBGraphNode node1 = EasyMock.createMock(TBGraphNode.class);
 		// consistency
-		final Capture<TLCState> capture1 = new Capture<TLCState>();
+		final Capture<TLCState> capture1 = Capture.newInstance();
 		EasyMock.expect(node1.isConsistent(EasyMock.capture(capture1), (ITool) EasyMock.anyObject())).andAnswer(new IAnswer<Boolean>() {
 			public Boolean answer() throws Throwable {
 				final TLCState value = capture1.getValue();
@@ -359,7 +359,7 @@ public class SymmetryTableauLiveCheckTest {
 		
 		final ITool tool = EasyMock.createNiceMock(ITool.class);
 		EasyMock.expect(tool.hasSymmetry()).andReturn(true);
-		final Capture<TLCState> nextStates = new Capture<TLCState>();
+		final Capture<TLCState> nextStates = Capture.newInstance();
 		EasyMock.expect(tool.getNextStates((Action) EasyMock.anyObject(), EasyMock.capture(nextStates))).andAnswer(new IAnswer<StateVec>() {
 			public StateVec answer() throws Throwable {
 			    final StateVec nss = new StateVec(0);

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/other/CheckFP.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/other/CheckFP.java
@@ -16,6 +16,7 @@ import tlc2.util.BufferedRandomAccessFile;
  * This program does these sanity checkings.
  * @deprecated (SZ February 19, 2009)
  */
+@Deprecated
 public class CheckFP {
   public static void main(String args[]) {
     try {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/other/CurrentDir.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/other/CurrentDir.java
@@ -11,6 +11,7 @@ import java.io.File;
  * Simple printing utility
  * @deprecated is likely not used (SZ February 19, 2009)
  */
+@Deprecated
 public class CurrentDir
 {
     public static void main(String args[])

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/other/FileClassLoader.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/other/FileClassLoader.java
@@ -14,6 +14,7 @@ import java.io.IOException;
  * it seems to be a helper utility used during the development 
  * @deprecated according to the paths it is not used (SZ February 19, 2009) 
  */
+@Deprecated
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class FileClassLoader extends ClassLoader {
   /* Load a class from a file. */


### PR DESCRIPTION
This extracts the un-contentious changes from #931 to fix a bunch of trivial warnings about deprecated functions that were introduced by the migration to Java 11.

It adds `-Werror` to the `compile-test` target at least.