### PR TITLE
Fix handling of integral time elapse in UT parse/summary script

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         echo "Unit test exit code: $UT_EXIT_CODE"
         python .github/scripts/parse-unit-test-output.py        \
+          $UT_EXIT_CODE                                         \
           test-output.txt                                       \
           tlatools/org.lamport.tlatools/target/surefire-reports
         exit $UT_EXIT_CODE


### PR DESCRIPTION
Bug exposed in PR #953

The source of the bug was the expectation that elapsed time would always take the decimal form `123.123 sec`. The test failures in question elapsed in `0 sec` because it was an entirely commented-out file.

This will also print out a warning if test failures were expected but could not be found.