### PR TITLE
Add documentation for `constrained` sub-command

### DIFF
--- a/general/docs/current-tools.md
+++ b/general/docs/current-tools.md
@@ -258,7 +258,7 @@ In case of a property violation, formats the TLA+ error trace to the given forma
 Example: `-dumpTrace tla file.tla -dumpTrace json file.json`.
 
 `-dump` _format file_
-The _format_ parameter can be omitted, or it can be a comma-separated list beginning with `dot` that may also contain one or both of the items `colorize` and `actionlabels`. If _format_ is omitted, TLC writes a list of all reachable states, described by TLA+ formulas, on _file_. Otherwise, TLC writes the state graph in dot format, the input format of the GraphViz program for displaying graphs. The parameter `colorize` indicates that state transitions should be colored according to the action generating the transition, and `actionlabels` indicates that they should be labeled with the name of the action. 
+The _format_ parameter can be omitted, or it can be a comma-separated list beginning with `dot` that may also contain any subset of `colorize`, `actionlabels`, and `constrained`. If _format_ is omitted, TLC writes a list of all reachable states, described by TLA+ formulas, on _file_. Otherwise, TLC writes the state graph in dot format, the input format of the GraphViz program for displaying graphs. The parameter `colorize` indicates that state transitions should be colored according to the action generating the transition, and `actionlabels` indicates that they should be labeled with the name of the action.  The parameter `constrained` causes TLC to include states in the dot file that are excluded from the model via a state or action constraint.
 
 Example: `-dump dot,colorize,actionlabels file.dot`.
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -1571,15 +1571,17 @@ public class TLC {
         sharedArguments.add(new UsageGenerator.Argument("-dump", "format file",
                                                         "dump all states into the specified file.\n"
     													+ "The format parameter can be omitted, or it can be a comma-separated\n"
-    														+ "list beginning with 'dot' that may also contain one or both of\n"
-    														+ "the items 'colorize' and 'actionlabels'. If format is omitted,\n"
-    														+ "TLC writes a list of all reachable states, described by TLA+ formulas, \n"
-                                                            + "on file. Otherwise, TLC writes the state graph in dot format, \n"
+    														+ "list beginning with 'dot' that may also contain a subset of\n"
+    														+ "the items 'colorize', 'actionlabels', and 'constrained'. If format is\n"
+    														+ "omitted, TLC writes a list of all reachable states, described by TLA+\n"
+                                                            + "formulas, on file. Otherwise, TLC writes the state graph in dot format,\n"
                                                             + "the input format of the GraphViz program for displaying graphs. \n"
                                                             + "The parameter 'colorize' indicates that state transitions should be \n"
                                                             + "colored according to the action generating the transition,  \n"
                                                             + "and 'actionlabels' indicates that they should be labeled with \n"
-    														+ "the name of the action.", true));
+    														+ "the name of the action. The parameter 'constrained' causes TLC to include\n"
+    														+ "states in the dot file that are excluded from the model via a state or\n"
+    														+ "action constraint.", true));
     	sharedArguments.add(new UsageGenerator.Argument("-fp", "N",
     													"use the Nth irreducible polynomial from the list stored\n"
     														+ "in the class FP64", true));


### PR DESCRIPTION
Subcommand causes TLC to include states in the dot file that are excluded from the model via a state or action constraint.

Feature introduced in git commit 24479f74c8a02fbe2f83981ca6210e2f7fa7799f
https://github.com/tlaplus/tlaplus/commit/24479f74c8a02fbe2f83981ca6210e2f7fa7799f

[Doc]