### PR TITLE
Show the changed variables as part of the transition if `-difftrace` is given and the successor has previously been added to the GraphViz graph.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
@@ -251,16 +251,24 @@ public class DotStateWriter extends StateWriter {
 			maintainRanks(state);
 		} else {
 			// Add the transition edge label.
-			final String labelFmtStr = " [label=\"%s%s\",color=\"%s\",fontcolor=\"%s\"]";
+			final String labelFmtStr = " [label=\"%s%s%s\",color=\"%s\",fontcolor=\"%s\"]";
 			
 			// Only colorize edges if specified. Default to black otherwise.
 			final String color = colorize ? this.getActionColor(action).toString() : "black" ;
 
 			// Only add action label if specified.
 			final String actionName = actionLabels && action != null ? action.getName().toString() : "" ;
-				
+			
+			// Show the changes variables as part of the transition if the successor has
+			// previously been added.
+			String diff = "";
+			if (TLCGlobals.printDiffsOnly && isSet(stateFlags, IStateWriter.IsSeen)
+					&& rankToNodes.values().stream().filter(s -> s.contains(sfp)).findAny().isEmpty()) {
+				diff = states2dot(state.evalStateLevelAlias(), successor.evalStateLevelAlias());
+			}
+
 			this.writer.append(
-					String.format(labelFmtStr, actionName, pred == null ? "" : "\n" + pred.toString(), color, color));
+					String.format(labelFmtStr, actionName, diff, pred == null ? "" : "\n" + pred.toString(), color, color));
 			
 			this.writer.append(";\n");
 			

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
@@ -248,6 +248,7 @@ public class DotStateWriter extends StateWriter {
 		this.writer.append(successorsFP);
 		if (visualization == Visualization.STUTTERING) {
 			this.writer.append(" [style=\"dashed\",color=\"lightgray\"];\n");
+			maintainRanks(state);
 		} else {
 			// Add the transition edge label.
 			if(action!=null) {
@@ -278,10 +279,10 @@ public class DotStateWriter extends StateWriter {
 					this.writer.append("\"]");
 				}
 				this.writer.append(";\n");
+				
+				maintainRanks(state);
 			}
 		}
-		
-		maintainRanks(state);
 		
 		if (snapshot) {
 			try {

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/DotStateWriter.java
@@ -251,10 +251,16 @@ public class DotStateWriter extends StateWriter {
 			maintainRanks(state);
 		} else {
 			// Add the transition edge label.
-			if(action!=null) {
-				String transitionLabel = this.dotTransitionLabel(state, successor, action, pred);
-				this.writer.append(transitionLabel);	
-			}
+			final String labelFmtStr = " [label=\"%s%s\",color=\"%s\",fontcolor=\"%s\"]";
+			
+			// Only colorize edges if specified. Default to black otherwise.
+			final String color = colorize ? this.getActionColor(action).toString() : "black" ;
+
+			// Only add action label if specified.
+			final String actionName = actionLabels && action != null ? action.getName().toString() : "" ;
+				
+			this.writer.append(
+					String.format(labelFmtStr, actionName, pred == null ? "" : "\n" + pred.toString(), color, color));
 			
 			this.writer.append(";\n");
 			

--- a/tlatools/org.lamport.tlatools/test-model/DiffDot.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/DiffDot.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+CONSTRAINT Constraint

--- a/tlatools/org.lamport.tlatools/test-model/DiffDot.tla
+++ b/tlatools/org.lamport.tlatools/test-model/DiffDot.tla
@@ -1,0 +1,46 @@
+------------------- MODULE DiffDot ----------------------
+EXTENDS Integers
+
+VARIABLE x, y
+
+Init ==
+    x = 0 /\ y = "a"
+
+Inc ==
+    x' = x + 1
+
+Dec ==
+    x' = x - 1
+
+Mul ==
+    x' = x * 2
+
+Div ==
+    x' = x \div 2
+
+Rst ==
+    x' = 0
+
+Stutt ==
+    x' = x
+
+Dis ==
+    /\ x < 0
+    /\ x' = x * (-1)
+    
+Next ==
+ /\ y' = IF x % 2 = 0 THEN "a" ELSE "b"
+ /\ \/ Inc
+    \/ Dec
+    \/ Mul
+    \/ Div
+    \/ Rst
+\*    \/ Stutt
+\*    \/ Dis
+
+------------------------------------------------------------
+
+Constraint == 
+	x \in 0..5
+
+============================================================

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/DiffDotTest.dot
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/DiffDotTest.dot
@@ -1,0 +1,64 @@
+strict digraph DiskGraph {
+node [shape=box,style=rounded]
+nodesep=0.35;
+subgraph cluster_graph {
+color="white";
+-7105578134370194095 [label="/\\ x = 0\n/\\ y = \"a\"",style = filled]
+-7105578134370194095 -> -3219420052081701213 [label="",color="black",fontcolor="black"];
+-3219420052081701213 [label="/\\ x = 1",tooltip="/\\ x = 1\n/\\ y = \"a\""];
+-7105578134370194095 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-7105578134370194095 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-7105578134370194095 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-3219420052081701213 -> 5648648852758402454 [label="",color="black",fontcolor="black"];
+5648648852758402454 [label="/\\ x = 2\n/\\ y = \"b\"",tooltip="/\\ x = 2\n/\\ y = \"b\""];
+-3219420052081701213 -> -3312545320546479502 [label="",color="black",fontcolor="black"];
+-3312545320546479502 [label="/\\ x = 0\n/\\ y = \"b\"",tooltip="/\\ x = 0\n/\\ y = \"b\""];
+-3219420052081701213 -> 5648648852758402454 [label="/\\ x = 2\n/\\ y = \"b\"",color="black",fontcolor="black"];
+-3219420052081701213 -> -3312545320546479502 [label="/\\ x = 0\n/\\ y = \"b\"",color="black",fontcolor="black"];
+-3219420052081701213 -> -3312545320546479502 [label="/\\ x = 0\n/\\ y = \"b\"",color="black",fontcolor="black"];
+5648648852758402454 -> 5706380848417360199 [label="",color="black",fontcolor="black"];
+5706380848417360199 [label="/\\ x = 3\n/\\ y = \"a\"",tooltip="/\\ x = 3\n/\\ y = \"a\""];
+5648648852758402454 -> -3219420052081701213 [label="",color="black",fontcolor="black"];
+5648648852758402454 -> -8679500495765629132 [label="",color="black",fontcolor="black"];
+-8679500495765629132 [label="/\\ x = 4\n/\\ y = \"a\"",tooltip="/\\ x = 4\n/\\ y = \"a\""];
+5648648852758402454 -> -3219420052081701213 [label="",color="black",fontcolor="black"];
+5648648852758402454 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-3312545320546479502 -> -3219420052081701213 [label="",color="black",fontcolor="black"];
+-3312545320546479502 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-3312545320546479502 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-3312545320546479502 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+5706380848417360199 -> -3969734464858937321 [label="",color="black",fontcolor="black"];
+-3969734464858937321 [label="/\\ x = 4\n/\\ y = \"b\"",tooltip="/\\ x = 4\n/\\ y = \"b\""];
+5706380848417360199 -> 5648648852758402454 [label="",color="black",fontcolor="black"];
+5706380848417360199 -> -7190347254974926464 [label="",color="black",fontcolor="black"];
+-7190347254974926464 [label="/\\ x = 1\n/\\ y = \"b\"",tooltip="/\\ x = 1\n/\\ y = \"b\""];
+5706380848417360199 -> -3312545320546479502 [label="/\\ x = 0\n/\\ y = \"b\"",color="black",fontcolor="black"];
+-8679500495765629132 -> -3909827508481919802 [label="",color="black",fontcolor="black"];
+-3909827508481919802 [label="/\\ x = 5",tooltip="/\\ x = 5\n/\\ y = \"a\""];
+-8679500495765629132 -> 5706380848417360199 [label="",color="black",fontcolor="black"];
+-8679500495765629132 -> 72229073743522485 [label="",color="black",fontcolor="black"];
+72229073743522485 [label="/\\ x = 2",tooltip="/\\ x = 2\n/\\ y = \"a\""];
+-8679500495765629132 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-3969734464858937321 -> -3909827508481919802 [label="/\\ x = 5\n/\\ y = \"a\"",color="black",fontcolor="black"];
+-3969734464858937321 -> 5706380848417360199 [label="",color="black",fontcolor="black"];
+-3969734464858937321 -> 72229073743522485 [label="/\\ x = 2\n/\\ y = \"a\"",color="black",fontcolor="black"];
+-3969734464858937321 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+-7190347254974926464 -> 5648648852758402454 [label="",color="black",fontcolor="black"];
+-7190347254974926464 -> -3312545320546479502 [label="/\\ x = 0",color="black",fontcolor="black"];
+-7190347254974926464 -> 5648648852758402454 [label="",color="black",fontcolor="black"];
+-7190347254974926464 -> -3312545320546479502 [label="/\\ x = 0",color="black",fontcolor="black"];
+-7190347254974926464 -> -3312545320546479502 [label="/\\ x = 0",color="black",fontcolor="black"];
+-3909827508481919802 -> -3969734464858937321 [label="/\\ x = 4\n/\\ y = \"b\"",color="black",fontcolor="black"];
+-3909827508481919802 -> 5648648852758402454 [label="",color="black",fontcolor="black"];
+-3909827508481919802 -> -3312545320546479502 [label="/\\ x = 0\n/\\ y = \"b\"",color="black",fontcolor="black"];
+72229073743522485 -> 5706380848417360199 [label="",color="black",fontcolor="black"];
+72229073743522485 -> -3219420052081701213 [label="",color="black",fontcolor="black"];
+72229073743522485 -> -8679500495765629132 [label="",color="black",fontcolor="black"];
+72229073743522485 -> -3219420052081701213 [label="",color="black",fontcolor="black"];
+72229073743522485 -> -7105578134370194095 [label="",color="black",fontcolor="black"];
+{rank = same; -7105578134370194095;}
+{rank = same; -3219420052081701213;}
+{rank = same; 5648648852758402454;}
+{rank = same; -8679500495765629132;5706380848417360199;}
+}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/DiffDotTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/DiffDotTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Microsoft Research. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Federico Ponzi - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class DiffDotTest extends ModelCheckerTestCase {
+
+	public DiffDotTest() {
+		super("DiffDot", new String[] { "-difftrace", "-dump", "dot",
+				System.getProperty("java.io.tmpdir") + File.separator + "DiffDotTest" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		// -dump appends the ".dump" extension to the file name
+		final File dumpFile = new File(System.getProperty("java.io.tmpdir") + File.separator + "DiffDotTest.dot");
+		assertTrue(dumpFile.exists());
+		
+		// If the file exist, simply compare it to a correct and manually checked version.
+		final InputStream master = getClass().getResourceAsStream("DiffDotTest.dot");
+		assertTrue(Arrays.equals(getBytes(master), getBytes(new FileInputStream(dumpFile))));
+
+		assertZeroUncovered();
+	}
+	
+	// http://stackoverflow.com/a/17861016
+	public static byte[] getBytes(InputStream is) throws IOException {
+		final ByteArrayOutputStream os = new ByteArrayOutputStream();
+		try {
+			byte[] buffer = new byte[0xFFFF];
+			for (int len; (len = is.read(buffer)) != -1;) {
+				os.write(buffer, 0, len);
+			}
+			os.flush();
+			return os.toByteArray();
+		} finally {
+			os.close();
+		}
+	}
+
+	@Override
+	protected boolean doDump() {
+		// Explicitly set by this test in its ctor.
+		return false;
+	}
+
+	// overrides below are nice-to-have but not relevant for the test.
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/ModelCheckerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/ModelCheckerTestCase.java
@@ -189,7 +189,7 @@ public abstract class ModelCheckerTestCase extends CommonTestCase {
 			// Always print the state graph in dot file notation.
 			if (doDump()) {
 				args.add("-dump");
-				args.add("dot");
+				args.add(getDumpArgs());
 				args.add("${metadir}" + FileUtil.separator + getClass().getCanonicalName() + ".dot");
 			}
 
@@ -214,6 +214,10 @@ public abstract class ModelCheckerTestCase extends CommonTestCase {
 		}
 	}
 	
+	protected String getDumpArgs() {
+		return "dot";
+	}
+
 	protected String getMetaDir() {
 		return TLCGlobals.metaRoot + FileUtil.separator + getClass().getCanonicalName();
 	}


### PR DESCRIPTION
/cc @heidihoward