### PR TITLE
All JUnit tests fail when executed from within Eclipse unless the basedir is explicitly set.

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/CommonTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/CommonTestCase.java
@@ -54,7 +54,7 @@ import util.IsolatedTestCaseRunner;
 @RunWith(IsolatedTestCaseRunner.class)
 public abstract class CommonTestCase {
 
-	protected static final String BASE_DIR = System.getProperty("basedir", "");
+	protected static final String BASE_DIR = System.getProperty("basedir", System.getProperty("user.dir", "."));
 	protected static final String TEST_MODEL = "test-model" + File.separator;
 	public static final String BASE_PATH = System.getProperty("basepath", BASE_DIR + File.separator + TEST_MODEL);
 


### PR DESCRIPTION
Git commit ad454838ad3eaa296aad212e5e1d480b450ead37 unintentionally broke test execution in Eclipse. This commit, however, resolves the issue, so tests no longer require manually setting the basedir in Eclipse

[Tests][TLC]