### PR TITLE
<fix> fix javvcc generator error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,10 @@ on: [pull_request]
 jobs:
   tlatools-build-and-test:
     name: TLA+ Tools Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include: [ubuntu-latest, windows-latest]
     steps:
     - name: Clone tlaplus/tlaplus
       uses: actions/checkout@v4

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,7 +19,7 @@ Make sure that you're using Java 11+. If you're using a lower version you'll see
 
 You can build TLC from a fresh clone of this repository+:
 ```bash
-$ git clone https://github.com/tlaplus.git
+$ git clone https://github.com/tlaplus/tlaplus.git
 $ cd tlaplus/tlatools/org.lamport.tlatools
 $ ant -f customBuild.xml info clean compile compile-test dist
 ```

--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -97,6 +97,7 @@
 		<java classpath="lib/javacc-4.0.jar" classname="javacc" fork="true" failonerror="true">
 			<arg value="-OUTPUT_DIRECTORY=${javacc-tmpdir}" />
 			<arg value="javacc/tla+.jj" />
+			<jvmarg value="-Dfile.encoding=UTF-8" />
 		</java>
 		<fixcrlf srcdir="${javacc-tmpdir}" eol="lf" includes="*.java" />
 		<move todir="src/tla2sany/parser">


### PR DESCRIPTION
Hi, I find that when I compiles tlatools.jar, the javacc will report some errors due to a missing configuration of UTF_8 charset. 

![TLC generate UTF-8-1](https://github.com/tlaplus/tlaplus/assets/43179325/2872b62e-f333-464f-a558-1c83c47fe320)

I see there are some other issues about the charset in javacc, like #919 . However, unlike that issue, this commit is simple and I hope it can prevent some compilering confusions for a short time to come.

By the way, I also found a small mistake on DEVELOPING.md. The link to tlaplus repository is not right. I also update it.