### PR TITLE
Silence noisy `EndOfFileException`

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/REPL.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/REPL.java
@@ -1,3 +1,5 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
 package tlc2;
 
 import java.io.BufferedWriter;
@@ -197,7 +199,10 @@ public class REPL {
             } catch (UserInterruptException e) {
                 return;
             } catch (EndOfFileException e) {
-                e.printStackTrace();
+                String partial = e.getPartialLine();
+                if (partial != null && !partial.isBlank()) {
+                    System.err.println("Warning: ignoring partial line '" + partial + '\'');
+                }
                 return;
             } finally {
 				// Persistent file and directory will be create on demand.


### PR DESCRIPTION
Quitting out of the REPL with Ctrl+D or piping input to the REPL always results in

    org.jline.reader.EndOfFileException
        at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:697)
        at org.jline.reader.impl.LineReaderImpl.readLine(LineReaderImpl.java:512)
        at tlc2.REPL.runREPL(REPL.java:191)
        at tlc2.REPL.main(REPL.java:236)

This is quite distracting; end-of-file is a normal condition and there is no reason to see its stacktrace.

This commit silences the noisy output.  It also adds a warning if some partially-entered input would be ignored because of the end-of-file (which should be a rare condition).