### PR TITLE
Don't enforce LF line endings on JavaCC-generated code

### DIFF
--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -98,20 +98,11 @@
 
 	<!-- Runs JavaCC to generate the TLA+ parser files. -->
 	<target name="generate">
-		<tempfile property="javacc-tmpdir" destdir="${java.io.tmpdir}" prefix="javacc_" />
-		<mkdir dir="${javacc-tmpdir}" />
 		<java classpath="lib/javacc-4.0.jar" classname="javacc" fork="true" failonerror="true">
-			<arg value="-OUTPUT_DIRECTORY=${javacc-tmpdir}" />
+			<arg value="-OUTPUT_DIRECTORY=src/tla2sany/parser" />
 			<arg value="javacc/tla+.jj" />
 			<jvmarg value="-Dfile.encoding=UTF-8" />
 		</java>
-		<fixcrlf srcdir="${javacc-tmpdir}" eol="lf" includes="*.java" />
-		<move todir="src/tla2sany/parser">
-			<fileset dir="${javacc-tmpdir}">
-				<include name="*.java" />
-			</fileset>
-		</move>
-		<delete dir="${javacc-tmpdir}" />
 	</target>
 
 	<!-- ===========================================================-->


### PR DESCRIPTION
Another minor thing to come out of my Windows bug-bashing jaunt. My understanding of how line endings work with git is if a file has entirely line endings of a certain type (all LF or all CRLF), git does not actually store its line endings internally & it is checked out with different line endings depending on what OS you are using. All the generated JavaCC files have uniform line endings, so if you clone the repo on Windows the files will all have CRLF line endings (and LF if cloned on linux/macOS). Thus if you run the Ant JavaCC generate target it will force-convert them all to LF and so cause a spurious local diff when nothing really changed. This removes the LF conversion step and so the files will just be output as whatever is the OS default.

I recall this force-LF step was originally added out of concern for build reproducibility but due to how git works I guess that doesn't really matter.