### PR TITLE
Checking liveness properties in simulation mode creates a scalability bottleneck due to unnecessary sharing of ILiveCheck instances.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.TimerTask;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
@@ -111,6 +112,7 @@ public class Simulator {
 		this.aril = 0;
 
 		ILiveCheck liveCheck = new NoOpLiveCheck(tool, metadir);
+		final AtomicBoolean errorFound = new AtomicBoolean(false);
 		this.numWorkers = numWorkers;
 		this.workers = new ArrayList<>(numWorkers);
 		for (int i = 0; i < this.numWorkers; i++) {
@@ -120,7 +122,7 @@ public class Simulator {
 					final String tmpDir = Files.createTempDirectory(String.format("tlc-simulator-%s-", i)).toString();
 					liveCheck = new LiveCheck(this.tool.noDebug(), tmpDir, new DummyBucketStatistics());
 				} else {
-					liveCheck = new LiveCheck1(this.tool.noDebug(), i != 0);
+					liveCheck = new LiveCheck1(this.tool.noDebug(), errorFound, i != 0);
 				}
 			}
 			

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -120,7 +120,7 @@ public class Simulator {
 					final String tmpDir = Files.createTempDirectory(String.format("tlc-simulator-%s-", i)).toString();
 					liveCheck = new LiveCheck(this.tool.noDebug(), tmpDir, new DummyBucketStatistics());
 				} else {
-					liveCheck = new LiveCheck1(this.tool.noDebug());
+					liveCheck = new LiveCheck1(this.tool.noDebug(), i != 0);
 				}
 			}
 			

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/LiveCheck1.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/LiveCheck1.java
@@ -79,8 +79,12 @@ public class LiveCheck1 implements ILiveCheck {
 	private BEGraphNode initNode = null;
 
 	public LiveCheck1(ITool tool) {
+		this(tool, false);
+	}
+
+	public LiveCheck1(ITool tool, final boolean silent) {
 		myTool = tool;
-		solutions = Liveness.processLiveness(myTool);
+		solutions = Liveness.processLiveness(myTool, silent);
 		bgraphs = new BEGraph[0];
 	}
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/Liveness.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/liveness/Liveness.java
@@ -532,6 +532,10 @@ public class Liveness implements ToolGlobals, ASTConstants {
 	 * <i>liveness properties</i> to be checked.
 	 */
 	public static OrderOfSolution[] processLiveness(final ITool tool) {
+		return processLiveness(tool, false);
+	}
+
+	public static OrderOfSolution[] processLiveness(final ITool tool, final boolean silent) {
 		LiveExprNode lexpr = parseLiveness(tool);
 
 		// Contrary to the Manna & Pnueli book - which discusses LTL and LTL with only
@@ -773,9 +777,9 @@ public class Liveness implements ToolGlobals, ASTConstants {
 		}
 		// Could null TBPar tfbin and Vect<Vect<OSExprPem>> pembin here.
 
-		MP.printMessage(EC.TLC_LIVE_IMPLIED, String.valueOf(oss.length));
-		// SZ Jul 28, 2009: What for?
-		// ToolIO.out.flush();
+		if (!silent) {
+			MP.printMessage(EC.TLC_LIVE_IMPLIED, String.valueOf(oss.length));
+		}
 
 		return oss;
 	}


### PR DESCRIPTION
Fixes Github issue #1065
https://github.com/tlaplus/tlaplus/issues/1065

[Bug][TLC]