### PR TITLE
Remove `Value.assignable()`

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/BoolValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/BoolValue.java
@@ -157,18 +157,6 @@ public class BoolValue extends Value implements IBoolValue {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return ((val instanceof BoolValue) &&
-        this.val == ((BoolValue)val).val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public void write(IValueOutputStream vos) throws IOException {
 		vos.writeByte(BOOLVALUE);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EvaluatingValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EvaluatingValue.java
@@ -217,16 +217,6 @@ public class EvaluatingValue extends OpValue {
 
   public final IValue deepCopy() { return this; }
 
-  public final boolean assignable(Value val) {
-    try {
-      throw new WrongInvocationException("It is a TLC bug: Attempted to initialize an operator.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* String representation of the value.  */
   public final StringBuffer toString(StringBuffer sb, int offset, boolean ignored) {
     try {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnLambdaValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnLambdaValue.java
@@ -520,17 +520,6 @@ public class FcnLambdaValue extends Value implements FunctionValue, IFcnLambdaVa
     }
   }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return (val instanceof FcnLambdaValue);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   private void readObject(ObjectInputStream ois) throws IOException, ClassNotFoundException {
     this.fcnRcd = (FcnRcdValue)ois.readObject();
   }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/FcnRcdValue.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import tlc2.tool.EvalControl;
 import tlc2.tool.FingerprintException;
 import tlc2.tool.TLCState;
 import tlc2.tool.coverage.CostModel;
@@ -753,26 +752,6 @@ public class FcnRcdValue extends Value implements FunctionValue, IFcnRcdValue {
     	  return new FcnRcdValue(Arrays.copyOf(this.domain, this.domain.length), vals, false);
       }
       return new FcnRcdValue(this, vals);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      boolean canAssign = ((val instanceof FcnRcdValue) &&
-        this.values.length == ((FcnRcdValue)val).values.length);
-      if (!canAssign) return false;
-      FcnRcdValue fcn = (FcnRcdValue)val;
-      for (int i = 0; i < this.values.length; i++) {
-        canAssign = (canAssign &&
-         this.domain[i].equals(fcn.domain[i]) &&
-         this.values[i].assignable(fcn.values[i]));
-      }
-      return canAssign;
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/IntValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/IntValue.java
@@ -192,18 +192,6 @@ public class IntValue extends Value {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return ((val instanceof IntValue) &&
-        this.val == ((IntValue)val).val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public void write(IValueOutputStream vos) throws IOException {
 		vos.writeByte(INTVALUE);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/IntervalValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/IntervalValue.java
@@ -247,19 +247,6 @@ implements Enumerable, Reducible {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return ((val instanceof IntervalValue) &&
-        this.high == ((IntervalValue)val).high &&
-        this.low == ((IntervalValue)val).low);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public void write(final IValueOutputStream vos) throws IOException {
 		vos.writeByte(INTERVALVALUE);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/LazyValue.java
@@ -338,20 +338,6 @@ public class LazyValue extends Value {
     }
   }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      if (this.val == null || this.val == UndefValue.ValUndef) {
-        Assert.fail("Error(TLC): Attempted to call assignable on lazy value.", getSource());
-      }
-      return this.val.assignable(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* The fingerprint method */
   @Override
   public final long fingerPrint(long fp) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/MethodValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/MethodValue.java
@@ -244,17 +244,6 @@ public class MethodValue extends OpValue {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      throw new WrongInvocationException("It is a TLC bug: Attempted to initialize an operator.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* String representation of the value.  */
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean ignored) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/ModelValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/ModelValue.java
@@ -350,18 +350,6 @@ public class ModelValue extends Value implements IModelValue {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return ((val instanceof ModelValue) &&
-        this.val.equals(((ModelValue)val).val));
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public void write(IValueOutputStream vos) throws IOException {
 		vos.writeByte(MODELVALUE);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpLambdaValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpLambdaValue.java
@@ -190,17 +190,6 @@ public class OpLambdaValue extends OpValue {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      throw new WrongInvocationException("Should not initialize an operator.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* String representation of the value.  */
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean ignored) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/OpRcdValue.java
@@ -242,17 +242,6 @@ public class OpRcdValue extends OpValue {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      throw new WrongInvocationException("Should not initialize an operator.");
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* Pretty-printing  */
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
@@ -633,25 +633,6 @@ public class RecordValue extends Value implements FunctionValue {
     }
   }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      boolean canAssign = ((val instanceof RecordValue) &&
-        this.names.length == ((RecordValue)val).names.length);
-      if (!canAssign) return false;
-      for (int i = 0; i < this.values.length; i++) {
-        canAssign = (canAssign &&
-         this.names[i].equals(((RecordValue)val).names[i]) &&
-         this.values[i].assignable(((RecordValue)val).values[i]));
-      }
-      return canAssign;
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public final void write(final IValueOutputStream vos) throws IOException {
 		final int index = vos.put(this);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetCapValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetCapValue.java
@@ -166,17 +166,6 @@ public class SetCapValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public void write(final IValueOutputStream vos) throws IOException {
 		capSet.write(vos);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetCupValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetCupValue.java
@@ -182,17 +182,6 @@ public class SetCupValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public final void write(final IValueOutputStream vos) throws IOException {
 		cupSet.write(vos);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetDiffValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetDiffValue.java
@@ -187,17 +187,6 @@ public class SetDiffValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public final void write(final IValueOutputStream vos) throws IOException {
 		diffSet.write(vos);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetEnumValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetEnumValue.java
@@ -328,17 +328,6 @@ public static final SetEnumValue DummyEnum = new SetEnumValue((ValueVec)null, tr
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public final void write(IValueOutputStream vos) throws IOException {
 		final int index = vos.put(this);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -246,17 +246,6 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* The fingerprint  */
   @Override
   public final long fingerPrint(long fp) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -299,17 +299,6 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* The fingerprint  */
   @Override
   public final long fingerPrint(long fp) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -262,17 +262,6 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* The fingerprint  */
   @Override
   public final long fingerPrint(long fp) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetPredValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetPredValue.java
@@ -266,17 +266,6 @@ public class SetPredValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* The fingerprint method */
   @Override
   public final long fingerPrint(long fp) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/StringValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/StringValue.java
@@ -166,18 +166,6 @@ public class StringValue extends Value {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return ((val instanceof StringValue) &&
-        this.equals(val));
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   public final int length() {
     try {
       return this.val.length();

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SubsetValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SubsetValue.java
@@ -235,17 +235,6 @@ public class SubsetValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public final void write(final IValueOutputStream vos) throws IOException {
 		pset.write(vos);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/TupleValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/TupleValue.java
@@ -307,23 +307,6 @@ public class TupleValue extends Value implements FunctionValue, ITupleValue {
     }
   }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      boolean canAssign = ((val instanceof TupleValue) &&
-         (this.elems.length == ((TupleValue)val).elems.length));
-      if (!canAssign) return false;
-      for (int i = 0; i < this.elems.length; i++) {
-        canAssign = canAssign && this.elems[i].assignable(((TupleValue)val).elems[i]);
-      }
-      return canAssign;
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
 	@Override
 	public final void write(IValueOutputStream vos) throws IOException {
 		final int index = vos.put(this);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UndefValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UndefValue.java
@@ -127,9 +127,6 @@ public class UndefValue extends Value {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) { return true; }
-
   /* The string representation. */
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UnionValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UnionValue.java
@@ -214,17 +214,6 @@ public class UnionValue extends EnumerableValue implements Enumerable {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   public static Value union(Value val) {
     boolean canCombine = (val instanceof SetEnumValue);
     if (canCombine) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserValue.java
@@ -124,17 +124,6 @@ public class UserValue extends Value {
   @Override
   public final IValue deepCopy() { return this; }
 
-  @Override
-  public final boolean assignable(Value val) {
-    try {
-      return this.equals(val);
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
-  }
-
   /* The string representation. */
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
@@ -91,9 +91,6 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
   /* This method returns a new value after taking the excepts. */
   public abstract Value takeExcept(ValueExcept[] exs);
 
-  /* This method returns true iff val can be assigned to this. */
-  abstract boolean assignable(Value val);
-  
   public abstract Value normalize();
 
   @Override

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/EnumerableValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/EnumerableValueTest.java
@@ -139,11 +139,6 @@ public class EnumerableValueTest {
 		}
 
 		@Override
-		public boolean assignable(Value val) {
-			return false;
-		}
-
-		@Override
 		public StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {
 			return toString(sb, offset, swallow);
 		}


### PR DESCRIPTION
This method is not used by the Toolbox, the Community Modules, or TLC itself.

The `assignable()` method creates problems for Java module overrides because it is package-private.  A package-private method cannot be overridden by another class in a different package, meaning that module overrides cannot create their own `Value` implementations.

----

@lemmy I ran into this while trying to write a new overridden operator for the Community Modules. Making the method `public` would also fix the problem, but this seemed cleaner since it isn't used anywhere.