### PR TITLE
Reset random number generator before evaluating constants per worker.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/WorkerValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/WorkerValue.java
@@ -32,6 +32,7 @@ import tlc2.tool.coverage.CostModel;
 import tlc2.util.Context;
 import tlc2.util.IdThread;
 import tlc2.value.IValue;
+import tlc2.value.RandomEnumerableValues;
 
 /*
 Root Cause:
@@ -121,7 +122,13 @@ public class WorkerValue {
     		final IValue[] values = new IValue[TLCGlobals.getNumWorkers()];
     		values[0] = defVal;
 
+    		final long seed = RandomEnumerableValues.getSeed();
     		for (int i = 1; i < values.length; i++) {
+    			// Resetting the random seed ensures that operators involving RandomElement or
+    			// those from the Randomization module evaluate to consistent values across all
+    			// workers. Without this, workers might assign different values to constants and
+    			// constant definitions, leading to bogus counterexamples.
+    			RandomEnumerableValues.setSeed(seed);
     			// Ideally, we could invoke IValue#deepCopy here instead of evaluating opDef again.  However,
     			// IValue#deepCopy doesn't create copies for most values.
     			values[i] = spec.eval(en, Context.Empty, TLCState.Empty, cm);

--- a/tlatools/org.lamport.tlatools/test-model/Github866.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github866.tla
@@ -1,20 +1,52 @@
 ---------------------------- MODULE Github866 ---------------------------
-EXTENDS Naturals, TLC, FiniteSets
+EXTENDS Naturals, TLC
+
+\* Test requires at least two workers.
+ASSUME TLCGet("config").worker > 1
+
+r == 0
+
+\* Initialize the register to a value *outside* of X.
+ASSUME TLCSet(r, {0})
+
+\* At startup, SpecProcessor evaluates X. The likelihood that two or more
+\* workers will evaluate X differently is proportional to the size of the
+\* input set provided to RandomElement.
+X ==
+  \* The value that RandomElement evaluates to has to be nested in a TLC 
+  \* IValue instance that may change its internal representation during
+  \* normalization/fingerprinting (see IValue#mutates). Otherwise,
+  \* WorkerValue#demux becomes a no-op.
+  {RandomElement(1..10000)}
+
+-------------------------------------------------------------------------
+
 VARIABLES x
-vars == << x >>
 
-X == {RandomElement({1,2,3})}
+Init ==
+  x = 0
 
-Init == x = 0
-Lbl_1 == /\ x < 50 \* Generate some states to ensure both workers have work to do.
-         /\ TLCSet(42, X)
-         /\ x' = x + 1
+Next ==
+  \* Keep going until all workers have evaluated next.
+  /\ \E w \in 1..TLCGet("config").worker: 
+          TLCGet("all")[r][w] = {0}
+  /\ x' = x + 1
+  \* Set the register value r to the worker-specific value of X.
+  /\ TLCSet(r, X)
 
-Next == Lbl_1
+Spec ==
+  Init /\ [][Next]_x
 
-Spec == Init /\ [][Next]_vars
+-------------------------------------------------------------------------
 
+PostCondition ==
+  /\ PrintT(TLCGet("all")[r])
+  /\ \A v,w \in 1..TLCGet("config").worker:
+       /\ TLCGet("all")[r][v] # {0}
+       /\ TLCGet("all")[r][v] = TLCGet("all")[r][w]
+       
 ==========================================================================
 ---------------------------- CONFIG Github866 ----------------------------
 SPECIFICATION Spec
-=============================
+POSTCONDITION PostCondition
+==========================================================================

--- a/tlatools/org.lamport.tlatools/test-model/Github866.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github866.tla
@@ -1,0 +1,20 @@
+---------------------------- MODULE Github866 ---------------------------
+EXTENDS Naturals, TLC, FiniteSets
+VARIABLES x
+vars == << x >>
+
+X == {RandomElement({1,2,3})}
+
+Init == x = 0
+Lbl_1 == /\ x < 50 \* Generate some states to ensure both workers have work to do.
+         /\ TLCSet(42, X)
+         /\ x' = x + 1
+
+Next == Lbl_1
+
+Spec == Init /\ [][Next]_vars
+
+==========================================================================
+---------------------------- CONFIG Github866 ----------------------------
+SPECIFICATION Spec
+=============================

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github866Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github866Test.java
@@ -29,14 +29,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.junit.Test;
 
-import tlc2.TLCGlobals;
 import tlc2.output.EC;
 import tlc2.tool.liveness.ModelCheckerTestCase;
-import tlc2.value.IValue;
 
 public class Github866Test extends ModelCheckerTestCase {
 
@@ -54,16 +51,6 @@ public class Github866Test extends ModelCheckerTestCase {
 	public void testSpec() throws IOException {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
 		assertFalse(recorder.recorded(EC.GENERAL));
-		
-        final List<IValue> allValue = TLCGlobals.mainChecker.getAllValue(42);
-        IValue w1 = allValue.get(0);
-        IValue w2 = allValue.get(1);
-
-        // Either one worker did all the work, so the other has null for key 42
-        boolean oneWorkerWorked = w1 == null ^ w2 == null;
-        // Or both workers did all the work, so they both have non-null key 42
-        boolean bothWorkersWorked = w1 != null && w2 != null && w1.equals(w2);
-        assertTrue(oneWorkerWorked || bothWorkersWorked);
 	}
 	
 	// overrides below are nice-to-have but not relevant for the test.

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github866Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github866Test.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Federico Ponzi - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.TLCGlobals;
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+import tlc2.value.IValue;
+
+public class Github866Test extends ModelCheckerTestCase {
+
+	public Github866Test() {
+		super("Github866", new String[] { "-config", "Github866.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected int getNumberOfThreads() {
+		// Test requires more than one worker, and 2 seemed like a good number.
+		return 2;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+        final List<IValue> allValue = TLCGlobals.mainChecker.getAllValue(42);
+        IValue w1 = allValue.get(0);
+        IValue w2 = allValue.get(1);
+
+        // Either one worker did all the work, so the other has null for key 42
+        boolean oneWorkerWorked = w1 == null ^ w2 == null;
+        // Or both workers did all the work, so they both have non-null key 42
+        boolean bothWorkersWorked = w1 != null && w2 != null && w1.equals(w2);
+        assertTrue(oneWorkerWorked || bothWorkersWorked);
+	}
+	
+	// overrides below are nice-to-have but not relevant for the test.
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	protected boolean doDump() {
+		return false;
+	}
+
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+}


### PR DESCRIPTION
Fixes Github issue #866
https://github.com/tlaplus/tlaplus/issues/866

[Bug][TLC]