### PR TITLE
Convert TLC.traceNum to a non-static class variable

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -157,7 +157,7 @@ public class TLC {
     /**
      * The number of traces/behaviors to generate in simulation mode
      */
-    private static long traceNum = Long.MAX_VALUE;
+    private long traceNum = Long.MAX_VALUE;
 
     /**
      * Name of the file to which to write state traces.
@@ -384,10 +384,6 @@ public class TLC {
 		}
 		
 		return true;
-	}
-
-	public static void setTraceNum(long aTraceNum) {
-		traceNum = aTraceNum;
 	}
 
     /**

--- a/tlatools/org.lamport.tlatools/test/tlc2/TLCTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/TLCTest.java
@@ -127,12 +127,10 @@ public class TLCTest {
 	public void testHandleParametersSimulateFileNum() {
 		TLC tlc = new TLC();
 		assertTrue(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "num=5,file=test.txt"}));
-		// reset static field
-		tlc.setTraceNum(Long.MAX_VALUE);
+		tlc = new TLC();
 		assertFalse(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "file=test.txt"}));
-		// reset static fields.
-		tlc.setTraceNum(Long.MAX_VALUE);
-		assertFalse(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "num=10"}));
+		tlc = new TLC();
+		assertTrue(tlc.handleParameters(new String[] {TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "-simulate", "num=10"}));
     }
 
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/LiveCheckSimulationTest2.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/LiveCheckSimulationTest2.java
@@ -36,7 +36,6 @@ public class LiveCheckSimulationTest2 extends SuccessfulSimulationTestCase {
 	}
 
 	public LiveCheckSimulationTest2() {
-		super("Test2", "/", new String[] {"-simulate", "-depth", "10"});
-		TLC.setTraceNum(50);
+		super("Test2", "/", new String[] {"-simulate", "num=50", "-depth", "10"});
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/LiveCheckSimulationTest2a.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/LiveCheckSimulationTest2a.java
@@ -51,10 +51,8 @@ public class LiveCheckSimulationTest2a extends ModelCheckerTestCase {
 	}
 
 	public LiveCheckSimulationTest2a() {
-		super("Test2a", "/", new String[] {"-simulate", "-depth", "10"}, ExitStatus.VIOLATION_LIVENESS);
-		
+		super("Test2a", "/", new String[] {"-simulate", "num=100", "-depth", "10"}, ExitStatus.VIOLATION_LIVENESS);
 		// Stop after 100 traces due to lack of general timeout regardless of outcome
-		TLC.setTraceNum(100);
 	}
 	
 	@Test

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/SimulationTest2.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/SimulationTest2.java
@@ -31,7 +31,6 @@ import tlc2.TLC;
 public class SimulationTest2 extends SuccessfulSimulationTestCase {
 
 	public SimulationTest2() {
-		super("Test2", "/", new String[] {"-simulate", "-depth", "6"});
-		TLC.setTraceNum(50);
+		super("Test2", "/", new String[] {"-simulate", "num=50", "-depth", "6"});
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/SimulationTest2PostCondition.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/SimulationTest2PostCondition.java
@@ -36,8 +36,7 @@ import tlc2.output.EC;
 public class SimulationTest2PostCondition extends SuccessfulSimulationTestCase {
 
 	public SimulationTest2PostCondition() {
-		super("Test2", "/", new String[] { "-config", "Test2PostCondition.cfg", "-simulate", "-depth", "6" }, EC.ExitStatus.VIOLATION_ASSUMPTION);
-		TLC.setTraceNum(1);
+		super("Test2", "/", new String[] { "-config", "Test2PostCondition.cfg", "-simulate", "num=1", "-depth", "6" }, EC.ExitStatus.VIOLATION_ASSUMPTION);
 	}
 	@Test
 	public void testSpec() {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/Github602Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/Github602Test.java
@@ -38,8 +38,7 @@ import tlc2.tool.liveness.ModelCheckerTestCase;
 public class Github602Test extends ModelCheckerTestCase {
 
 	public Github602Test() {
-		super("Github602", new String[] { "-config", "Github602.tla", "-simulate" });
-		TLC.setTraceNum(1);
+		super("Github602", new String[] { "-config", "Github602.tla", "-simulate", "num=1" });
 	}
 
 	@Test

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/NQSpecTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/NQSpecTest.java
@@ -41,8 +41,7 @@ import util.TLAConstants;
 public class NQSpecTest extends ModelCheckerTestCase {
 
 	public NQSpecTest() {
-		super(TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "simulation" + File.separator + "NQSpec", new String[] { "-simulate" });
-		TLC.setTraceNum(100);
+		super(TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, "simulation" + File.separator + "NQSpec", new String[] { "-simulate", "num=100" });
 	}
 
 	@Test


### PR DESCRIPTION
Another easy fix to advance the goal of https://github.com/tlaplus/tlaplus/issues/891 and simplify testing.

Similar to #1033