### PR TITLE
Cancel PR CI workflow runs when newer changes are pushed

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: TLA+ PR Validation
 on: [pull_request]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   tlatools-build-and-test:


### PR DESCRIPTION
Docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

Learned about this from https://turso.tech/blog/simple-trick-to-save-environment-and-money-when-using-github-actions