### PR TITLE
Add note about Eclipse interference with Ant CLI build

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -82,6 +82,8 @@ This will also add the `RunAllTLCTests` target to the external tools runner menu
 
 If you ran Ant from your CLI for whatever reason and are encountering issues with nonexistent compilation errors in Eclipse, you can resolve them by right-clicking the project in the Workspace pane then selecting "Refresh".
 This can also be set to refresh automatically in the Eclipse settings; open them by clicking Eclipse > Settings on macOS or Window > Preferences on Linux, then check the box at General > Workspace > "Refresh using native hooks or polling".
+Note, however, that enabling this setting may cause compilation failures when running Ant from your CLI while Eclipse is open; you should only enable it if you are running Ant solely from within Eclipse.
+The setting also helps Eclipse pick up changes as you switch between git branches.
 
 ### Developing the Toolbox in Eclipse
 


### PR DESCRIPTION
Ran into some very weird Ant compilation failures in the CLI and found they were caused by the Eclipse "Refresh using native hooks or polling" setting; added a note about this interference to the developing docs.