### PR TITLE
Add Eclipse project setting file enforcing UTF-8 usage

### DIFF
--- a/tlatools/org.lamport.tlatools/.settings/org.eclipse.core.resources.prefs
+++ b/tlatools/org.lamport.tlatools/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
This solved Leslie Lamport's issues developing on Windows in https://github.com/tlaplus/tlaplus/pull/911#discussion_r1789191547