### PR TITLE
Locate the the "StandardModules" folder more reliably

### DIFF
--- a/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2024, Oracle and/or its affiliates.
 // Last modified on Sat 28 June 2008 at  0:23:49 PST by lamport
 
 package util;
@@ -68,10 +68,13 @@ public class SimpleFilenameToStream implements FilenameToStream {
 	  libraryPaths = getLibraryPaths(getInstallationBasePath(), anLibraryPaths);
   }
 
-  // Find the absolute path in the file system to the directory
-  // that is the base of the entire installation of tlaSANY; this path
-  // must have separators appropriate to the Unix ('/') or Windows ('\') world.
-
+  /**
+   * Find the absolute path in the file system to the directory
+   * that is the base of the entire installation of tlaSANY; this path
+   * must have separators appropriate to the Unix ('/') or Windows ('\') world.
+   *
+   * @return the path to the tlaSANY installation, or a "jar:" URL
+   */
   private String getInstallationBasePath() {
 
     // get a "file:" URL for the base directory for package tla2sany

--- a/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
@@ -70,15 +70,15 @@ public class SimpleFilenameToStream implements FilenameToStream {
 
   /**
    * Find the absolute path in the file system to the directory
-   * that is the base of the entire installation of tlaSANY; this path
+   * containing the TLA+ standard modules; this path
    * must have separators appropriate to the Unix ('/') or Windows ('\') world.
    *
-   * @return the path to the tlaSANY installation, or a "jar:" URL
+   * @return the location of the TLA+ standard modules as an absolute path or as a "jar:" URL
    */
   private String getInstallationBasePath() {
 
     // get a "file:" URL for the base directory for package tla2sany
-    final URL         url = cl.getResource("tla2sany");
+    final URL         url = cl.getResource(STANDARD_MODULES);
 
     // jar expanded to the fs (make sure to handle whitespaces correctly
     final String path = url.toString();
@@ -138,7 +138,7 @@ public class SimpleFilenameToStream implements FilenameToStream {
     }
     if (path == null) {
       res = new String[1];
-      res[0] = installationBasePath + FileUtil.separator + STANDARD_MODULES_FOLDER + FileUtil.separator;
+      res[0] = installationBasePath + FileUtil.separator;
     }
     else {
       String[] paths = path.split(FileUtil.pathSeparator);
@@ -149,7 +149,7 @@ public class SimpleFilenameToStream implements FilenameToStream {
 	  res[i] = res[i] + FileUtil.separator;
 	}
       }
-      res[paths.length] = installationBasePath + FileUtil.separator + STANDARD_MODULES_FOLDER + FileUtil.separator;
+      res[paths.length] = installationBasePath + FileUtil.separator;
     }
     return res;
   }


### PR DESCRIPTION
If a given `path` exists on the classpath in multiple places, `class.getResource(path)` will return an arbitrary one of them.  This behavior creates a potential problem for `SimpleFilenameToStream` when running the TLA+ tests:

 - Main classes and test classes are placed in separate folders, and both folders are on the classpath.
 - The path "tla2sany/" exists in both locations, since there are some test classes in the `tla2sany` package.

As a result, `SimpleFilenameToStream` may decide that the installation base path is actually "test-classes/tla2sany", which does not contain a "StandardModules" folder.

This is not a problem in most cases, since in practice `getResource` returns the _first_ place it found the requested path, and the main classes go on the classpath first.  But that behavior is not guaranteed, and furthermore some IDEs like IntelliJ actually put the test classes first on the classpath.

This patch changes the internals of `SimpleFilenameToStream` to look for "tla2sany/StandardModules" instead of looking for "tla2sany" and assuming the arbitrarily-chosen result has a "StandardModules" folder.