### PR TITLE
ClassCastException when evaluating TLCGet("spec") with coverage enabled.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TLCGetSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TLCGetSet.java
@@ -351,13 +351,13 @@ public class TLCGetSet implements ValueConstants {
 			n[7] = SPEC_ACTION_CONSTRAINTS;
 			v[7] = new SetEnumValue(new ValueVec(
 					Arrays.asList(tool.getActionConstraints()).stream().map(expr -> expr.getToolObject(tool.getId()))
-							.map(o -> (OpDefNode) o).map(odn -> new RecordValue(odn)).collect(Collectors.toList())),
+							.map(TLCGetSet::constraint2Value).collect(Collectors.toList())),
 					false);
-			
+
 			n[8] = SPEC_CONSTRAINTS;
 			v[8] = new SetEnumValue(new ValueVec(
 					Arrays.asList(tool.getModelConstraints()).stream().map(expr -> expr.getToolObject(tool.getId()))
-							.map(o -> (OpDefNode) o).map(odn -> new RecordValue(odn)).collect(Collectors.toList())),
+							.map(TLCGetSet::constraint2Value).collect(Collectors.toList())),
 					false);
 			
 			return new RecordValue(n, v, false);
@@ -536,5 +536,13 @@ public class TLCGetSet implements ValueConstants {
 			return new RecordValue(odn, COVERAGE, coverage);
 		}
 		return new RecordValue(odn);
+	}
+
+	private static RecordValue constraint2Value(Object o) {
+		if (o instanceof OpDefNode) {
+			return new RecordValue((OpDefNode) o);
+		} else {
+			return new RecordValue((Action) o);
+		}
 	}
 }

--- a/tlatools/org.lamport.tlatools/test-model/Github866.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github866.tla
@@ -44,9 +44,58 @@ PostCondition ==
   /\ \A v,w \in 1..TLCGet("config").worker:
        /\ TLCGet("all")[r][v] # {0}
        /\ TLCGet("all")[r][v] = TLCGet("all")[r][w]
-       
+  /\ TLCGet("spec") = 
+				[ impliedinits |-> {},
+				  invariants |-> {},
+				  impliedtemporals |-> {},
+				  temporals |-> {},
+				  actions |->
+				      { [ name |-> "Next",
+				          location |->
+				              [ beginLine |-> 31,
+				                beginColumn |-> 3,
+				                endLine |-> 35,
+				                endColumn |-> 17,
+				                module |-> "Github866" ] ] },
+				  inits |->
+				      { [ name |-> "Init",
+				          location |->
+				              [ beginLine |-> 27,
+				                beginColumn |-> 3,
+				                endLine |-> 27,
+				                endColumn |-> 7,
+				                module |-> "Github866" ] ] },
+				  variables |->
+				      { [ name |-> "x",
+				          location |->
+				              [ beginLine |-> 24,
+				                beginColumn |-> 11,
+				                endLine |-> 24,
+				                endColumn |-> 11,
+				                module |-> "Github866" ] ] },
+				  actionconstraints |->
+				      { [ name |-> "ActionConstraint",
+				          location |->
+				              [ beginLine |-> 94,
+				                beginColumn |-> 1,
+				                endLine |-> 94,
+				                endColumn |-> 30,
+				                module |-> "Github866" ] ] },
+				  constraints |->
+				      { [ name |-> "Constraint",
+				          location |->
+				              [ beginLine |-> 93,
+				                beginColumn |-> 1,
+				                endLine |-> 93,
+				                endColumn |-> 23,
+				                module |-> "Github866" ] ] } ]
+				  
+Constraint == x \in Nat
+ActionConstraint == x' \in Nat
 ==========================================================================
 ---------------------------- CONFIG Github866 ----------------------------
 SPECIFICATION Spec
 POSTCONDITION PostCondition
+CONSTRAINT Constraint
+ACTION_CONSTRAINT ActionConstraint
 ==========================================================================

--- a/tlatools/org.lamport.tlatools/test-model/TLCGetLevel.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/TLCGetLevel.cfg
@@ -10,3 +10,5 @@ CONSTRAINT
 StateConstraint
 ACTION_CONSTRAINT
 ActionConstraint
+POSTCONDITION 
+PostCondition

--- a/tlatools/org.lamport.tlatools/test-model/TLCGetLevel.tla
+++ b/tlatools/org.lamport.tlatools/test-model/TLCGetLevel.tla
@@ -37,4 +37,93 @@ StateConstraint ==
 Prop ==
     /\ <>[](x = 2)
     /\ [][y' > y /\ yb' > yb /\ TLCGet("level") + 1 = TLCGet("level")']_<<x, y, yb, z>>
+
+PostCondition ==
+    TLCGet("spec") = [ impliedinits |-> {},
+                invariants |->
+                    { [ coverage |-> [count |-> 4],
+                        name |-> "Inv",
+                        location |->
+                            [ beginLine |-> 26,
+                                beginColumn |-> 5,
+                                endLine |-> 28,
+                                endColumn |-> 30,
+                                module |-> "TLCGetLevel" ] ] },
+                impliedtemporals |->
+                    { [ name |-> "UnnamedAction",
+                        location |->
+                            [ beginLine |-> 38,
+                                beginColumn |-> 8,
+                                endLine |-> 38,
+                                endColumn |-> 18,
+                                module |-> "TLCGetLevel" ] ] },
+                temporals |-> {},
+                actions |->
+                    { [ coverage |-> [generated |-> 6, distinct |-> 3],
+                        name |-> "Next",
+                        location |->
+                            [ beginLine |-> 16,
+                                beginColumn |-> 4,
+                                endLine |-> 23,
+                                endColumn |-> 79,
+                                module |-> "TLCGetLevel" ] ] },
+                inits |->
+                    { [ coverage |-> [generated |-> 2, distinct |-> 2],
+                        name |-> "Init",
+                        location |->
+                            [ beginLine |-> 9,
+                                beginColumn |-> 4,
+                                endLine |-> 13,
+                                endColumn |-> 11,
+                                module |-> "TLCGetLevel" ] ] },
+                variables |->
+                    { [ coverage |-> [distinct |-> 3],
+                        name |-> "x",
+                        location |->
+                            [ beginLine |-> 4,
+                                beginColumn |-> 11,
+                                endLine |-> 4,
+                                endColumn |-> 11,
+                                module |-> "TLCGetLevel" ] ],
+                        [ coverage |-> [distinct |-> 3],
+                        name |-> "y",
+                        location |->
+                            [ beginLine |-> 4,
+                                beginColumn |-> 14,
+                                endLine |-> 4,
+                                endColumn |-> 14,
+                                module |-> "TLCGetLevel" ] ],
+                        [ coverage |-> [distinct |-> 3],
+                        name |-> "yb",
+                        location |->
+                            [ beginLine |-> 4,
+                                beginColumn |-> 17,
+                                endLine |-> 4,
+                                endColumn |-> 18,
+                                module |-> "TLCGetLevel" ] ],
+                        [ coverage |-> [distinct |-> 3],
+                        name |-> "z",
+                        location |->
+                            [ beginLine |-> 4,
+                                beginColumn |-> 21,
+                                endLine |-> 4,
+                                endColumn |-> 21,
+                                module |-> "TLCGetLevel" ] ] },
+                actionconstraints |->
+                    { [ name |-> "ActionConstraint",
+                        location |->
+                            [ beginLine |-> 32,
+                                beginColumn |-> 5,
+                                endLine |-> 32,
+                                endColumn |-> 82,
+                                module |-> "TLCGetLevel" ] ] },
+                constraints |->
+                    { [ name |-> "StateConstraint",
+                        location |->
+                            [ beginLine |-> 35,
+                                beginColumn |-> 5,
+                                endLine |-> 35,
+                                endColumn |-> 31,
+                                module |-> "TLCGetLevel" ] ] } ]
+
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github866Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github866Test.java
@@ -51,14 +51,18 @@ public class Github866Test extends ModelCheckerTestCase {
 	public void testSpec() throws IOException {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
 		assertFalse(recorder.recorded(EC.GENERAL));
+
+		// Assert POSTCONDITION.
+		assertFalse(recorder.recorded(EC.TLC_ASSUMPTION_FALSE));
+		assertFalse(recorder.recorded(EC.TLC_ASSUMPTION_EVALUATION_ERROR));
 	}
 	
-	// overrides below are nice-to-have but not relevant for the test.
-
 	@Override
 	protected boolean doCoverage() {
 		return false;
 	}
+	
+	// overrides below are nice-to-have but not relevant for the test.
 
 	@Override
 	protected boolean runWithDebugger() {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/TLCGetLevelTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/TLCGetLevelTest.java
@@ -75,5 +75,9 @@ public class TLCGetLevelTest extends ModelCheckerTestCase {
 		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace);
 
 		assertStuttering(5);
+
+		// Assert POSTCONDITION.
+		assertFalse(recorder.recorded(EC.TLC_ASSUMPTION_FALSE));
+		assertFalse(recorder.recorded(EC.TLC_ASSUMPTION_EVALUATION_ERROR));
 	}
 }


### PR DESCRIPTION
```
Attempted to apply the operator overridden by the Java method
public static tlc2.value.impl.Value
tlc2.module.TLCGetSet.TLCGetEval(tlc2.tool.impl.Tool,tla2sany.semantic.ExprOrOpArgNode[],tlc2.util.Context,tlc2.tool.TLCState,tlc2.tool.TLCState,int,tlc2.tool.coverage.CostModel),
but it produced the following error:
class tlc2.tool.Action cannot be cast to class
tla2sany.semantic.OpDefNode (tlc2.tool.Action and
tla2sany.semantic.OpDefNode are in unnamed module of loader 'app')
```

Follow-up from db98efba8a9000d7f2afa13fb66d796d4a36dbaf

[Bug][TLC]