### PR TITLE
Print a log message whenever simulator has finished to compute initial state

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -302,6 +302,8 @@ public class Simulator {
 			return MP.printError(EC.TLC_NO_STATES_SATISFYING_INIT_AND_CONSTRAINT);
 		}
 
+		MP.printMessage(EC.TLC_INIT_GENERATED1, String.valueOf(initStates.size()), "");
+
 		// It appears deepNormalize brings the states into a canonical form to
 		// speed up equality checks.
 		initStates.deepNormalize();


### PR DESCRIPTION
This will add a log line:
```
Computed 1 initial states...
Finished computing initial states: 1 distinct state generated at 2024-09-28 00:26:25.
```
It's not super informative, but it's helpful for the ux of the vscode extension. Without it, users need to wait about a minute to get another log line before seeing something on the table:
![image](https://github.com/user-attachments/assets/b47c40b0-ad02-4074-a78f-a06f2049794e)
This adds the initial line:
![image](https://github.com/user-attachments/assets/bffb6e9f-a193-4292-886a-2e7b709a1ab6)
I think it's helpful to know that something is happening behind the scenes.

