### PR TITLE
Add missing `init` calls in `MultiFPSetTest`

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/MultiFPSetTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/MultiFPSetTest.java
@@ -114,6 +114,7 @@ public class MultiFPSetTest {
 		FPSetConfiguration conf = new FPSetConfiguration();
 		conf.setFpBits(1);
 		final MultiFPSet mfps = new MultiFPSet(conf);
+		mfps.init(1, tmpdir, "testPutMax");
 
 		// put a random fp value into set
 		try {
@@ -132,6 +133,7 @@ public class MultiFPSetTest {
 		FPSetConfiguration conf = new FPSetConfiguration();
 		conf.setFpBits(1);
 		final MultiFPSet mfps = new MultiFPSet(conf);
+		mfps.init(1, tmpdir, "testPutMin");
 
 		// put a random fp value into set
 		try {
@@ -150,6 +152,7 @@ public class MultiFPSetTest {
 		FPSetConfiguration conf = new FPSetConfiguration();
 		conf.setFpBits(1);
 		final MultiFPSet mfps = new MultiFPSet(conf);
+		mfps.init(1, tmpdir, "testPutZero");
 
 		// put a random fp value into set
 		try {


### PR DESCRIPTION
This should improve the reliability of this test, fixing exceptions like

    Table violates invariants prior to eviction: [...]

thrown by `OffHeapDiskFPSet.checkInput`.

The tests now pass even with the very pessimistic patch below in place; previously they did not always pass because the internal `LongArray` object(s) could have arbitrary contents.  The call to `init` is responsible for zeroing out any internal `LongArray` objects.

Test patch (not checked in for performance reasons):

    diff --git a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
    index 85e720456..e90023632 100644
    --- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
    +++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
    @@ -7,10 +7,12 @@ import java.util.ArrayList;
     import java.util.Collection;
     import java.util.Iterator;
     import java.util.List;
    +import java.util.Random;
     import java.util.concurrent.Callable;
     import java.util.concurrent.ExecutorService;
     import java.util.concurrent.Executors;
     import java.util.concurrent.Future;
    +import java.util.concurrent.ThreadLocalRandom;

     /*
      * On Java 11 (probably starting with 9) sun.misc.Unsafe is implemented on top @@ -30,6 +32,7 @@ import java.util.concurrent.Future;
      * command-line.  As we do not want to expose JVM parameters to them, we keep * sun.misc.Unsafe for now. */ +import sun.misc.Unsafe; import tlc2.output.EC; import util.Assert; import util.TLCRuntime; @@ -75,8 +78,15 @@ public final class LongArray { // (see FP64). Assert.check(this.unsafe.addressSize() == (Long.SIZE / 8), EC.GENERAL); baseAddress = this.unsafe.allocateMemory(positions << logAddressSize);
    +               randomize(unsafe, baseAddress, positions, ThreadLocalRandom.current());
            }
    -
    +
    +       private static void randomize(Unsafe unsafe, long baseAddress, long positions, Random rng) {
    +               for (long i = 0; i < positions; ++i) {
    +                       unsafe.putAddress(baseAddress + i*8, Math.abs(rng.nextLong()));
    +               }
    +       }
    +
            LongArray(final Collection<Long> from) {
                    this(from.size());