### PR TITLE
Add a `:help` command to the REPL

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/REPL.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/REPL.java
@@ -27,6 +27,9 @@ import tla2sany.semantic.ModuleNode;
 import tla2sany.semantic.OpDefNode;
 import tlc2.output.EC;
 import tlc2.output.MP;
+import tlc2.repl.Command;
+import tlc2.repl.CommandParseException;
+import tlc2.repl.EvaluateExpressionCommand;
 import tlc2.tool.EvalException;
 import tlc2.tool.impl.FastTool;
 import tlc2.tool.impl.Tool;
@@ -187,15 +190,13 @@ public class REPL {
      */
     public void runREPL(final LineReader reader) throws IOException {
         // Run the loop.
-    	String expr;
         while (true) {
             try {
-                expr = reader.readLine(prompt);
-                String res = processInput(expr);
-                if (res.equals("")) {
-                    continue;
-                }
-                System.out.println(res);
+                String line = reader.readLine(prompt);
+                Command command = Command.parse(line);
+                command.apply(this, System.out);
+            } catch (CommandParseException e) {
+                System.err.println("Failed to parse command: " + e.getMessage());
             } catch (UserInterruptException e) {
                 return;
             } catch (EndOfFileException e) {
@@ -218,10 +219,7 @@ public class REPL {
             // TODO: Allow external spec file to be loaded into REPL context.
  
             if(args.length == 1) {
-                String res = repl.processInput(args[0]);
-                if (!res.equals("")) {
-                	System.out.println(res);
-                }
+                new EvaluateExpressionCommand(args[0]).apply(repl, System.out);
                 //TODO Return actual exit value if parsing/evaluation fails.
                 System.exit(0);
             }
@@ -236,7 +234,7 @@ public class REPL {
 
 			System.out.println("Welcome to the TLA+ REPL!");
             MP.printMessage(EC.TLC_VERSION, TLCGlobals.versionOfTLC);
-        	System.out.println("Enter a constant-level TLA+ expression.");
+            System.out.println("Enter a constant-level TLA+ expression or type :help for help.");
 
             repl.runREPL(reader);
         } catch (Exception e) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/repl/Command.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/repl/Command.java
@@ -1,0 +1,33 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
+package tlc2.repl;
+
+import tlc2.REPL;
+
+import java.io.PrintStream;
+
+/**
+ * A parsed command for the {@link REPL}.
+ */
+public interface Command {
+
+    /**
+     * Apply this command to the state of the REPL.
+     *
+     * @param replState the REPL state to modify
+     * @param out where to write the output of the command, if any
+     */
+    void apply(REPL replState, PrintStream out);
+
+    /**
+     * Parse a command.
+     *
+     * @param line the input
+     * @return a parsed command
+     * @throws CommandParseException if the input was not a well-formed command
+     */
+    public static Command parse(String line) throws CommandParseException {
+        return CommandParser.parse(line);
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/repl/CommandParseException.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/repl/CommandParseException.java
@@ -1,0 +1,14 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
+package tlc2.repl;
+
+/**
+ * Thrown when a {@link Command} cannot be parsed.
+ *
+ * @see Command#parse(String)
+ */
+public class CommandParseException extends Exception {
+    public CommandParseException(String message) {
+        super(message);
+    }
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/repl/CommandParser.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/repl/CommandParser.java
@@ -1,0 +1,38 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
+package tlc2.repl;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class for {@link Command#parse(String)}.
+ */
+class CommandParser {
+
+    private static final String COMMAND_PREFIX = ":";
+    private static final Pattern COMMAND_PATTERN = Pattern.compile("^\\s*(" + Pattern.quote(COMMAND_PREFIX) + "\\w+)\\s*(.*?)\\s*$");
+
+    public static Command parse(String line) throws CommandParseException {
+        if (line.isBlank()) {
+            return new NoOpCommand();
+        }
+
+        Matcher matcher = COMMAND_PATTERN.matcher(line);
+        if (matcher.matches()) {
+            switch (matcher.group(1)) {
+                case ":help":
+                    if (matcher.group(2).isBlank()) {
+                        return new HelpCommand();
+                    } else {
+                        throw new CommandParseException("Junk input after help command: '" + matcher.group(2) + '\'');
+                    }
+                default:
+                    throw new CommandParseException("Unknown command '" + matcher.group(1) + '\'');
+            }
+        } else {
+            return new EvaluateExpressionCommand(line);
+        }
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/repl/EvaluateExpressionCommand.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/repl/EvaluateExpressionCommand.java
@@ -1,0 +1,32 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
+package tlc2.repl;
+
+import tlc2.REPL;
+
+import java.io.PrintStream;
+
+/**
+ * Command to evaluate an expression and print the result.
+ */
+public class EvaluateExpressionCommand implements Command {
+
+    private final String expression;
+
+    public EvaluateExpressionCommand(String expression) {
+        this.expression = expression;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    @Override
+    public void apply(REPL replState, PrintStream out) {
+        String res = replState.processInput(expression);
+        if (!res.isEmpty()) {
+            out.println(res);
+        }
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/repl/HelpCommand.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/repl/HelpCommand.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
+package tlc2.repl;
+
+import tlc2.REPL;
+
+import java.io.PrintStream;
+
+/**
+ * Command to show REPL help.
+ */
+public class HelpCommand implements Command {
+
+    @Override
+    public void apply(REPL replState, PrintStream out) {
+        out.println("---- REPL HELP ----");
+        out.println("  :help");
+        out.println("           show this help");
+        out.println("  <expr>");
+        out.println("           evaluate a TLA+ expression");
+        out.println("===================");
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/repl/NoOpCommand.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/repl/NoOpCommand.java
@@ -1,0 +1,16 @@
+// Copyright (c) 2024, Oracle and/or its affiliates.
+
+package tlc2.repl;
+
+import tlc2.REPL;
+
+import java.io.PrintStream;
+
+/**
+ * Command that does nothing.
+ */
+public class NoOpCommand implements Command {
+    @Override
+    public void apply(REPL replState, PrintStream out) {
+    }
+}


### PR DESCRIPTION
Originally requested in a comment:

https://github.com/tlaplus/tlaplus/issues/627#issuecomment-844538528

I chose the `:` prefix for `:help` because

 - it is already used in at least one other REPL (ghci)
 - it cannot appear at the start of any legal TLA+ expression.

This commit also lays out a bit of infrastructure for adding additional commands.