### PR TITLE
SANY XML: added CLI help text

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tla2sany/xml/TestXMLExporterHelpText.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/xml/TestXMLExporterHelpText.java
@@ -1,0 +1,77 @@
+package tla2sany.xml;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import util.ToolIO;
+
+public class TestXMLExporterHelpText {
+
+  private final PrintStream toolOut = ToolIO.out;
+  private final PrintStream toolErr = ToolIO.err;
+  private final ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errStream = new ByteArrayOutputStream();
+
+  @Before
+  public void captureOutput() {
+    ToolIO.out = new PrintStream(this.outStream);
+    ToolIO.err = new PrintStream(this.errStream);
+  }
+
+  @After
+  public void restoreOutput() {
+    ToolIO.out = this.toolOut;
+    ToolIO.err = this.toolErr;
+  }
+
+  private String getHelpText() {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    XMLExporter.printUsage(new PrintStream(out));
+    return out.toString();
+  }
+
+  @Test
+  public void testPrintHelpText() throws XMLExportingException {
+    Assert.assertEquals(0, XMLExporter.run("-help"));
+    String out = this.outStream.toString();
+    String err = this.errStream.toString();
+    Assert.assertNotEquals(out, 0, out.length());
+    Assert.assertTrue(out, out.contains(getHelpText()));
+    Assert.assertEquals(err, 0, err.length());
+  }
+
+  @Test
+  public void testPrintHelpTextOnNoArgs() throws XMLExportingException {
+    Assert.assertEquals(1, XMLExporter.run());
+    String out = this.outStream.toString();
+    String err = this.errStream.toString();
+    Assert.assertEquals(out, 0, out.length());
+    Assert.assertNotEquals(err, 0, err.length());
+    Assert.assertTrue(err, err.contains(getHelpText()));
+  }
+
+  @Test
+  public void testPrintHelpTextOnUnknownArg() throws XMLExportingException {
+    Assert.assertEquals(1, XMLExporter.run("-InvalidArg"));
+    String out = this.outStream.toString();
+    String err = this.errStream.toString();
+    Assert.assertEquals(out, 0, out.length());
+    Assert.assertNotEquals(err, 0, err.length());
+    Assert.assertTrue(err, err.contains(getHelpText()));
+  }
+
+  @Test
+  public void testPrintHelpTextOnNonexistentFile() throws XMLExportingException {
+    Assert.assertEquals(1, XMLExporter.run("DoesNotExist.tla"));
+    String out = this.outStream.toString();
+    String err = this.errStream.toString();
+    Assert.assertEquals(out, 0, out.length());
+    Assert.assertNotEquals(err, 0, err.length());
+    Assert.assertTrue(err, err.contains(getHelpText()));
+  }
+}


### PR DESCRIPTION
It's difficult to add this in a way that helps in all cases without totally rewriting the very flawed parse logic but this is the minimal diff. Now outputs the following help text:
```
NAME

	tla2sany.xml.XMLExporter - Emit SANY's parse tree as XML - Version 2.2 created 08 July 2020


SYNOPSIS

	tla2sany.xml.XMLExporter [-Iot] [-help] FILE

DESCRIPTION

	Given a TLA+ file, parse that file with SANY then translate the module's semantic parse tree to XML, including all the modules depended on. The XML is printed to stdout and its output format is given by an XML Schema file (.xsd) found at https://proofs.tlapl.us/doc/web/sany.xsd.

OPTIONS

	-I
		Include; use given directory path to resolve module dependencies.
	-help
		Print this usage information.
	-o
		Offline mode; skip XML schema validation step.
	-t
		Terse; format XML output without tabs or newlines.

TIPS

	Only one root TLA+ file can be parsed per run.

	Multiple directory search paths can be given by providing multiple -I arguments.

	XML schema validation does not require network access.
```