### PR TITLE
Rearrange position of var "pc" in pluscal translations

### DIFF
--- a/tlatools/org.lamport.tlatools/test-model/CallGotoUnlabeledTest.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CallGotoUnlabeledTest.tla
@@ -23,9 +23,9 @@ C:
 
 end algorithm *)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-4786c31224fe8555dc7ad50128a92fc6
-VARIABLES x, pc, stack
+VARIABLES pc, x, stack
 
-vars == << x, pc, stack >>
+vars == << pc, x, stack >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/CallGotoUnlabeledTest.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CallGotoUnlabeledTest.tla
@@ -22,7 +22,7 @@ C:
   goto A;
 
 end algorithm *)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-4786c31224fe8555dc7ad50128a92fc6
+\* BEGIN TRANSLATION (chksum(pcal) = "1fe457ba" /\ chksum(tla) = "a7227a89")
 VARIABLES pc, x, stack
 
 vars == << pc, x, stack >>
@@ -66,6 +66,6 @@ Spec == Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-8ca0b91b1573d7c7ae4c4135afa5f61b
+\* END TRANSLATION
 
 ====

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Bakery.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Bakery.tla
@@ -49,9 +49,9 @@ Proc == 1..NumProcs  \* The set of processes
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-3787a86d71fe978e1e68a7e275a515ae
-VARIABLES num, choosing, pc, read, max, nxt
+VARIABLES pc, num, choosing, read, max, nxt
 
-vars == << num, choosing, pc, read, max, nxt >>
+vars == << pc, num, choosing, read, max, nxt >>
 
 ProcSet == (Proc)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Bakery.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Bakery.tla
@@ -48,7 +48,7 @@ Proc == 1..NumProcs  \* The set of processes
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-3787a86d71fe978e1e68a7e275a515ae
+\* BEGIN TRANSLATION (chksum(pcal) = "b88cf8f1" /\ chksum(tla) = "28b15ae")
 VARIABLES pc, num, choosing, read, max, nxt
 
 vars == << pc, num, choosing, read, max, nxt >>
@@ -131,7 +131,7 @@ Next == (\E self \in Proc: proc(self))
 
 Spec == Init /\ [][Next]_vars
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-044cd15e6eddcf8edc1cfa67089d17cf
+\* END TRANSLATION
 
 Constraint == \A i \in Proc : num[i] \leq MaxNum
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CBakery.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CBakery.tla
@@ -38,9 +38,9 @@ Proc == 1..NumProcs  \* The set of processes
 
   
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-3787a86d71fe978e1e68a7e275a515ae
-VARIABLES num, choosing, pc, read, max, nxt
+VARIABLES pc, num, choosing, read, max, nxt
 
-vars == << num, choosing, pc, read, max, nxt >>
+vars == << pc, num, choosing, read, max, nxt >>
 
 ProcSet == (Proc)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CBakery.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CBakery.tla
@@ -37,7 +37,7 @@ Proc == 1..NumProcs  \* The set of processes
 ********)
 
   
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-3787a86d71fe978e1e68a7e275a515ae
+\* BEGIN TRANSLATION (chksum(pcal) = "b88cf8f1" /\ chksum(tla) = "28b15ae")
 VARIABLES pc, num, choosing, read, max, nxt
 
 vars == << pc, num, choosing, read, max, nxt >>
@@ -120,7 +120,7 @@ Next == (\E self \in Proc: proc(self))
 
 Spec == Init /\ [][Next]_vars
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-044cd15e6eddcf8edc1cfa67089d17cf
+\* END TRANSLATION
 Constraint 
 == \A i \in Proc : num[i] \leq MaxNum
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CDiningPhilosophers.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CDiningPhilosophers.tla
@@ -40,7 +40,7 @@ l01 : while (TRUE)
           }
 } }
 ********)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-d34a24305f241c923d0f8daa00682e02
+\* BEGIN TRANSLATION (chksum(pcal) = "184c914a" /\ chksum(tla) = "597c9e51")
 VARIABLES pc, sem
 
 vars == << pc, sem >>
@@ -109,7 +109,7 @@ Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in 1..(N-1) : SF_vars(Proc(self))
         /\ SF_vars(Proc0)
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-ff7acdd47d76382441ae75c392052170
+\* END TRANSLATION
 
 IsEating(i) == IF i = 0 THEN pc[i] = "e0"
                         ELSE pc[i] = "e"

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CDiningPhilosophers.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CDiningPhilosophers.tla
@@ -41,9 +41,9 @@ l01 : while (TRUE)
 } }
 ********)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-d34a24305f241c923d0f8daa00682e02
-VARIABLES sem, pc
+VARIABLES pc, sem
 
-vars == << sem, pc >>
+vars == << pc, sem >>
 
 ProcSet == (1..(N-1)) \cup {0}
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CEither1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CEither1.tla
@@ -12,9 +12,9 @@ EXTENDS Naturals, Sequences, TLC
 *)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-af9f3b0389ad56ee237e79295b3205ff
-VARIABLES x, y, pc
+VARIABLES pc, x, y
 
-vars == << x, y, pc >>
+vars == << pc, x, y >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CEither1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CEither1.tla
@@ -11,7 +11,7 @@ EXTENDS Naturals, Sequences, TLC
      
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-af9f3b0389ad56ee237e79295b3205ff
+\* BEGIN TRANSLATION (chksum(pcal) = "f7b78f6e" /\ chksum(tla) = "7186648")
 VARIABLES pc, x, y
 
 vars == << pc, x, y >>
@@ -55,6 +55,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-91542970fa29f8acc63f0f9ca8f27be3
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CMultiprocDefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CMultiprocDefine.tla
@@ -16,7 +16,7 @@ EXTENDS Naturals, Sequences, TLC
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-9c797e1d4e2fc4c259c478fdea1bd5fa
 CONSTANT defaultInitValue
-VARIABLES n, pc
+VARIABLES pc, n
 
 (* define statement *)
 nplus1 == n + 1
@@ -24,7 +24,7 @@ nplus2 == nplus1 + 1
 
 VARIABLE i
 
-vars == << n, pc, i >>
+vars == << pc, n, i >>
 
 ProcSet == ({1, 2, 3})
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CMultiprocDefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CMultiprocDefine.tla
@@ -14,7 +14,7 @@ EXTENDS Naturals, Sequences, TLC
   
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-9c797e1d4e2fc4c259c478fdea1bd5fa
+\* BEGIN TRANSLATION (chksum(pcal) = "4bb9a304" /\ chksum(tla) = "1a7f1749")
 CONSTANT defaultInitValue
 VARIABLES pc, n
 
@@ -55,5 +55,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-70c2856f6a2b2707884c9cedc014d866
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CallReturn2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CallReturn2.tla
@@ -48,7 +48,7 @@ EXTENDS Naturals, Sequences, TLC
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-84a5cdf59d68214ad905732a585890ae
+\* BEGIN TRANSLATION (chksum(pcal) = "f5092fa7" /\ chksum(tla) = "23551e86")
 \* Procedure variable x of procedure P at line 13 col 16 changed to x_
 CONSTANT defaultInitValue
 VARIABLES pc, depth, stack, a, x_, y, aa, xx, yy, r, x, s
@@ -195,5 +195,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c8e76178d4d24aee35fa88a19dd439d8
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/CallReturn2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/CallReturn2.tla
@@ -51,9 +51,9 @@ EXTENDS Naturals, Sequences, TLC
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-84a5cdf59d68214ad905732a585890ae
 \* Procedure variable x of procedure P at line 13 col 16 changed to x_
 CONSTANT defaultInitValue
-VARIABLES depth, pc, stack, a, x_, y, aa, xx, yy, r, x, s
+VARIABLES pc, depth, stack, a, x_, y, aa, xx, yy, r, x, s
 
-vars == << depth, pc, stack, a, x_, y, aa, xx, yy, r, x, s >>
+vars == << pc, depth, stack, a, x_, y, aa, xx, yy, r, x, s >>
 
 Init == (* Global variables *)
         /\ depth = 3

--- a/tlatools/org.lamport.tlatools/test-model/pcal/DetlefSpec.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/DetlefSpec.tla
@@ -29,7 +29,7 @@ L2:   rV := null
     } } }
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-1ffa57620b1dc5120c521caddbcfa0df
+\* BEGIN TRANSLATION (chksum(pcal) = "ef5d02d1" /\ chksum(tla) = "8f1961dc")
 VARIABLES pc, queue, rV
 
 vars == << pc, queue, rV >>
@@ -71,7 +71,7 @@ Next == (\E self \in Procs: P(self))
 Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in Procs : WF_vars(P(self))
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-a5e9e9156ce3a9bf6c7fb3f657f54020
+\* END TRANSLATION
 
 CONSTANT N
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/DetlefSpec.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/DetlefSpec.tla
@@ -30,9 +30,9 @@ L2:   rV := null
 *)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-1ffa57620b1dc5120c521caddbcfa0df
-VARIABLES queue, pc, rV
+VARIABLES pc, queue, rV
 
-vars == << queue, pc, rV >>
+vars == << pc, queue, rV >>
 
 ProcSet == (Procs)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Dijkstra1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Dijkstra1.tla
@@ -27,9 +27,9 @@ CONSTANT K, N
 ASSUME (K > N) /\ (N > 0) 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-64143a14f748e286ec27eafe96303703
-VARIABLES M, pc
+VARIABLES pc, M
 
-vars == << M, pc >>
+vars == << pc, M >>
 
 ProcSet == {0} \cup (1..(N-1))
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Dijkstra1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Dijkstra1.tla
@@ -26,7 +26,7 @@ CONSTANT K, N
 
 ASSUME (K > N) /\ (N > 0) 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-64143a14f748e286ec27eafe96303703
+\* BEGIN TRANSLATION (chksum(pcal) = "745d7796" /\ chksum(tla) = "72549c2c")
 VARIABLES pc, M
 
 vars == << pc, M >>
@@ -67,7 +67,7 @@ Spec == /\ Init /\ [][Next]_vars
         /\ WF_vars(P0)
         /\ \A self \in 1..(N-1) : WF_vars(Pi(self))
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-80735c28b54285a89ec67fce31b85c9d
+\* END TRANSLATION
 
 HasToken(self) == \/ (self = 0) /\ (M[0] = M[N - 1])
                   \/ (self > 0) /\ (M[self] # M[self - 1])

--- a/tlatools/org.lamport.tlatools/test-model/pcal/DiningPhilosophers.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/DiningPhilosophers.tla
@@ -48,9 +48,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-d34a24305f241c923d0f8daa00682e02
-VARIABLES sem, pc
+VARIABLES pc, sem
 
-vars == << sem, pc >>
+vars == << pc, sem >>
 
 ProcSet == (1..(N-1)) \cup {0}
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/DiningPhilosophers.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/DiningPhilosophers.tla
@@ -47,7 +47,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-d34a24305f241c923d0f8daa00682e02
+\* BEGIN TRANSLATION (chksum(pcal) = "184c914a" /\ chksum(tla) = "597c9e51")
 VARIABLES pc, sem
 
 vars == << pc, sem >>
@@ -116,7 +116,7 @@ Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in 1..(N-1) : SF_vars(Proc(self))
         /\ SF_vars(Proc0)
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-ff7acdd47d76382441ae75c392052170
+\* END TRANSLATION
 
 IsEating(i) == IF i = 0 THEN pc[i] = "e0"
                         ELSE pc[i] = "e"

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either1.tla
@@ -10,7 +10,7 @@ EXTENDS Naturals, Sequences, TLC
      end algorithm
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-af9f3b0389ad56ee237e79295b3205ff
+\* BEGIN TRANSLATION (chksum(pcal) = "f7b78f6e" /\ chksum(tla) = "7186648")
 VARIABLES pc, x, y
 
 vars == << pc, x, y >>
@@ -54,6 +54,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-91542970fa29f8acc63f0f9ca8f27be3
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either1.tla
@@ -11,9 +11,9 @@ EXTENDS Naturals, Sequences, TLC
 *)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-af9f3b0389ad56ee237e79295b3205ff
-VARIABLES x, y, pc
+VARIABLES pc, x, y
 
-vars == << x, y, pc >>
+vars == << pc, x, y >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either2.tla
@@ -15,7 +15,7 @@ EXTENDS Naturals, Sequences, TLC
      end algorithm
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-92c2a3ead1499974b8b837c3d25d0ccd
+\* BEGIN TRANSLATION (chksum(pcal) = "d9025312" /\ chksum(tla) = "1742027")
 VARIABLES pc, x, y, z
 
 vars == << pc, x, y, z >>
@@ -66,6 +66,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-dc9b13cd9fc5d96b6144b722cc2ffb3d
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either2.tla
@@ -16,9 +16,9 @@ EXTENDS Naturals, Sequences, TLC
 *)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-92c2a3ead1499974b8b837c3d25d0ccd
-VARIABLES x, y, z, pc
+VARIABLES pc, x, y, z
 
-vars == << x, y, z, pc >>
+vars == << pc, x, y, z >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either3.tla
@@ -17,9 +17,9 @@ EXTENDS Naturals, Sequences, TLC
 *)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-d275a21163e8b7088902b968d404026a
-VARIABLES x, y, z, pc
+VARIABLES pc, x, y, z
 
-vars == << x, y, z, pc >>
+vars == << pc, x, y, z >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either3.tla
@@ -16,7 +16,7 @@ EXTENDS Naturals, Sequences, TLC
      end algorithm
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-d275a21163e8b7088902b968d404026a
+\* BEGIN TRANSLATION (chksum(pcal) = "bcbce20" /\ chksum(tla) = "24b6654e")
 VARIABLES pc, x, y, z
 
 vars == << pc, x, y, z >>
@@ -71,6 +71,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-db7d9133d865d6309280098cc66b6a85
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either5.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either5.tla
@@ -19,9 +19,9 @@ EXTENDS Naturals, Sequences, TLC
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-be6b6d1cc0a0bacc6a419e686126c4c9
 \* Label a at line 10 col 16 changed to a_
 CONSTANT defaultInitValue
-VARIABLES x, y, z, pc, stack, a
+VARIABLES pc, x, y, z, stack, a
 
-vars == << x, y, z, pc, stack, a >>
+vars == << pc, x, y, z, stack, a >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Either5.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Either5.tla
@@ -16,7 +16,7 @@ EXTENDS Naturals, Sequences, TLC
      end algorithm
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-be6b6d1cc0a0bacc6a419e686126c4c9
+\* BEGIN TRANSLATION (chksum(pcal) = "145cbee8" /\ chksum(tla) = "7faba95b")
 \* Label a at line 10 col 16 changed to a_
 CONSTANT defaultInitValue
 VARIABLES pc, x, y, z, stack, a
@@ -79,6 +79,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-5c5a7c7b427cee2468d220b4a9fada35
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Euclid.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Euclid.tla
@@ -42,7 +42,7 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
                       
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-a069024aba51f10ce87a41824584b8ee
+\* BEGIN TRANSLATION (chksum(pcal) = "28795ef" /\ chksum(tla) = "5a156737")
 VARIABLES pc, u_ini, v_ini, u, v
 
 vars == << pc, u_ini, v_ini, u, v >>
@@ -84,7 +84,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-969126b68f5e9c79e9cbf33f45804301
+\* END TRANSLATION
 
 
 Invariant == 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Euclid.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Euclid.tla
@@ -43,9 +43,9 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-a069024aba51f10ce87a41824584b8ee
-VARIABLES u_ini, v_ini, u, v, pc
+VARIABLES pc, u_ini, v_ini, u, v
 
-vars == << u_ini, v_ini, u, v, pc >>
+vars == << pc, u_ini, v_ini, u, v >>
 
 Init == (* Global variables *)
         /\ u_ini \in 1 .. MaxNum

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Euclid2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Euclid2.tla
@@ -22,7 +22,7 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
                         /\ y % j = 0
                         => i \geq j
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-e89e843c1bd319cda8806c448153d025
+\* BEGIN TRANSLATION (chksum(pcal) = "73539281" /\ chksum(tla) = "52535266")
 VARIABLES pc, u, v, v_ini
 
 vars == << pc, u, v, v_ini >>
@@ -63,6 +63,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-13d9c528c7c380488278c40608c11ba4
+\* END TRANSLATION
  
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Euclid2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Euclid2.tla
@@ -23,9 +23,9 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
                         => i \geq j
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-e89e843c1bd319cda8806c448153d025
-VARIABLES u, v, v_ini, pc
+VARIABLES pc, u, v, v_ini
 
-vars == << u, v, v_ini, pc >>
+vars == << pc, u, v, v_ini >>
 
 Init == (* Global variables *)
         /\ u = 24

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Euclid3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Euclid3.tla
@@ -22,9 +22,9 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
                         => i \geq j
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-309bc67718dab989f45f39e55b144a3e
-VARIABLES u, v, v_ini, pc
+VARIABLES pc, u, v, v_ini
 
-vars == << u, v, v_ini, pc >>
+vars == << pc, u, v, v_ini >>
 
 Init == (* Global variables *)
         /\ u = 24

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Euclid3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Euclid3.tla
@@ -21,7 +21,7 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
                         /\ y % j = 0
                         => i \geq j
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-309bc67718dab989f45f39e55b144a3e
+\* BEGIN TRANSLATION (chksum(pcal) = "675f3d56" /\ chksum(tla) = "117dc46c")
 VARIABLES pc, u, v, v_ini
 
 vars == << pc, u, v, v_ini >>
@@ -61,6 +61,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-696f44302fe4977c6881615aedc0e885
+\* END TRANSLATION
  
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/EvenOdd.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/EvenOdd.tla
@@ -32,9 +32,9 @@ CONSTANT N
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-a4673a20b45b60ed7b169b671068cf77
-VARIABLES result, pc, stack, xEven, xOdd
+VARIABLES pc, result, stack, xEven, xOdd
 
-vars == << result, pc, stack, xEven, xOdd >>
+vars == << pc, result, stack, xEven, xOdd >>
 
 Init == (* Global variables *)
         /\ result = FALSE

--- a/tlatools/org.lamport.tlatools/test-model/pcal/EvenOdd.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/EvenOdd.tla
@@ -31,7 +31,7 @@ CONSTANT N
 ----------------------------------------------
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-a4673a20b45b60ed7b169b671068cf77
+\* BEGIN TRANSLATION (chksum(pcal) = "c9b7b3f7" /\ chksum(tla) = "76b647d3")
 VARIABLES pc, result, stack, xEven, xOdd
 
 vars == << pc, result, stack, xEven, xOdd >>
@@ -109,7 +109,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c666315b11da5eecc32bda536975b934
+\* END TRANSLATION
 
 ==============================================
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/EvenOddBad.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/EvenOddBad.tla
@@ -26,9 +26,9 @@ end algorithm
 *)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-4f4604590279cc4b2920a972bf28fdd0
-VARIABLES result, pc, stack, xEven, xOdd
+VARIABLES pc, result, stack, xEven, xOdd
 
-vars == << result, pc, stack, xEven, xOdd >>
+vars == << pc, result, stack, xEven, xOdd >>
 
 Init == (* Global variables *)
         /\ result \in { TRUE, FALSE }

--- a/tlatools/org.lamport.tlatools/test-model/pcal/EvenOddBad.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/EvenOddBad.tla
@@ -25,7 +25,7 @@ begin
 end algorithm
 *)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-4f4604590279cc4b2920a972bf28fdd0
+\* BEGIN TRANSLATION (chksum(pcal) = "3e253c1f" /\ chksum(tla) = "e431c312")
 VARIABLES pc, result, stack, xEven, xOdd
 
 vars == << pc, result, stack, xEven, xOdd >>
@@ -108,6 +108,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-7dc8ff54d82fc57126829898458b6c6f
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Factorial.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Factorial.tla
@@ -21,7 +21,7 @@ EXTENDS Naturals, Sequences, TLC
   end algorithm
 ***************************************************************************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-8354903ee5c9ddae0b8bb4f55d782009
+\* BEGIN TRANSLATION (chksum(pcal) = "bdf4fde5" /\ chksum(tla) = "f9927dd9")
 VARIABLES pc, result, stack, arg1, u
 
 vars == << pc, result, stack, arg1, u >>
@@ -76,7 +76,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-53ca468546a563a45762642894b2b2a3
+\* END TRANSLATION
 
 
 Invariant == result \in Nat

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Factorial.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Factorial.tla
@@ -22,9 +22,9 @@ EXTENDS Naturals, Sequences, TLC
 ***************************************************************************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-8354903ee5c9ddae0b8bb4f55d782009
-VARIABLES result, pc, stack, arg1, u
+VARIABLES pc, result, stack, arg1, u
 
-vars == << result, pc, stack, arg1, u >>
+vars == << pc, result, stack, arg1, u >>
 
 Init == (* Global variables *)
         /\ result = 1

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Factorial2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Factorial2.tla
@@ -33,9 +33,9 @@ Factorial Algorithm with 2 procedures
 ***************************************************************************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-7a6949afa2a72d41ea8a9ba97e423c98
-VARIABLES result, pc, stack, arg1, u, arg2, u2
+VARIABLES pc, result, stack, arg1, u, arg2, u2
 
-vars == << result, pc, stack, arg1, u, arg2, u2 >>
+vars == << pc, result, stack, arg1, u, arg2, u2 >>
 
 Init == (* Global variables *)
         /\ result = 1

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Factorial2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Factorial2.tla
@@ -32,7 +32,7 @@ Factorial Algorithm with 2 procedures
   end algorithm
 ***************************************************************************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-7a6949afa2a72d41ea8a9ba97e423c98
+\* BEGIN TRANSLATION (chksum(pcal) = "d9439ef1" /\ chksum(tla) = "a3f16e6a")
 VARIABLES pc, result, stack, arg1, u, arg2, u2
 
 vars == << pc, result, stack, arg1, u, arg2, u2 >>
@@ -125,7 +125,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-6c949f27864a3ffc1d874b0a64419ab7
+\* END TRANSLATION
 
 
 Invariant == result \in Nat

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq.tla
@@ -11,9 +11,9 @@ PlusCal options (version 1.5)
 }
  ***************************************************************************)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-07e0e68497291a78b07d8fb9d5597180
-VARIABLES x, pc
+VARIABLES pc, x
 
-vars == << x, pc >>
+vars == << pc, x >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq.tla
@@ -10,7 +10,7 @@ PlusCal options (version 1.5)
     }
 }
  ***************************************************************************)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-07e0e68497291a78b07d8fb9d5597180
+\* BEGIN TRANSLATION (chksum(pcal) = "bdda0c6a" /\ chksum(tla) = "afe7b75d")
 VARIABLES pc, x
 
 vars == << pc, x >>
@@ -37,7 +37,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-8d9de25f8162fd0489585bc374dff964
+\* END TRANSLATION
 =============================================================================
 \* Modification History
 \* Last modified Sun Mar 20 10:13:11 PDT 2011 by lamport

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq2.tla
@@ -11,9 +11,9 @@ PlusCal options (version 1.5)
 }
  ***************************************************************************)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-07e0e68497291a78b07d8fb9d5597180
-VARIABLES x, pc
+VARIABLES pc, x
 
-vars == << x, pc >>
+vars == << pc, x >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FairSeq2.tla
@@ -10,7 +10,7 @@ PlusCal options (version 1.5)
     }
 }
  ***************************************************************************)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-07e0e68497291a78b07d8fb9d5597180
+\* BEGIN TRANSLATION (chksum(pcal) = "7c28162a" /\ chksum(tla) = "afe7b75d")
 VARIABLES pc, x
 
 vars == << pc, x >>
@@ -37,7 +37,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-8d9de25f8162fd0489585bc374dff964
+\* END TRANSLATION
 =============================================================================
 \* Modification History
 \* Last modified Sun Mar 20 10:13:11 PDT 2011 by lamport

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex.tla
@@ -46,9 +46,9 @@ end algorithm
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-0bb63b56a09bbe2e9360c99d30162534
 CONSTANT defaultInitValue
-VARIABLES x, y, b, pc, j, failed
+VARIABLES pc, x, y, b, j, failed
 
-vars == << x, y, b, pc, j, failed >>
+vars == << pc, x, y, b, j, failed >>
 
 ProcSet == (1..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex.tla
@@ -44,7 +44,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-0bb63b56a09bbe2e9360c99d30162534
+\* BEGIN TRANSLATION (chksum(pcal) = "6934d70d" /\ chksum(tla) = "c3b2ff6d")
 CONSTANT defaultInitValue
 VARIABLES pc, x, y, b, j, failed
 
@@ -156,7 +156,7 @@ Next == (\E self \in 1..N: Proc(self))
 Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in 1..N : WF_vars(Proc(self))
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-7588f44b8dba7eba3195a1299d84da82
+\* END TRANSLATION
 
 inCS(i) ==  (pc[i] = "cs") /\ (~failed[i])
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex2.tla
@@ -78,9 +78,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-cc9279d759058abea504462b4ff084d7
-VARIABLES x, y, b, pc, j, failed, j2, failed2
+VARIABLES pc, x, y, b, j, failed, j2, failed2
 
-vars == << x, y, b, pc, j, failed, j2, failed2 >>
+vars == << pc, x, y, b, j, failed, j2, failed2 >>
 
 ProcSet == (1..M) \cup ((M+1)..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex2.tla
@@ -77,7 +77,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-cc9279d759058abea504462b4ff084d7
+\* BEGIN TRANSLATION (chksum(pcal) = "1f4110ad" /\ chksum(tla) = "367cd10c")
 VARIABLES pc, x, y, b, j, failed, j2, failed2
 
 vars == << pc, x, y, b, j, failed, j2, failed2 >>
@@ -284,7 +284,7 @@ Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in 1..M : WF_vars(Proc1(self))
         /\ \A self \in (M+1)..N : WF_vars(Proc2(self))
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-3862da72da966d861f548da308a59a9e
+\* END TRANSLATION
 
 ASSUME Print(<<"ProcSet =" , ProcSet>>, TRUE)
 inCS(i) ==  IF i \in 1..M 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex3.tla
@@ -78,9 +78,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-1901ed6bf685f13ebc84143ab4ef5b13
-VARIABLES x, y, b, pc, j, failed, j2, failed2
+VARIABLES pc, x, y, b, j, failed, j2, failed2
 
-vars == << x, y, b, pc, j, failed, j2, failed2 >>
+vars == << pc, x, y, b, j, failed, j2, failed2 >>
 
 ProcSet == {1} \cup (2..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutex3.tla
@@ -77,7 +77,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-1901ed6bf685f13ebc84143ab4ef5b13
+\* BEGIN TRANSLATION (chksum(pcal) = "d8254dd4" /\ chksum(tla) = "1847b253")
 VARIABLES pc, x, y, b, j, failed, j2, failed2
 
 vars == << pc, x, y, b, j, failed, j2, failed2 >>
@@ -282,7 +282,7 @@ Spec == /\ Init /\ [][Next]_vars
         /\ WF_vars(Proc1)
         /\ \A self \in 2..N : WF_vars(Proc2(self))
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-35555ac3cdd01367ca89de83ceeebd64
+\* END TRANSLATION
 
 ASSUME Print(<<"ProcSet =" , ProcSet>>, TRUE)
 inCS(i) ==  IF i = 1 THEN (pc[i] = "cs") /\ (~failed)

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto.tla
@@ -44,7 +44,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-765a4c9fba722b8f4115732919fba3a0
+\* BEGIN TRANSLATION (chksum(pcal) = "1004f339" /\ chksum(tla) = "f4730f26")
 VARIABLES pc, x, y, b, j
 
 vars == << pc, x, y, b, j >>
@@ -151,7 +151,7 @@ Next == (\E self \in 1..N: Proc(self))
 
 Spec == Init /\ [][Next]_vars
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-556f4fffd8fac96ddb09d8c9c984f878
+\* END TRANSLATION
 
 inCS(i) ==  (pc[i] = "cs") 
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto.tla
@@ -45,9 +45,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-765a4c9fba722b8f4115732919fba3a0
-VARIABLES x, y, b, pc, j
+VARIABLES pc, x, y, b, j
 
-vars == << x, y, b, pc, j >>
+vars == << pc, x, y, b, j >>
 
 ProcSet == (1..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto2.tla
@@ -42,7 +42,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-d10cf42a8598db9135c9a3e8255fdc3c
+\* BEGIN TRANSLATION (chksum(pcal) = "f52892c0" /\ chksum(tla) = "b02a536c")
 VARIABLES pc, x, y, b, S
 
 vars == << pc, x, y, b, S >>
@@ -150,7 +150,7 @@ Next == (\E self \in 1..N: Proc(self))
 Spec == /\ Init /\ [][Next]_vars
         /\ WF_vars(Next)
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-71043efb021aa260bc5d04181cce7e16
+\* END TRANSLATION
 
 inCS(i) ==  (pc[i] = "cs") 
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/FastMutexWithGoto2.tla
@@ -43,9 +43,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-d10cf42a8598db9135c9a3e8255fdc3c
-VARIABLES x, y, b, pc, S
+VARIABLES pc, x, y, b, S
 
-vars == << x, y, b, pc, S >>
+vars == << pc, x, y, b, S >>
 
 ProcSet == (1..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Fischer.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Fischer.tla
@@ -55,9 +55,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-fcd66548d87762ce6cd61f8b60ad89ec
-VARIABLES x, timer, pc, firstTime
+VARIABLES pc, x, timer, firstTime
 
-vars == << x, timer, pc, firstTime >>
+vars == << pc, x, timer, firstTime >>
 
 ProcSet == (1..N) \cup {0}
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Fischer.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Fischer.tla
@@ -54,7 +54,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-fcd66548d87762ce6cd61f8b60ad89ec
+\* BEGIN TRANSLATION (chksum(pcal) = "36cd5b05" /\ chksum(tla) = "6f1c46e")
 VARIABLES pc, x, timer, firstTime
 
 vars == << pc, x, timer, firstTime >>
@@ -127,7 +127,7 @@ Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in 1..N : WF_vars(Proc(self))
         /\ WF_vars(Tick)
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-d8d38bac35efc64e68e3d99ac06a0837
+\* END TRANSLATION
 
 inCS(i) ==  pc[i] = "cs"
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Github776.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Github776.cfg
@@ -1,0 +1,3 @@
+SPECIFICATION Spec
+CONSTANT defaultInitValue = defaultInitValue
+\* Add statements after this line.

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Github776.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Github776.tla
@@ -1,0 +1,129 @@
+------------------------------ MODULE Github776 -----------------------------
+
+EXTENDS Naturals, Sequences, TLC
+
+(*--algorithm Playground {
+
+    \* PlusCal does not have return values, but we can fake them
+    variables
+        retval,
+        output
+
+    procedure add(x, y) {
+        do_add:
+            retval := x + y;
+            return;
+    }
+
+    procedure to_string(int) {
+        do_to_string:
+            assert int = 10; \* this model only needs to be able to convert one value to a string
+            retval := "10";
+            return;
+    }
+
+    fair process (main = 1) {
+        step1: call add(3, 7);
+        step2: call to_string(retval);
+        step3: output := retval;
+        step4: assert output = "10";
+    }
+
+}*)
+\* BEGIN TRANSLATION (chksum(pcal) = "90defa92" /\ chksum(tla) = "375b0aff")
+CONSTANT defaultInitValue
+VARIABLES pc, retval, output, stack, x, y, int
+
+vars == << pc, retval, output, stack, x, y, int >>
+
+ProcSet == {1}
+
+Init == (* Global variables *)
+        /\ retval = defaultInitValue
+        /\ output = defaultInitValue
+        (* Procedure add *)
+        /\ x = [ self \in ProcSet |-> defaultInitValue]
+        /\ y = [ self \in ProcSet |-> defaultInitValue]
+        (* Procedure to_string *)
+        /\ int = [ self \in ProcSet |-> defaultInitValue]
+        /\ stack = [self \in ProcSet |-> << >>]
+        /\ pc = [self \in ProcSet |-> "step1"]
+
+do_add(self) == /\ pc[self] = "do_add"
+                /\ retval' = x[self] + y[self]
+                /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+                /\ x' = [x EXCEPT ![self] = Head(stack[self]).x]
+                /\ y' = [y EXCEPT ![self] = Head(stack[self]).y]
+                /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+                /\ UNCHANGED << output, int >>
+
+add(self) == do_add(self)
+
+do_to_string(self) == /\ pc[self] = "do_to_string"
+                      /\ Assert(int[self] = 10, 
+                                "Failure of assertion at line 20, column 13.")
+                      /\ retval' = "10"
+                      /\ pc' = [pc EXCEPT ![self] = Head(stack[self]).pc]
+                      /\ int' = [int EXCEPT ![self] = Head(stack[self]).int]
+                      /\ stack' = [stack EXCEPT ![self] = Tail(stack[self])]
+                      /\ UNCHANGED << output, x, y >>
+
+to_string(self) == do_to_string(self)
+
+step1 == /\ pc[1] = "step1"
+         /\ /\ stack' = [stack EXCEPT ![1] = << [ procedure |->  "add",
+                                                  pc        |->  "step2",
+                                                  x         |->  x[1],
+                                                  y         |->  y[1] ] >>
+                                              \o stack[1]]
+            /\ x' = [x EXCEPT ![1] = 3]
+            /\ y' = [y EXCEPT ![1] = 7]
+         /\ pc' = [pc EXCEPT ![1] = "do_add"]
+         /\ UNCHANGED << retval, output, int >>
+
+step2 == /\ pc[1] = "step2"
+         /\ /\ int' = [int EXCEPT ![1] = retval]
+            /\ stack' = [stack EXCEPT ![1] = << [ procedure |->  "to_string",
+                                                  pc        |->  "step3",
+                                                  int       |->  int[1] ] >>
+                                              \o stack[1]]
+         /\ pc' = [pc EXCEPT ![1] = "do_to_string"]
+         /\ UNCHANGED << retval, output, x, y >>
+
+step3 == /\ pc[1] = "step3"
+         /\ output' = retval
+         /\ pc' = [pc EXCEPT ![1] = "step4"]
+         /\ UNCHANGED << retval, stack, x, y, int >>
+
+step4 == /\ pc[1] = "step4"
+         /\ Assert(output = "10", 
+                   "Failure of assertion at line 29, column 16.")
+         /\ pc' = [pc EXCEPT ![1] = "Done"]
+         /\ UNCHANGED << retval, output, stack, x, y, int >>
+
+main == step1 \/ step2 \/ step3 \/ step4
+
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == /\ \A self \in ProcSet: pc[self] = "Done"
+               /\ UNCHANGED vars
+
+Next == main
+           \/ (\E self \in ProcSet: add(self) \/ to_string(self))
+           \/ Terminating
+
+Spec == /\ Init /\ [][Next]_vars
+        /\ WF_vars(main) /\ WF_vars(add(1)) /\ WF_vars(to_string(1))
+
+Termination == <>(\A self \in ProcSet: pc[self] = "Done")
+
+\* END TRANSLATION 
+
+
+Liveness == []<>(pc[1] = "Done")
+=============================================================================
+
+------------ CONFIG Github776 -----------------
+SPECIFICATION Spec
+CONSTANT defaultInitValue = defaultInitValue
+PROPERTY Liveness
+=======================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/InnerLabeledIf.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/InnerLabeledIf.tla
@@ -21,9 +21,9 @@ EXTENDS Sequences, Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-8d605a76553c67cf0740a3d27b57470b
-VARIABLES x, pc
+VARIABLES pc, x
 
-vars == << x, pc >>
+vars == << pc, x >>
 
 Init == (* Global variables *)
         /\ x \in 1..4

--- a/tlatools/org.lamport.tlatools/test-model/pcal/InnerLabeledIf.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/InnerLabeledIf.tla
@@ -20,7 +20,7 @@ EXTENDS Sequences, Naturals, TLC
     end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-8d605a76553c67cf0740a3d27b57470b
+\* BEGIN TRANSLATION (chksum(pcal) = "c4b5bec7" /\ chksum(tla) = "1eca9582")
 VARIABLES pc, x
 
 vars == << pc, x >>
@@ -77,7 +77,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c43944356bde2029519b5137bfd80466
+\* END TRANSLATION
 
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial.tla
@@ -28,7 +28,7 @@ EXTENDS Naturals, Sequences, TLC
   end algorithm
 ***************************************************************************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-1dbfa1687c2aacb174fffdcfcb1e6b08
+\* BEGIN TRANSLATION (chksum(pcal) = "671e5aa1" /\ chksum(tla) = "beb69680")
 CONSTANT defaultInitValue
 VARIABLES pc, result, stack, arg1, u
 
@@ -113,7 +113,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c530d8d4ac433df112955db00ba9f4a7
+\* END TRANSLATION
 
 
 Invariant == result \in Nat

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial.tla
@@ -30,9 +30,9 @@ EXTENDS Naturals, Sequences, TLC
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-1dbfa1687c2aacb174fffdcfcb1e6b08
 CONSTANT defaultInitValue
-VARIABLES result, pc, stack, arg1, u
+VARIABLES pc, result, stack, arg1, u
 
-vars == << result, pc, stack, arg1, u >>
+vars == << pc, result, stack, arg1, u >>
 
 ProcSet == (1..2) \cup {3}
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial2.tla
@@ -38,9 +38,9 @@ Factorial Algorithm with 2 procedures
 ***************************************************************************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-b4a39db84a865a6dcb14d3b14f4d88b3
-VARIABLES result, pc, stack, arg1, u, arg2, u2
+VARIABLES pc, result, stack, arg1, u, arg2, u2
 
-vars == << result, pc, stack, arg1, u, arg2, u2 >>
+vars == << pc, result, stack, arg1, u, arg2, u2 >>
 
 ProcSet == (1..2) \cup {3}
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MPFactorial2.tla
@@ -37,7 +37,7 @@ Factorial Algorithm with 2 procedures
   end algorithm
 ***************************************************************************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-b4a39db84a865a6dcb14d3b14f4d88b3
+\* BEGIN TRANSLATION (chksum(pcal) = "e57ed486" /\ chksum(tla) = "f3b78ef")
 VARIABLES pc, result, stack, arg1, u, arg2, u2
 
 vars == << pc, result, stack, arg1, u, arg2, u2 >>
@@ -157,7 +157,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-81af4b8b8e1c44a573ab6b21fa7843b0
+\* END TRANSLATION
 
 
 Invariant == result \in Nat

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MPNoParams.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MPNoParams.tla
@@ -23,7 +23,7 @@ EXTENDS Sequences, Naturals, TLC
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-deb6c76a28ce9358817b0dff2194ebab
+\* BEGIN TRANSLATION (chksum(pcal) = "f30ecf89" /\ chksum(tla) = "bbb0a5de")
 VARIABLES pc, sum, stack
 
 vars == << pc, sum, stack >>
@@ -86,7 +86,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-714bbad3547f7f99ec47cfca79fad75e
+\* END TRANSLATION
 
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MPNoParams.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MPNoParams.tla
@@ -24,9 +24,9 @@ EXTENDS Sequences, Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-deb6c76a28ce9358817b0dff2194ebab
-VARIABLES sum, pc, stack
+VARIABLES pc, sum, stack
 
-vars == << sum, pc, stack >>
+vars == << pc, sum, stack >>
 
 ProcSet == {1} \cup (2..4)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MergeSort.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MergeSort.tla
@@ -82,9 +82,9 @@ Copied from page 166 of the 2nd edition of Robert Sedgewick's "Algorithms".
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-3f24d15c1de7a8bf341d55378b5a76c0
 CONSTANT defaultInitValue
-VARIABLES a, b, pc, stack, l, r, i, j, k, m
+VARIABLES pc, a, b, stack, l, r, i, j, k, m
 
-vars == << a, b, pc, stack, l, r, i, j, k, m >>
+vars == << pc, a, b, stack, l, r, i, j, k, m >>
 
 Init == (* Global variables *)
         /\ a \in UNION {[1..N -> 1..N] : N \in 0..ArrayLen}

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MergeSort.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MergeSort.tla
@@ -80,7 +80,7 @@ Copied from page 166 of the 2nd edition of Robert Sedgewick's "Algorithms".
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-3f24d15c1de7a8bf341d55378b5a76c0
+\* BEGIN TRANSLATION (chksum(pcal) = "e813428c" /\ chksum(tla) = "e32bbbe5")
 CONSTANT defaultInitValue
 VARIABLES pc, a, b, stack, l, r, i, j, k, m
 
@@ -240,7 +240,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-ff6c7e89b9c9baac60a504f5cbacb5a2
+\* END TRANSLATION
 
 Invariant == 
    (pc = "Done") => \A x, y \in DOMAIN a :

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MultiProc2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MultiProc2.tla
@@ -31,7 +31,7 @@ EXTENDS Sequences, Naturals, TLC
     end algorithm 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-6a3f53faa6a08b14086cf6736a14399e
+\* BEGIN TRANSLATION (chksum(pcal) = "a4565407" /\ chksum(tla) = "add651f2")
 VARIABLES pc, x, sum, done, stack, arg, u, y, z
 
 vars == << pc, x, sum, done, stack, arg, u, y, z >>
@@ -127,5 +127,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-3f17bd1aee44cca22b14ef7de16f1390
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MultiProc2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MultiProc2.tla
@@ -32,9 +32,9 @@ EXTENDS Sequences, Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-6a3f53faa6a08b14086cf6736a14399e
-VARIABLES x, sum, done, pc, stack, arg, u, y, z
+VARIABLES pc, x, sum, done, stack, arg, u, y, z
 
-vars == << x, sum, done, pc, stack, arg, u, y, z >>
+vars == << pc, x, sum, done, stack, arg, u, y, z >>
 
 ProcSet == {41} \cup ({42, 43})
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MultiprocDefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MultiprocDefine.tla
@@ -15,7 +15,7 @@ EXTENDS Naturals, Sequences, TLC
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-255a10565612be8265861699149ea328
+\* BEGIN TRANSLATION (chksum(pcal) = "234d55b0" /\ chksum(tla) = "45423927")
 CONSTANT defaultInitValue
 VARIABLES pc, n
 
@@ -55,5 +55,5 @@ Spec == Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-0c8f6e25783592e29e1972ef47f12501
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/MultiprocDefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/MultiprocDefine.tla
@@ -17,7 +17,7 @@ EXTENDS Naturals, Sequences, TLC
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-255a10565612be8265861699149ea328
 CONSTANT defaultInitValue
-VARIABLES n, pc
+VARIABLES pc, n
 
 (* define statement *)
 nplus1 == n + 1
@@ -25,7 +25,7 @@ nplus2 == nplus1 + 1
 
 VARIABLE i
 
-vars == << n, pc, i >>
+vars == << pc, n, i >>
 
 ProcSet == ({1, 2, 3})
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NestedMacros.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NestedMacros.tla
@@ -26,7 +26,7 @@ EXTENDS Naturals, TLC
   }
 }
  ***************************************************************************)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-45eef21f51ec0ad28fe46e4b9a7b10ce
+\* BEGIN TRANSLATION (chksum(pcal) = "8605a38d" /\ chksum(tla) = "9b45950c")
 CONSTANT defaultInitValue
 VARIABLES pc, x, y, z
 
@@ -68,5 +68,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-5f6bcf611a462be83724e9522b1f4062
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NestedMacros.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NestedMacros.tla
@@ -28,9 +28,9 @@ EXTENDS Naturals, TLC
  ***************************************************************************)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-45eef21f51ec0ad28fe46e4b9a7b10ce
 CONSTANT defaultInitValue
-VARIABLES x, y, pc, z
+VARIABLES pc, x, y, z
 
-vars == << x, y, pc, z >>
+vars == << pc, x, y, z >>
 
 ProcSet == ({1,2})
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop.tla
@@ -11,7 +11,7 @@ EXTENDS Sequences, Naturals, TLC
     end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-688f592294a3ad1b9996ea0f884f9746
+\* BEGIN TRANSLATION (chksum(pcal) = "d83e0134" /\ chksum(tla) = "91a9a5f3")
 VARIABLES pc, x, y
 
 vars == << pc, x, y >>
@@ -52,5 +52,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-e78115b3384d72d09de2ad789d3620a6
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop.tla
@@ -12,9 +12,9 @@ EXTENDS Sequences, Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-688f592294a3ad1b9996ea0f884f9746
-VARIABLES x, y, pc
+VARIABLES pc, x, y
 
-vars == << x, y, pc >>
+vars == << pc, x, y >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop2.tla
@@ -15,7 +15,7 @@ EXTENDS Naturals, TLC
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-a111e49229d06e75e660ee8777442285
+\* BEGIN TRANSLATION (chksum(pcal) = "6c919199" /\ chksum(tla) = "b98d7fc5")
 VARIABLES pc, x, y
 
 vars == << pc, x, y >>
@@ -66,5 +66,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-7bfbfdcfed4c1aea23c410420c1f4f9d
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NoLoop2.tla
@@ -16,9 +16,9 @@ EXTENDS Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-a111e49229d06e75e660ee8777442285
-VARIABLES x, y, pc
+VARIABLES pc, x, y
 
-vars == << x, y, pc >>
+vars == << pc, x, y >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NoParams.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NoParams.tla
@@ -18,9 +18,9 @@ EXTENDS Sequences, Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-053c2fa748febe4e17ba5f50b599466c
-VARIABLES sum, pc, stack
+VARIABLES pc, sum, stack
 
-vars == << sum, pc, stack >>
+vars == << pc, sum, stack >>
 
 Init == (* Global variables *)
         /\ sum = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NoParams.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NoParams.tla
@@ -17,7 +17,7 @@ EXTENDS Sequences, Naturals, TLC
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-053c2fa748febe4e17ba5f50b599466c
+\* BEGIN TRANSLATION (chksum(pcal) = "3063a211" /\ chksum(tla) = "c3deb76f")
 VARIABLES pc, sum, stack
 
 vars == << pc, sum, stack >>
@@ -64,6 +64,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-621925aa8b4c5ddf90178ffc7da092a5
+\* END TRANSLATION
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NotSoSimpleLoop.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NotSoSimpleLoop.tla
@@ -15,9 +15,9 @@ EXTENDS Naturals, TLC
 
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-50f6f9a537b91874ce70a2eef129eb7f
-VARIABLES x, pc
+VARIABLES pc, x
 
-vars == << x, pc >>
+vars == << pc, x >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/NotSoSimpleLoop.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/NotSoSimpleLoop.tla
@@ -14,7 +14,7 @@ EXTENDS Naturals, TLC
      end algorithm                  *)
 
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-50f6f9a537b91874ce70a2eef129eb7f
+\* BEGIN TRANSLATION (chksum(pcal) = "3acbf16a" /\ chksum(tla) = "f1d2d847")
 VARIABLES pc, x
 
 vars == << pc, x >>
@@ -51,5 +51,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-0694bcde67f647179b7e22184415182a
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Peterson.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Peterson.tla
@@ -36,7 +36,7 @@ Here is the algorithm in +Cal (using the C syntax):
 (* assumes weak fairness of the next-state actions of both processes.      *)
 (* This fairness assumption is discussed below.                            *)
 (***************************************************************************)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-9255d446219a56b97b6d3847e8a2c94c
+\* BEGIN TRANSLATION (chksum(pcal) = "4b877bed" /\ chksum(tla) = "73a91bdf")
 VARIABLES pc, flag, turn
 
 vars == << pc, flag, turn >>
@@ -86,7 +86,7 @@ Next == (\E self \in {0,1}: proc(self))
 
 Spec == Init /\ [][Next]_vars
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-3c75243f0ddf7b933ebf70f115d692f3
+\* END TRANSLATION
 
 (***************************************************************************)
 (* Here is the invariant property that the algorithm should satisfy.  It   *)

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Peterson.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Peterson.tla
@@ -37,9 +37,9 @@ Here is the algorithm in +Cal (using the C syntax):
 (* This fairness assumption is discussed below.                            *)
 (***************************************************************************)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-9255d446219a56b97b6d3847e8a2c94c
-VARIABLES flag, turn, pc
+VARIABLES pc, flag, turn
 
-vars == << flag, turn, pc >>
+vars == << pc, flag, turn >>
 
 ProcSet == ({0,1})
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort.tla
@@ -49,9 +49,9 @@ PermsOf(Arr) ==
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-9360dabbf03d04fb938a53e6f43a0dc3
 CONSTANT defaultInitValue
-VARIABLES Ainit, A, returnVal, pc, stack, lo, hi, qlo, qhi, pivot
+VARIABLES pc, Ainit, A, returnVal, stack, lo, hi, qlo, qhi, pivot
 
-vars == << Ainit, A, returnVal, pc, stack, lo, hi, qlo, qhi, pivot >>
+vars == << pc, Ainit, A, returnVal, stack, lo, hi, qlo, qhi, pivot >>
 
 Init == (* Global variables *)
         /\ Ainit \in [1..ArrayLen -> 1..ArrayLen]

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort.tla
@@ -47,7 +47,7 @@ PermsOf(Arr) ==
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-9360dabbf03d04fb938a53e6f43a0dc3
+\* BEGIN TRANSLATION (chksum(pcal) = "8e049229" /\ chksum(tla) = "37350b35")
 CONSTANT defaultInitValue
 VARIABLES pc, Ainit, A, returnVal, stack, lo, hi, qlo, qhi, pivot
 
@@ -162,7 +162,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c890d98935ff53e5f234680508ac16aa
+\* END TRANSLATION
 =============================================================================
 Checked without termination on svc-lamport-2 with 2 workers:
   arrayLen = 4 in 15 sec, 32280 states, depth 22

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort2Procs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort2Procs.tla
@@ -59,10 +59,10 @@ PermsOf(Arr) ==
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-041626606cd9c50bd2700d7f84bf1f9c
-VARIABLES A, returnVal, pc, stack, lo, hi, qlo, qhi, pivot, qlo2, qhi2, 
+VARIABLES pc, A, returnVal, stack, lo, hi, qlo, qhi, pivot, qlo2, qhi2, 
           pivot2
 
-vars == << A, returnVal, pc, stack, lo, hi, qlo, qhi, pivot, qlo2, qhi2, 
+vars == << pc, A, returnVal, stack, lo, hi, qlo, qhi, pivot, qlo2, qhi2, 
            pivot2 >>
 
 Init == (* Global variables *)

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort2Procs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Quicksort2Procs.tla
@@ -58,7 +58,7 @@ PermsOf(Arr) ==
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-041626606cd9c50bd2700d7f84bf1f9c
+\* BEGIN TRANSLATION (chksum(pcal) = "2fcba02e" /\ chksum(tla) = "fd344bfd")
 VARIABLES pc, A, returnVal, stack, lo, hi, qlo, qhi, pivot, qlo2, qhi2, 
           pivot2
 
@@ -231,7 +231,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-da193a603aa89ac5bf05f91d5ffaf922
+\* END TRANSLATION
 
 Invariant == 
    (pc = "Done") => \A i, j \in 1..ArrayLen :

--- a/tlatools/org.lamport.tlatools/test-model/pcal/QuicksortMacro.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/QuicksortMacro.tla
@@ -44,9 +44,9 @@ PermsOf(Arr) ==
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-f3c86b18c12d46dfb100d83f44bd15cc
-VARIABLES A, returnVal, pc, stack, qlo, qhi, pivot
+VARIABLES pc, A, returnVal, stack, qlo, qhi, pivot
 
-vars == << A, returnVal, pc, stack, qlo, qhi, pivot >>
+vars == << pc, A, returnVal, stack, qlo, qhi, pivot >>
 
 Init == (* Global variables *)
         /\ A \in [1..ArrayLen -> 1..ArrayLen]

--- a/tlatools/org.lamport.tlatools/test-model/pcal/QuicksortMacro.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/QuicksortMacro.tla
@@ -43,7 +43,7 @@ PermsOf(Arr) ==
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-f3c86b18c12d46dfb100d83f44bd15cc
+\* BEGIN TRANSLATION (chksum(pcal) = "b2c7472a" /\ chksum(tla) = "d194e1b1")
 VARIABLES pc, A, returnVal, stack, qlo, qhi, pivot
 
 vars == << pc, A, returnVal, stack, qlo, qhi, pivot >>
@@ -128,7 +128,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-f36591cc8efd54110514a4b1f13d3500
+\* END TRANSLATION
 
 Invariant == 
    (pc = "Done") => \A i, j \in 1..ArrayLen :

--- a/tlatools/org.lamport.tlatools/test-model/pcal/RAB.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/RAB.tla
@@ -145,7 +145,7 @@ end algorithm
 *)    
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-36470f24ec099c641e8894d14dc1be7a
+\* BEGIN TRANSLATION (chksum(pcal) = "da7526ed" /\ chksum(tla) = "4913b402")
 VARIABLES pc, flags, calc, temp, myattr
 
 vars == << pc, flags, calc, temp, myattr >>
@@ -196,7 +196,7 @@ Next == (\E self \in Pid: work(self))
 
 Spec == Init /\ [][Next]_vars
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-e0d61e0fb8a75ee2eb592e9a5b0f5f46
+\* END TRANSLATION
 
 
 Consistency ==

--- a/tlatools/org.lamport.tlatools/test-model/pcal/RAB.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/RAB.tla
@@ -146,9 +146,9 @@ end algorithm
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-36470f24ec099c641e8894d14dc1be7a
-VARIABLES flags, calc, pc, temp, myattr
+VARIABLES pc, flags, calc, temp, myattr
 
-vars == << flags, calc, pc, temp, myattr >>
+vars == << pc, flags, calc, temp, myattr >>
 
 ProcSet == (Pid)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort.tla
@@ -52,9 +52,9 @@ Max(S) == CHOOSE i \in S : \A j \in S : i \geq j
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-1f05a46c32a9d2bb1934b39aad724eed
 CONSTANT defaultInitValue
-VARIABLES A, Uns, new, pc, stack, parg
+VARIABLES pc, A, Uns, new, stack, parg
 
-vars == << A, Uns, new, pc, stack, parg >>
+vars == << pc, A, Uns, new, stack, parg >>
 
 Init == (* Global variables *)
         /\ A \in UNION {[1..N -> 1..N] : N \in 0..MaxLen}

--- a/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort.tla
@@ -50,7 +50,7 @@ Max(S) == CHOOSE i \in S : \A j \in S : i \geq j
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-1f05a46c32a9d2bb1934b39aad724eed
+\* BEGIN TRANSLATION (chksum(pcal) = "9b6393de" /\ chksum(tla) = "9e112751")
 CONSTANT defaultInitValue
 VARIABLES pc, A, Uns, new, stack, parg
 
@@ -116,7 +116,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-4de5033005d037379ed702fb72c5f705
+\* END TRANSLATION
 
 Invariant == 
    (pc = "Done") => \A i, j \in 1..Len(A) :

--- a/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort2.tla
@@ -52,9 +52,9 @@ Max(S) == CHOOSE i \in S : \A j \in S : i \geq j
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-23d3f8a2c70b06b61c3d312c6981bc33
 CONSTANT defaultInitValue
-VARIABLES A, Uns, new, next, pc, stack, parg
+VARIABLES pc, A, Uns, new, next, stack, parg
 
-vars == << A, Uns, new, next, pc, stack, parg >>
+vars == << pc, A, Uns, new, next, stack, parg >>
 
 Init == (* Global variables *)
         /\ A \in UNION {[1..N -> 1..N] : N \in 0..MaxLen}

--- a/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/RealQuicksort2.tla
@@ -50,7 +50,7 @@ Max(S) == CHOOSE i \in S : \A j \in S : i \geq j
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-23d3f8a2c70b06b61c3d312c6981bc33
+\* BEGIN TRANSLATION (chksum(pcal) = "52883366" /\ chksum(tla) = "e311d19b")
 CONSTANT defaultInitValue
 VARIABLES pc, A, Uns, new, next, stack, parg
 
@@ -116,7 +116,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-86e50a32c6061aae8bbd3a4da8513951
+\* END TRANSLATION
 
 Invariant == 
    (pc = "Done") => \A i, j \in 1..Len(A) :

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ReallySimpleMultiProc.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ReallySimpleMultiProc.tla
@@ -26,9 +26,9 @@ EXTENDS Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-489e6572dfcfeaa9e2ac64d8c5013ef0
-VARIABLES x, sum, done, pc, y, z
+VARIABLES pc, x, sum, done, y, z
 
-vars == << x, sum, done, pc, y, z >>
+vars == << pc, x, sum, done, y, z >>
 
 ProcSet == {41} \cup ({42, 43})
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ReallySimpleMultiProc.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ReallySimpleMultiProc.tla
@@ -25,7 +25,7 @@ EXTENDS Naturals, TLC
 
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-489e6572dfcfeaa9e2ac64d8c5013ef0
+\* BEGIN TRANSLATION (chksum(pcal) = "2bdc51cc" /\ chksum(tla) = "bf9f6e5d")
 VARIABLES pc, x, sum, done, y, z
 
 vars == << pc, x, sum, done, y, z >>
@@ -85,5 +85,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-9c6ea370932e887119161ccedba84a47
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SBB.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SBB.tla
@@ -69,9 +69,9 @@ end algorithm
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-28938b6571490e0f82ac59c63d6f47e4
-VARIABLES sb, availablebuffers, publishedbuffers, pc, buf, op
+VARIABLES pc, sb, availablebuffers, publishedbuffers, buf, op
 
-vars == << sb, availablebuffers, publishedbuffers, pc, buf, op >>
+vars == << pc, sb, availablebuffers, publishedbuffers, buf, op >>
 
 ProcSet == (Pid)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SBB.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SBB.tla
@@ -68,7 +68,7 @@ end algorithm
 *)    
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-28938b6571490e0f82ac59c63d6f47e4
+\* BEGIN TRANSLATION (chksum(pcal) = "a8cd067d" /\ chksum(tla) = "17cf9c0")
 VARIABLES pc, sb, availablebuffers, publishedbuffers, buf, op
 
 vars == << pc, sb, availablebuffers, publishedbuffers, buf, op >>
@@ -140,7 +140,7 @@ Next == (\E self \in Pid: work(self))
 
 Spec == Init /\ [][Next]_vars
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-0476e94d7836683a2a4a6e344c5a0a7b
+\* END TRANSLATION
 
 
 Immutability ==

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SemaphoreMutex.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SemaphoreMutex.tla
@@ -29,7 +29,7 @@ end algorithm
 
 ***********************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-44c6b54854f894e836bedeb86826fe34
+\* BEGIN TRANSLATION (chksum(pcal) = "a301f784" /\ chksum(tla) = "b8c844fe")
 VARIABLES pc, sem
 
 vars == << pc, sem >>
@@ -65,7 +65,7 @@ Next == (\E self \in 1..N: Proc(self))
 Spec == /\ Init /\ [][Next]_vars
         /\ \A self \in 1..N : SF_vars(Proc(self))
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-30232ad9c07579ad742b84411a6a279a
+\* END TRANSLATION
 
 inCS(i) ==  (pc[i] = "cs") 
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SemaphoreMutex.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SemaphoreMutex.tla
@@ -30,9 +30,9 @@ end algorithm
 ***********************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-44c6b54854f894e836bedeb86826fe34
-VARIABLES sem, pc
+VARIABLES pc, sem
 
-vars == << sem, pc >>
+vars == << pc, sem >>
 
 ProcSet == (1..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoop.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoop.tla
@@ -13,9 +13,9 @@ EXTENDS Naturals, TLC
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-33bbd786fd9a21815a80c1c8d918b5c0
-VARIABLES x, pc
+VARIABLES pc, x
 
-vars == << x, pc >>
+vars == << pc, x >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoop.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoop.tla
@@ -12,7 +12,7 @@ EXTENDS Naturals, TLC
      end algorithm                                                         
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-33bbd786fd9a21815a80c1c8d918b5c0
+\* BEGIN TRANSLATION (chksum(pcal) = "a551c6d" /\ chksum(tla) = "ebecf3f")
 VARIABLES pc, x
 
 vars == << pc, x >>
@@ -42,5 +42,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-d8f87f4745585bbecc6137f522211233
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoopWithProcedure.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoopWithProcedure.tla
@@ -20,7 +20,7 @@ EXTENDS Naturals, Sequences, TLC
 *)
 
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-925d38ef233a8a8c33b34bb25ba0c30d
+\* BEGIN TRANSLATION (chksum(pcal) = "2f5b32ad" /\ chksum(tla) = "7cd1d431")
 VARIABLES pc, x, y, n, i, stack, incr, z
 
 vars == << pc, x, y, n, i, stack, incr, z >>
@@ -77,5 +77,5 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-1145b37773754e0c960b38596f8082a0
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoopWithProcedure.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SimpleLoopWithProcedure.tla
@@ -21,9 +21,9 @@ EXTENDS Naturals, Sequences, TLC
 
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-925d38ef233a8a8c33b34bb25ba0c30d
-VARIABLES x, y, n, i, pc, stack, incr, z
+VARIABLES pc, x, y, n, i, stack, incr, z
 
-vars == << x, y, n, i, pc, stack, incr, z >>
+vars == << pc, x, y, n, i, stack, incr, z >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SyncCons.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SyncCons.tla
@@ -103,7 +103,7 @@ bot == CHOOSE v: v \notin Data
 
 Proc == 1..N
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-6c62906a7a71f4a60f9b9f0eecf7e59e
+\* BEGIN TRANSLATION (chksum(pcal) = "e77f8a29" /\ chksum(tla) = "778d0f52")
 \* Label clock of process Clock at line 77 col 12 changed to clock_
 VARIABLES pc, clock, input, round, buffer, crashed, output, procs, value, 
           recd
@@ -240,7 +240,7 @@ Spec == Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-166884a9c4ec2ab81b93439149dfdc07
+\* END TRANSLATION
 
 C1 == \A p1, p2 \in (1..N) \ crashed:
   (pc[p1] = "Done" /\ pc[p2] = "Done") => (output[p1] = output[p2])

--- a/tlatools/org.lamport.tlatools/test-model/pcal/SyncCons.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/SyncCons.tla
@@ -105,10 +105,10 @@ Proc == 1..N
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-6c62906a7a71f4a60f9b9f0eecf7e59e
 \* Label clock of process Clock at line 77 col 12 changed to clock_
-VARIABLES clock, input, round, buffer, crashed, pc, output, procs, value, 
+VARIABLES pc, clock, input, round, buffer, crashed, output, procs, value, 
           recd
 
-vars == << clock, input, round, buffer, crashed, pc, output, procs, value, 
+vars == << pc, clock, input, round, buffer, crashed, output, procs, value, 
            recd >>
 
 ProcSet == (1..N) \cup {N + 1} \cup {N + 2}

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Test.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Test.tla
@@ -30,9 +30,9 @@ EXTENDS Sequences, Naturals, TLC
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-648cb8f5989caacb85bf4050478c7a20
-VARIABLES x, y, pc, stack
+VARIABLES pc, x, y, stack
 
-vars == << x, y, pc, stack >>
+vars == << pc, x, y, stack >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/Test.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/Test.tla
@@ -29,7 +29,7 @@ end algorithm
 EXTENDS Sequences, Naturals, TLC
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-648cb8f5989caacb85bf4050478c7a20
+\* BEGIN TRANSLATION (chksum(pcal) = "ce121599" /\ chksum(tla) = "52889fb")
 VARIABLES pc, x, y, stack
 
 vars == << pc, x, y, stack >>
@@ -100,6 +100,6 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-025c418c95de365cc2a03da9bdd7e60c
+\* END TRANSLATION
 
 ============================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/TestTabs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/TestTabs.tla
@@ -16,7 +16,7 @@ l:  x := IF /\ \A i \in {1} : 1 + 1 = 2
     assert x = 1 ;
   end algorithm
 *)
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-df86b294351f95a8207d12196b3732f0
+\* BEGIN TRANSLATION (chksum(pcal) = "fc3ea28a" /\ chksum(tla) = "5d92a104")
 VARIABLES pc, x
 
 vars == << pc, x >>
@@ -47,5 +47,5 @@ Spec == Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-ec3da753015679c262e945265fc700f9
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/TestTabs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/TestTabs.tla
@@ -17,9 +17,9 @@ l:  x := IF /\ \A i \in {1} : 1 + 1 = 2
   end algorithm
 *)
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-df86b294351f95a8207d12196b3732f0
-VARIABLES x, pc
+VARIABLES pc, x
 
-vars == << x, pc >>
+vars == << pc, x >>
 
 Init == (* Global variables *)
         /\ x = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/TreeBarrier.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/TreeBarrier.tla
@@ -33,7 +33,7 @@ N == 2^exp-1
 
 --------------------------------------------------------------------
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-f8296f0cc6166098bc809c33e090e03e
+\* BEGIN TRANSLATION (chksum(pcal) = "cbf5663c" /\ chksum(tla) = "4834106")
 VARIABLES pc, arrived, proceed, b, p
 
 vars == << pc, arrived, proceed, b, p >>
@@ -127,7 +127,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-cbb736d8ea82daa6b485e32bbe870840
+\* END TRANSLATION
 
 
 SafeBarrier == \A p1, p2 \in ProcSet:

--- a/tlatools/org.lamport.tlatools/test-model/pcal/TreeBarrier.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/TreeBarrier.tla
@@ -34,9 +34,9 @@ N == 2^exp-1
 --------------------------------------------------------------------
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-f8296f0cc6166098bc809c33e090e03e
-VARIABLES arrived, proceed, pc, b, p
+VARIABLES pc, arrived, proceed, b, p
 
-vars == << arrived, proceed, pc, b, p >>
+vars == << pc, arrived, proceed, b, p >>
 
 ProcSet == (1..N)
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULEuclid.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULEuclid.tla
@@ -41,7 +41,7 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
                       
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-15a96a62d4bb94349f0b7e97b7877563
+\* BEGIN TRANSLATION (chksum(pcal) = "400e3286" /\ chksum(tla) = "ff294014")
 VARIABLES pc, u_ini, v_ini, u, v
 
 vars == << pc, u_ini, v_ini, u, v >>
@@ -83,7 +83,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-42ac9bbadc686601495c6cb5a86d3d55
+\* END TRANSLATION
 
 
 Invariant == 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULEuclid.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULEuclid.tla
@@ -42,9 +42,9 @@ GCD(x, y) == CHOOSE i \in (1..x) \cap (1..y) :
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-15a96a62d4bb94349f0b7e97b7877563
-VARIABLES u_ini, v_ini, u, v, pc
+VARIABLES pc, u_ini, v_ini, u, v
 
-vars == << u_ini, v_ini, u, v, pc >>
+vars == << pc, u_ini, v_ini, u, v >>
 
 Init == (* Global variables *)
         /\ u_ini \in 1 .. MaxNum

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULEvenOdd.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULEvenOdd.tla
@@ -31,7 +31,7 @@ CONSTANT N
 ----------------------------------------------
 
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-ead0453df43345041c6d46c21bad39b3
+\* BEGIN TRANSLATION (chksum(pcal) = "b096ae5c" /\ chksum(tla) = "1a7e5b15")
 VARIABLES pc, result, stack, xEven, xOdd
 
 vars == << pc, result, stack, xEven, xOdd >>
@@ -109,7 +109,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-20632e604e66ef1ac373dca4eac3efb3
+\* END TRANSLATION
 
 ==============================================
 

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULEvenOdd.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULEvenOdd.tla
@@ -32,9 +32,9 @@ CONSTANT N
 
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-ead0453df43345041c6d46c21bad39b3
-VARIABLES result, pc, stack, xEven, xOdd
+VARIABLES pc, result, stack, xEven, xOdd
 
-vars == << result, pc, stack, xEven, xOdd >>
+vars == << pc, result, stack, xEven, xOdd >>
 
 Init == (* Global variables *)
         /\ result = FALSE

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULFactorial2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULFactorial2.tla
@@ -32,7 +32,7 @@ Factorial Algorithm with 2 procedures
   end algorithm
 ***************************************************************************)
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-e543cee5733d328853b3f740967ffc6f
+\* BEGIN TRANSLATION (chksum(pcal) = "75e64215" /\ chksum(tla) = "1f94e6d5")
 VARIABLES pc, result, stack, arg1, u, arg2, u2
 
 vars == << pc, result, stack, arg1, u, arg2, u2 >>
@@ -119,7 +119,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-13df185bb6632a27d39dd317f4d5a749
+\* END TRANSLATION
 
 
 Invariant == result \in Nat

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULFactorial2.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULFactorial2.tla
@@ -33,9 +33,9 @@ Factorial Algorithm with 2 procedures
 ***************************************************************************)
 
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-e543cee5733d328853b3f740967ffc6f
-VARIABLES result, pc, stack, arg1, u, arg2, u2
+VARIABLES pc, result, stack, arg1, u, arg2, u2
 
-vars == << result, pc, stack, arg1, u, arg2, u2 >>
+vars == << pc, result, stack, arg1, u, arg2, u2 >>
 
 Init == (* Global variables *)
         /\ result = 1

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULQuicksortMacro.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULQuicksortMacro.tla
@@ -44,9 +44,9 @@ PermsOf(Arr) ==
 *)
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-749f221938b5b2dde2ae6c5d6a23511d
-VARIABLES A, returnVal, pc, stack, qlo, qhi, pivot
+VARIABLES pc, A, returnVal, stack, qlo, qhi, pivot
 
-vars == << A, returnVal, pc, stack, qlo, qhi, pivot >>
+vars == << pc, A, returnVal, stack, qlo, qhi, pivot >>
 
 Init == (* Global variables *)
         /\ A \in [1..ArrayLen -> 1..ArrayLen]

--- a/tlatools/org.lamport.tlatools/test-model/pcal/ULQuicksortMacro.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/ULQuicksortMacro.tla
@@ -43,7 +43,7 @@ PermsOf(Arr) ==
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-749f221938b5b2dde2ae6c5d6a23511d
+\* BEGIN TRANSLATION (chksum(pcal) = "3cfb9047" /\ chksum(tla) = "69a3ce3c")
 VARIABLES pc, A, returnVal, stack, qlo, qhi, pivot
 
 vars == << pc, A, returnVal, stack, qlo, qhi, pivot >>
@@ -124,7 +124,7 @@ Spec == /\ Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-d263fef6f518e6f97b673c4d40ca9921
+\* END TRANSLATION
 
 Invariant == 
    (pc = "Done") => \A i, j \in 1..ArrayLen :

--- a/tlatools/org.lamport.tlatools/test-model/pcal/UniprocDefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/UniprocDefine.tla
@@ -19,7 +19,7 @@ EXTENDS Naturals, Sequences, TLC
                     
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-6a1ac8b08c9ed86b40d0f6e5ef5cbdb0
 CONSTANT defaultInitValue
-VARIABLES n, pc, stack
+VARIABLES pc, n, stack
 
 (* define statement *)
 nplus1 == n + 1
@@ -27,7 +27,7 @@ nplus2 == nplus1 + 1
 
 VARIABLES a, b
 
-vars == << n, pc, stack, a, b >>
+vars == << pc, n, stack, a, b >>
 
 Init == (* Global variables *)
         /\ n = 0

--- a/tlatools/org.lamport.tlatools/test-model/pcal/UniprocDefine.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/UniprocDefine.tla
@@ -17,7 +17,7 @@ EXTENDS Naturals, Sequences, TLC
   end algorithm
 *)
                     
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-6a1ac8b08c9ed86b40d0f6e5ef5cbdb0
+\* BEGIN TRANSLATION (chksum(pcal) = "133d587" /\ chksum(tla) = "3f254480")
 CONSTANT defaultInitValue
 VARIABLES pc, n, stack
 
@@ -72,5 +72,5 @@ Spec == Init /\ [][Next]_vars
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-bb2646c148c04705a11ba77b1f981f05
+\* END TRANSLATION
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/bug_06_01_25.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/bug_06_01_25.tla
@@ -80,7 +80,7 @@ EXTENDS Sequences, Naturals, TLC
 
 ASSUME \forall i \in {} : i \geq 1
 
-\* BEGIN TRANSLATION - the hash of the PCal code: PCal-9ef67f07b10dbbf43fc7d4cb2d8d7b02
+\* BEGIN TRANSLATION (chksum(pcal) = "af4107c0" /\ chksum(tla) = "ff608d23")
 \* Label P1 of procedure P at line 22 col 17 changed to P1_
 CONSTANT defaultInitValue
 VARIABLES pc, x, y, z, stack
@@ -224,5 +224,5 @@ Spec == Init /\ [][Next]_vars
 
 Termination == <>(\A self \in ProcSet: pc[self] = "Done")
 
-\* END TRANSLATION - the hash of the generated TLA code (remove to silence divergence warnings): TLA-c0ae8bdf7ad8a969ed412d1b64210cb9
+\* END TRANSLATION
 ========================================

--- a/tlatools/org.lamport.tlatools/test-model/pcal/bug_06_01_25.tla
+++ b/tlatools/org.lamport.tlatools/test-model/pcal/bug_06_01_25.tla
@@ -83,7 +83,7 @@ ASSUME \forall i \in {} : i \geq 1
 \* BEGIN TRANSLATION - the hash of the PCal code: PCal-9ef67f07b10dbbf43fc7d4cb2d8d7b02
 \* Label P1 of procedure P at line 22 col 17 changed to P1_
 CONSTANT defaultInitValue
-VARIABLES x, y, z, pc, stack
+VARIABLES pc, x, y, z, stack
 
 (* define statement *)
 foo == /\ \A i \in {1} : i > 0
@@ -92,7 +92,7 @@ foo == /\ \A i \in {1} : i > 0
 
 VARIABLES a, w
 
-vars == << x, y, z, pc, stack, a, w >>
+vars == << pc, x, y, z, stack, a, w >>
 
 ProcSet == ({qq \in {1,2} : /\ \A i \in {1} : i > 0
                             /\ \A j \in {1} : j > 0

--- a/tlatools/org.lamport.tlatools/test/pcal/Github776Test.java
+++ b/tlatools/org.lamport.tlatools/test/pcal/Github776Test.java
@@ -1,0 +1,27 @@
+package pcal;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import util.ToolIO;
+
+import java.util.Arrays;
+
+public class Github776Test extends PCalModelCheckerTestCase {
+
+    public Github776Test() {
+        super("Github776", "pcal");
+    }
+
+    @Test
+    public void testSpec() {
+        assertTrue(recorder.recordedWithStringValue(EC.TLC_INIT_GENERATED1, "1"));
+        assertTrue(recorder.recorded(EC.TLC_FINISHED));
+        assertFalse(recorder.recorded(EC.GENERAL));
+
+        assertZeroUncovered();
+    }
+}


### PR DESCRIPTION
to avoid RuntimeException, see #776.