### PR TITLE
[Provisional] Support running the TLA+ debugger with multiple workers.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -1014,9 +1014,10 @@ public class TLC {
             }
         }
 		
-		if (TLCGlobals.getNumWorkers() != 1 && debugPort >= 0) {
+		if (TLCGlobals.getNumWorkers() != 1 && debugPort >= 0
+				&& !Boolean.getBoolean(TLC.class.getName() + ".multiWorkerDebug")) {
 			printErrorMsg("Error: TLA+ Debugger does not support running with multiple workers.");
-            return false;
+			return false;
 		}
 		
         startTime = System.currentTimeMillis();
@@ -1228,7 +1229,6 @@ public class TLC {
 				
             	// model checking
 				if (debugPort >= 0) {
-					assert TLCGlobals.getNumWorkers() == 1 : "TLCDebugger does not support running with multiple workers.";
 					final TLCDebugger instance = TLCDebugger.Factory.getInstance(debugPort, suspend, halt);
 					synchronized (instance) {
 						tool = new DebugTool(mainFile, configFile, resolver, params, instance);

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -1199,14 +1199,17 @@ public class TLC {
 				
 				Simulator simulator;
 				if (debugPort >= 0) {
-					assert TLCGlobals.getNumWorkers() == 1
-							: "TLCDebugger does not support running with multiple workers.";
 					final TLCDebugger instance = TLCDebugger.Factory.getInstance(debugPort, suspend, halt);
 					synchronized (instance) {
 						tool = new DebugTool(mainFile, configFile, resolver, Tool.Mode.Simulation, params, instance);
 					}
-					simulator = new SingleThreadedSimulator(tool, metadir, traceFile, deadlock, traceDepth, 
-	                        traceNum, traceActions, rng, seed, resolver);
+					if (Boolean.getBoolean(TLC.class.getName() + ".multiWorkerDebug")) {
+						simulator = new Simulator(tool, metadir, traceFile, deadlock, traceDepth, 
+								traceNum, traceActions, rng, seed, resolver, TLCGlobals.getNumWorkers());
+					} else {
+						simulator = new SingleThreadedSimulator(tool, metadir, traceFile, deadlock, traceDepth, 
+								traceNum, traceActions, rng, seed, resolver);
+					}	
 				} else {
 					tool = new FastTool(mainFile, configFile, resolver, Tool.Mode.Simulation, params);
 					simulator = new Simulator(tool, metadir, traceFile, deadlock, traceDepth, 

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
@@ -71,6 +71,7 @@ import tlc2.tool.INextStateFunctor.InvariantViolatedException;
 import tlc2.tool.TLCState;
 import tlc2.tool.impl.SpecProcessor;
 import tlc2.tool.impl.Tool;
+import tlc2.tool.impl.WorkerValue;
 import tlc2.util.Context;
 import tlc2.value.IValue;
 import tlc2.value.impl.LazyValue;
@@ -353,7 +354,8 @@ public class TLCStackFrame extends StackFrame {
 					// If there is only one module, do *not* organize the constants in the variable
 					// view by modules. In other words, constants get moved up by one level in the
 					// variable view iff there is only one module.
-					e.getValue().entrySet().stream().map(c -> getVariable((Value) c.getValue(), c.getKey().getName()))
+					e.getValue().entrySet().stream()
+							.map(c -> getVariable((Value) WorkerValue.mux(c.getValue()), c.getKey().getName()))
 							.forEach(var -> vars.add(var));
 				} else {
 					final ModuleNode module = e.getKey();

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ITool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ITool.java
@@ -38,6 +38,7 @@ import tla2sany.semantic.SymbolNode;
 import tlc2.TLCGlobals;
 import tlc2.tool.coverage.CostModel;
 import tlc2.tool.impl.ModelConfig;
+import tlc2.tool.impl.OpDefEvaluator;
 import tlc2.tool.impl.SpecProcessor;
 import tlc2.tool.impl.Tool.Mode;
 import tlc2.util.Context;
@@ -48,7 +49,7 @@ import tlc2.value.IMVPerm;
 import tlc2.value.IValue;
 import util.FilenameToStream;
 
-public interface ITool extends TraceApp {
+public interface ITool extends TraceApp, OpDefEvaluator {
 
 	Mode getMode();
 	

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
@@ -80,7 +80,8 @@ public class ModelChecker extends AbstractChecker
         this.workers = new Worker[TLCGlobals.getNumWorkers()];
         for (int i = 0; i < this.workers.length; i++)
         {
-            this.workers[i] = this.trace.addWorker(new Worker(i, this, this.metadir, this.tool.getRootName()));
+			this.workers[i] = this.trace.addWorker(
+					new Worker(i, this, i == 0 ? tool : tool.noDebug(), this.metadir, this.tool.getRootName()));
         }
     }
     
@@ -93,7 +94,8 @@ public class ModelChecker extends AbstractChecker
         this.workers = new Worker[TLCGlobals.getNumWorkers()];
         for (int i = 0; i < this.workers.length; i++)
         {
-            this.workers[i] = this.trace.addWorker(new Worker(i, this, this.metadir, this.tool.getRootName()));
+			this.workers[i] = this.trace.addWorker(
+					new Worker(i, this, i == 0 ? tool : tool.noDebug(), this.metadir, this.tool.getRootName()));
         }
     }
     
@@ -287,7 +289,7 @@ public class ModelChecker extends AbstractChecker
 					// to rewrite the trace file but to reconstruct actual states referenced by
 					// their fingerprints in the trace.
 					this.doNext(cTool, this.predErrState, this.checkLiveness ? new SetOfStates() : null,
-							new Worker(4223, this, this.metadir, tool.getRootName()));
+							new Worker(4223, this, tool, this.metadir, tool.getRootName()));
                 } catch (FingerprintException e)
                 {
 					result = MP.printError(EC.TLC_FINGERPRINT_EXCEPTION, new String[] {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
@@ -715,7 +715,7 @@ public class ModelChecker extends AbstractChecker
             	updateRuntimeRatio(0L);
             }
             
-            if (periodic != null && BoolValue.ValFalse.equals(tool.eval(periodic))) {
+            if (periodic != null && BoolValue.ValFalse.equals(tool.noDebug().eval(periodic))) {
        			return EC.TLC_ASSUMPTION_FALSE;
             }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCState.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCState.java
@@ -86,6 +86,10 @@ public abstract class TLCState implements Serializable {
   public abstract StateVec addToVec(StateVec states);
   public abstract void deepNormalize();
   public abstract long fingerPrint();
+  public long fingerPrint(ITool tool) {
+		return fingerPrint();
+  }
+
   public abstract boolean allAssigned();
   public abstract Set<OpDeclNode> getUnassigned();
   public abstract TLCState createEmpty();

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
@@ -174,9 +174,14 @@ public final class TLCStateMutExt extends TLCState implements Serializable {
    * via the state queue. They have to be normalized before adding to
    * the state queue.  We do that here.
    */
+    @Override
 	public final long fingerPrint() {
-		int sz = this.values.length;
+		return fingerPrint(mytool);
+	}
 
+    @Override
+	public final long fingerPrint(final ITool tool) {
+			int sz = this.values.length;
 		// TLC supports symmetry reduction. Symmetry reduction works by defining classes
 		// of symmetrically equivalent states for which TLC only checks a
 		// single representative of the equivalence class (orbit). E.g. in a two
@@ -271,7 +276,7 @@ public final class TLCStateMutExt extends TLCState implements Serializable {
 			if (minVals != this.values) {
 				state = new TLCStateMutExt(minVals);
 			}
-			IValue val = mytool.eval(viewMap, Context.Empty, state);
+			IValue val = tool.eval(viewMap, Context.Empty, state);
 			fp = val.fingerPrint(fp);
 		}
 		return fp;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
@@ -169,7 +169,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 		final long curStateFP = curState.fingerPrint();
 
 		// Add the stuttering step:
-		liveNextStates.put(curStateFP, curState);
+		liveNextStates.put(curStateFP, curState, tool);
 		this.tlc.allStateWriter.writeState(curState, curState, IStateWriter.IsUnseen, IStateWriter.Visualization.STUTTERING);
 
 		// Contrary to exceptions that are thrown during the evaluation of the init
@@ -520,7 +520,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 
 	private final boolean isSeenState(final TLCState curState, final TLCState succState, final Action action)
 			throws IOException {
-		final long fp = succState.fingerPrint();
+		final long fp = succState.fingerPrint(tool);
 		final boolean seen = this.theFPSet.put(fp);
 		// Write out succState when needed:
 		this.allStateWriter.writeState(curState, succState, seen ? IStateWriter.IsSeen : IStateWriter.IsUnseen, action);
@@ -539,7 +539,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 		// For liveness checking:
 		if (this.checkLiveness || mode == Mode.MC_DEBUG)
 		{
-			this.setOfStates.put(fp, succState);
+			this.setOfStates.put(fp, succState, tool);
 		}
 		return seen;
 	}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
@@ -65,14 +65,14 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 	private volatile int maxLevel = 0;
 
 	// SZ Feb 20, 2009: changed due to super type introduction
-	public Worker(int id, AbstractChecker tlc, String metadir, String specFile) throws IOException {
+	public Worker(int id, AbstractChecker tlc, ITool tool, String metadir, String specFile) throws IOException {
 		super(id);
 		// SZ 12.04.2009: added thread name
 		this.setName("TLC Worker " + id);
 		this.tlc = (ModelChecker) tlc;
 		this.checkLiveness = this.tlc.checkLiveness;
 		this.checkDeadlock = this.tlc.checkDeadlock;
-		this.tool = (Tool) this.tlc.tool;
+		this.tool = (Tool) tool;
 		this.mode = this.tool.getMode();
 		this.squeue = this.tlc.theStateQueue;
 		this.theFPSet = this.tlc.theFPSet;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/WorkerValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/WorkerValue.java
@@ -27,6 +27,7 @@ package tlc2.tool.impl;
 
 import tla2sany.semantic.ExprOrOpArgNode;
 import tlc2.TLCGlobals;
+import tlc2.tool.ITool;
 import tlc2.tool.TLCState;
 import tlc2.tool.coverage.CostModel;
 import tlc2.util.Context;
@@ -131,7 +132,8 @@ public class WorkerValue {
     			RandomEnumerableValues.setSeed(seed);
     			// Ideally, we could invoke IValue#deepCopy here instead of evaluating opDef again.  However,
     			// IValue#deepCopy doesn't create copies for most values.
-    			values[i] = spec.eval(en, Context.Empty, TLCState.Empty, cm);
+				final ITool noDebug = ((ITool) spec).noDebug();
+				values[i] = noDebug.eval(en, Context.Empty, TLCState.Empty, cm);
     			values[i].deepNormalize();
     		}
     		


### PR DESCRIPTION
Previously, the debugger could only run with a single worker (`-workers 1`), limiting its usefulness for large models. This commit introduces support for running the debugger with multiple workers (`-workers N`).

The debugger attaches to one worker, while the other workers continue without being directly debugged. This setup reduces debugging overhead, such as the creation of stack frames, on the non-debugged workers.