### PR TITLE
POSTCONDITION is evaluated twice with different values for TLCExt!Counterexample when TLC detects a liveness violation.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
@@ -269,7 +269,13 @@ public class ModelChecker extends AbstractChecker
                 }
 
                 // We get here because the checking has been completed.
-                result = EC.NO_ERROR;
+                
+                // Check the postcondition.
+                result = tool.checkPostCondition();
+                if (result != EC.NO_ERROR) {
+                	return result;
+                }
+
                 reportSuccess(this.theFPSet, getStatesGenerated());
             } else if (this.keepCallStack)
             {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
@@ -96,12 +96,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 				curState = this.squeue.sDequeue();
 				if (curState == null) {
 					synchronized (this.tlc) {
-						if(!this.tlc.setDone()) {
-							final int ec = tool.checkPostCondition();
-							if (ec != EC.NO_ERROR) {
-								tlc.setError(true, ec);
-							}
-						}
+						this.tlc.setDone();
 						this.tlc.notify();
 					}
 					//TODO: finishAll not inside the synchronized block above, while

--- a/tlatools/org.lamport.tlatools/test-model/CodePlexBug08/EWD840MC1.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CodePlexBug08/EWD840MC1.tla
@@ -5,8 +5,7 @@ const_123 == 4
 
 PostCondition ==
 	/\ TLCSet(42, TLCGet("generated"))
-	/\ \/ CounterExample = [ action |-> {} , state |-> {} ]
-	   \/ /\ ToTrace(CounterExample) = 
+	/\ \/ /\ ToTrace(CounterExample) = 
 				<< [ active |-> (0 :> FALSE @@ 1 :> FALSE @@ 2 :> FALSE @@ 3 :> TRUE),
 				     color |-> (0 :> "white" @@ 1 :> "white" @@ 2 :> "white" @@ 3 :> "white"),
 				     tpos |-> 0,

--- a/tlatools/org.lamport.tlatools/test-model/CodePlexBug08/MCa.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CodePlexBug08/MCa.tla
@@ -11,8 +11,7 @@ x=1 ~> x=0
 ----
 PostCondition ==
 	/\ TLCSet(42, TLCGet("generated"))
-	/\ \/ CounterExample = [state |-> {}, action |-> {}]
-	   \/ /\ CounterExample = 
+	/\ \/ /\ CounterExample = 
 				[ state |->
 				      { <<1, [x |-> 1, b |-> FALSE]>>,
 				        <<2, [x |-> 2, b |-> TRUE]>>,

--- a/tlatools/org.lamport.tlatools/test-model/Test3.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Test3.tla
@@ -16,8 +16,7 @@ Prop1 ==  <>[](x#1) \/ <>[](x#2)
 
 PostCondition ==
 	/\ TLCSet(42, TLCGet("generated"))
-	/\ \/ CounterExample = [state|->{},action|->{}] 
-	   \/ /\ ToTrace(CounterExample) = <<[x |-> 0], [x |-> 1], [x |-> 0], [x |-> 2]>>
+	/\ \/ /\ ToTrace(CounterExample) = <<[x |-> 0], [x |-> 1], [x |-> 0], [x |-> 2]>>
 	   
 	      /\ CounterExample =
 			[ action |->

--- a/tlatools/org.lamport.tlatools/test-model/symmetry/OneBitMutex/OneBitMutexNoSymmetryMC.tla
+++ b/tlatools/org.lamport.tlatools/test-model/symmetry/OneBitMutex/OneBitMutexNoSymmetryMC.tla
@@ -23,8 +23,7 @@ StarvationFreedom
 PostCondition ==
 	/\ TLCSet(42, TLCGet("generated"))
 	/\ PrintT(ToTrace(CounterExample))
-  	/\ \/ CounterExample = [state|->{},action|->{}]
-  	   \/ /\ CounterExample = 
+  	/\ \/ /\ CounterExample = 
 				[ action |->
 				      { << << 1,
 				              [ x |-> (A :> FALSE @@ B :> FALSE),


### PR DESCRIPTION
POSTCONDITION is evaluated twice with different values for TLCExt!Counterexample when TLC detects a liveness violation.

[TLC][Bug]