### PR TITLE
Fix PlusCal Unicode handling on Windows

### DIFF
--- a/tlatools/org.lamport.tlatools/src/pcal/Validator.java
+++ b/tlatools/org.lamport.tlatools/src/pcal/Validator.java
@@ -5,6 +5,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -67,7 +68,7 @@ public class Validator {
 			throws IOException {
 		final BufferedReader reader = new BufferedReader(
 				new InputStreamReader((inputStream instanceof BufferedInputStream) ? (BufferedInputStream) inputStream
-						: new BufferedInputStream(inputStream)));
+						: new BufferedInputStream(inputStream), StandardCharsets.UTF_8));
 		return validate(parseUnit, reader);
 	}
 	


### PR DESCRIPTION
I have hopes that this will address #1005, although I cannot actually test that it does on my Windows install locally.