### PR TITLE
SANY: Removed init error logging since it's static now

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/InitException.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/InitException.java
@@ -1,4 +1,0 @@
-// Copyright (c) 2003 Compaq Corporation.  All rights reserved.
-package tla2sany.drivers;
-
-public class InitException extends Exception {}

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -92,18 +92,10 @@ public class SpecObj
     // The String name of rootModule, unknown until rootParseUnit is parsed,
     // although it is supposed to be closely related to the file name
 
-    public Errors initErrors = new Errors();
-    // The Errors object for reporting errors that happen at initialization
-    // time.
-
     public Errors parseErrors = new Errors();
     // The Errors object for reporting errors that occur during parsing,
     // including the retrieval of files (ParseUnits) for extention and
     // instantiation or the root and their extentions and instantiations, etc.
-
-    private Errors globalContextErrors = new Errors();
-    // The Errors object for reporting errors in creating the global
-    // context from the file that stores it.
 
     public Errors semanticErrors = new Errors();
     // The Errors object for reporting errors discovered during semantic
@@ -188,39 +180,11 @@ public class SpecObj
     }
 
     /**
-     * Returns Errors object produced during initialization of the FrontEnd.
-     * Should never be interesting.
-     */
-    public final Errors getInitErrors()
-    {
-        return initErrors;
-    }
-
-    /**
      * Returns Errors object containing errors found during parsing.
      */
     public final Errors getParseErrors()
     {
         return parseErrors;
-    }
-
-    /**
-     * Returns Errors object containing errors found while parsing the
-     * built-in operator and synonym tables.  Should never be interesting.
-     * 
-     * The above appears to be Simon's comment, and it is wrong.  Global
-     * context errors include cases where two EXTENDed modules contain
-     * conflicting definitions or declarations of the same operator.   These
-     * errors probably used to get put here in Yuan's code.  They are not
-     * being put there in Simon's rewriting.  As a result, they were getting
-     * lost--in the sense of not being put anywhere where the Toolbox could
-     * find them.  This was corrected by LL and Dan on 23 Oct 2009 by adding
-     * a call of spec.setGlobalContextErrors to SANY.frontEndSemanticAnalysis.
-     *  
-     */
-    public final Errors getGlobalContextErrors()
-    {
-        return globalContextErrors;
     }
 
     /**
@@ -1069,14 +1033,6 @@ public class SpecObj
     public FilenameToStream getResolver()
     {
         return resolver;
-    }
-
-    /**
-     * @param globalContextErrors the globalContextErrors to set
-     */
-    public void setGlobalContextErrors(Errors globalContextErrors)
-    {
-        this.globalContextErrors = globalContextErrors;
     }
 
 	public ParseUnit getRootParseUnit() {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Context.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Context.java
@@ -124,14 +124,13 @@ public class Context implements ExploreNode {
     }*/
   }
 
-  private static Context initialContext = new Context(null, new Errors());
+  private static Context initialContext = new Context(null);
                                       // the one, static unique Context with builtin operators
                                       // null ModuleTable arg because this is shared by all modules
 
   private ExternalModuleTable exMT;   // The external ModuleTable that this context's SymbolTable
                                       // belongs to is null for global context shared by all modules.
 
-  private Errors         errors;      // Object in which to register errors
   private Hashtable<Object, Pair>      table;       // Mapping from symbol name to Pair's that include SymbolNode's
   private Pair           lastPair;    // Pair added last to the this.table
 
@@ -139,10 +138,9 @@ public class Context implements ExploreNode {
    * exMT is the ExternalModuleTable containing the module whose
    * SymbolTable this Context is part of (or null).
    */
-  public Context(ExternalModuleTable mt, Errors errs) {
+  public Context(ExternalModuleTable mt) {
     table = new Hashtable<>();
     this.exMT = mt;
-    this.errors = errs;
     this.lastPair = null;
   }
 
@@ -152,7 +150,7 @@ public class Context implements ExploreNode {
    * of a spec.
    */
   public static void reInit() {
-    initialContext =  new Context(null, new Errors()); // null because outside of any module
+    initialContext = new Context(null); // null because outside of any module
     initialize();
   }
 
@@ -174,8 +172,6 @@ public class Context implements ExploreNode {
 		}
 		return false;
 	}
-
-  public Errors getErrors() { return errors; }
 
   /**
    * Adds a symbol to the initial context.
@@ -372,7 +368,7 @@ public class Context implements ExploreNode {
    * 
    * Note that the return value is never used in our code base. (2020.03.06)
    */
-	public boolean mergeExtendContext(final Context ct) {
+	public boolean mergeExtendContext(final Context ct, Errors errors) {
 		if (ct.lastPair == null) {
 			// If the context represents an inner module that defines no EXTENDS, ct.lastPair will be null
 			return true;
@@ -449,7 +445,7 @@ public class Context implements ExploreNode {
    * linked-list of Pairs starting from this.lastpair.
    */
   public Context duplicate(ExternalModuleTable exMT) {    // Added argument exMT (DRJ)
-    Context dup       = new Context(exMT, errors);
+    Context dup       = new Context(exMT);
     Pair    p         = this.lastPair;
     Pair    current   = null;
     boolean firstTime = true;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
@@ -2036,7 +2036,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 				checkIfInRecursiveSection(definitions[lvi], "A MODULE ");
 				SymbolTable oldSt = symbolTable;
 				symbolTable = new SymbolTable(moduleTable, errors, oldSt);
-				context = new Context(moduleTable, errors);
+				context = new Context(moduleTable);
 				symbolTable.pushContext(context);
 				ModuleNode mn = generateModule(definitions[lvi], currentModule);
 				symbolTable.popContext();
@@ -2153,7 +2153,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 				Context context = this.getContext(extendeeID);
 				if (context != null) {
-					symbolTable.getContext().mergeExtendContext(context);
+					symbolTable.getContext().mergeExtendContext(context, errors);
 				} else {
 					errors.addError(treeNodes[lvi].getLocation(),
 							"Couldn't find context for module `" + extendeeID + "'.");
@@ -2274,7 +2274,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		TreeNode[] children = syntaxTreeNode.one();
 		TreeNode[] ss = children[0].heirs();
 		FormalParamNode[] params = null;
-		Context ctxt = new Context(moduleTable, errors);
+		Context ctxt = new Context(moduleTable);
 		boolean isRecursive = false;
 		/*********************************************************************
 		 * Will be set to true if this operator was declared in a RECURSIVE * statement.
@@ -2544,7 +2544,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		boolean[] tuples = new boolean[ql];
 		ExprNode[] domains = new ExprNode[ql];
 		ExprNode[] lhs = new ExprNode[1];
-		Context newContext = new Context(moduleTable, errors);
+		Context newContext = new Context(moduleTable);
 		boolean isRecursive = false;
 		/*********************************************************************
 		 * Will be set to true if this operator was declared in a RECURSIVE * statement.
@@ -2715,7 +2715,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		Vector defVec = new Vector(4);
 		Vector instVec = new Vector(1);
 
-		Context letCtxt = new Context(moduleTable, errors);
+		Context letCtxt = new Context(moduleTable);
 		symbolTable.pushContext(letCtxt);
 		/*********************************************************************
 		 * Create a new sub-Context for the IN expression, containing the * LET
@@ -3376,7 +3376,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			 * The context is pushed by the top-level caller of * generateAssumeProve, which
 			 * is processTheorem. *
 			 ******************************************************************/
-			symbolTable.pushContext(new Context(moduleTable, errors));
+			symbolTable.pushContext(new Context(moduleTable));
 			/******************************************************************
 			 * I don't understand exactly what's going on here, but this * seems to be the
 			 * magic incantation for starting a new context * into which declarations among
@@ -3521,7 +3521,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		TreeNode[] syntaxTreeNode = children[2].heirs();
 		OpApplNode result;
 
-		symbolTable.pushContext(new Context(moduleTable, errors));
+		symbolTable.pushContext(new Context(moduleTable));
 
 		if (syntaxTreeNode == null || syntaxTreeNode.length == 0) {
 			// unbounded case
@@ -3595,7 +3595,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		ExprNode[] ea = new ExprNode[length];
 
 		// then process parameters
-		symbolTable.pushContext(new Context(moduleTable, errors));
+		symbolTable.pushContext(new Context(moduleTable));
 		processQuantBoundArgs(children, 1, odna, bt, ea, cm);
 
 		// process expression
@@ -3656,7 +3656,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		// Process all identifiers bound by thus quantifier
 		int length = (children.length - 2) / 2;
 		FormalParamNode odn[] = new FormalParamNode[length];
-		symbolTable.pushContext(new Context(moduleTable, errors));
+		symbolTable.pushContext(new Context(moduleTable));
 
 		for (int lvi = 0; lvi < length; lvi++) {
 			odn[lvi] = new FormalParamNode(children[2 * lvi + 1].getUS(), 0, children[2 * lvi + 1], symbolTable, cm);
@@ -3705,7 +3705,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		exprs[0] = generateExpression(children[3], cm);
 
-		symbolTable.pushContext(new Context(moduleTable, errors));
+		symbolTable.pushContext(new Context(moduleTable));
 
 		if (children[1].isKind(N_IdentifierTuple)) {
 			TreeNode[] ss = children[1].heirs();
@@ -3740,7 +3740,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		boolean[] tuples = new boolean[length];
 		ExprNode[] exprs = new ExprNode[length];
 
-		symbolTable.pushContext(new Context(moduleTable, errors));
+		symbolTable.pushContext(new Context(moduleTable));
 		processQuantBoundArgs(children, 3, odna, tuples, exprs, cm);
 
 		pushFormalParams(flattenParams(odna));
@@ -3764,7 +3764,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		boolean[] tuples = new boolean[length];
 		ExprNode[] exprs = new ExprNode[length];
 
-		symbolTable.pushContext(new Context(moduleTable, errors));
+		symbolTable.pushContext(new Context(moduleTable));
 		processQuantBoundArgs(children, 1, odna, tuples, exprs, cm);
 
 		pushFormalParams(flattenParams(odna));
@@ -4233,7 +4233,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 * children.length = 3 + arity + arity-1 * so arity = (children.length - 2) / 2.
 		 * *
 		 *********************************************************************/
-		Context ctxt = new Context(moduleTable, errors);
+		Context ctxt = new Context(moduleTable);
 		symbolTable.pushContext(ctxt);
 		/*********************************************************************
 		 * The context ctxt will hold the parameters of the lambda * expression, which
@@ -4432,7 +4432,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			args = new FormalParamNode[children.length / 2 - 1];
 
 			// Push a new context in current module's SymbolTable
-			parmCtxt = new Context(moduleTable, errors);
+			parmCtxt = new Context(moduleTable);
 			symbolTable.pushContext(parmCtxt);
 
 			// For each formal parameter declared for the op being defined
@@ -5277,7 +5277,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			 * clause to be visible in the proof. Therefore, we do the * context push for
 			 * the top-level AssumeProveNode here instead of * in generateAssumeProve. *
 			 *******************************************************************/
-			symbolTable.pushContext(new Context(moduleTable, errors));
+			symbolTable.pushContext(new Context(moduleTable));
 			body = generateAssumeProve(stn.heirs()[bodyIndex], cm);
 			currentGoal = null;
 		} else { /****************************************************************
@@ -5394,7 +5394,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		}
 		;
 
-		Context pfCtxt = new Context(moduleTable, errors);
+		Context pfCtxt = new Context(moduleTable);
 		symbolTable.pushContext(pfCtxt);
 		/*********************************************************************
 		 * Create a new sub-Context for the proof. *
@@ -5675,7 +5675,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 						 * proof for * an ordinary ASSUME/PROVE, and only after the statement's * proof
 						 * for a SUFFICES ASSUME/PROVE. *
 						 ************************************************************/
-						symbolTable.pushContext(new Context(moduleTable, errors));
+						symbolTable.pushContext(new Context(moduleTable));
 
 						currentGoal = tadn;
 						/**********************************************************
@@ -5813,7 +5813,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 						 * Push a new context onto the symbolTable stack to get the * declarations of
 						 * the PICK symbols. *
 						 ************************************************************/
-						symbolTable.pushContext(new Context(moduleTable, errors));
+						symbolTable.pushContext(new Context(moduleTable));
 					}
 					;
 
@@ -6313,7 +6313,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 				 *****************************************************************/
 				isAssumeProve = true;
 				if (!isSuffices) {
-					symbolTable.pushContext(new Context(moduleTable, errors));
+					symbolTable.pushContext(new Context(moduleTable));
 // System.out.println("here") ;
 				}
 				;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/CheckImplFile.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/CheckImplFile.java
@@ -100,7 +100,7 @@ public class CheckImplFile extends CheckImpl
         SpecObj spec = new SpecObj(rfname, null);
         try
         {
-            SANY.frontEndInitialize(spec, ToolIO.out);
+            SANY.frontEndInitialize();
             SANY.frontEndParse(spec, ToolIO.out);
             SANY.frontEndSemanticAnalysis(spec, ToolIO.out, true);
         } catch (Throwable e)
@@ -108,7 +108,7 @@ public class CheckImplFile extends CheckImpl
             String msg = (e.getMessage()==null)?e.toString():e.getMessage();
             Assert.fail(EC.CHECK_COULD_NOT_READ_TRACE, msg);
         }
-        if (!spec.initErrors.isSuccess() || !spec.parseErrors.isSuccess() || !spec.semanticErrors.isSuccess())
+        if (!spec.parseErrors.isSuccess() || !spec.semanticErrors.isSuccess())
         {
             Assert.fail(EC.TLC_PARSING_FAILED);
         }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -407,9 +407,6 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
         // since failed parsing is not marked by an exception,
         // check the status of the spec
         // check if the specification has been successfully created
-		if (!specObj.initErrors.isSuccess()) {
-			Assert.fail(EC.TLC_PARSING_FAILED, specObj.initErrors.getErrors());
-		}
 		if (!specObj.parseErrors.isSuccess()) {
 			Assert.fail(EC.TLC_PARSING_FAILED, specObj.parseErrors.getErrors());
 		}

--- a/tlatools/org.lamport.tlatools/test-model/tla2sany/semantic/TestMergeContextError.tla
+++ b/tlatools/org.lamport.tlatools/test-model/tla2sany/semantic/TestMergeContextError.tla
@@ -1,0 +1,9 @@
+---- MODULE TestMergeContextError ----
+EXTENDS TestMergeContextError2, TestMergeContextError3
+====
+---- MODULE TestMergeContextError2 ----
+op == TRUE
+====
+---- MODULE TestMergeContextError3 ----
+CONSTANT op
+====

--- a/tlatools/org.lamport.tlatools/test-model/tla2sany/semantic/TestMergeContextWarning.tla
+++ b/tlatools/org.lamport.tlatools/test-model/tla2sany/semantic/TestMergeContextWarning.tla
@@ -1,0 +1,9 @@
+---- MODULE TestMergeContextWarning ----
+EXTENDS TestMergeContextWarning2, TestMergeContextWarning3
+====
+---- MODULE TestMergeContextWarning2 ----
+op == TRUE
+====
+---- MODULE TestMergeContextWarning3 ----
+op == TRUE 
+====

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/Bug156TEStackOverflowTest.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/Bug156TEStackOverflowTest.java
@@ -22,7 +22,7 @@ public class Bug156TEStackOverflowTest {
 	public void setUp() throws Exception {
 		// create a model and initialize
 		moduleSpec = new SpecObj("test-model/Bug156/TE.tla", new SimpleFilenameToStream());
-		SANY.frontEndInitialize(moduleSpec, ToolIO.out);
+		SANY.frontEndInitialize();
 	}
 
 	/**

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/Github429Test.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/Github429Test.java
@@ -17,7 +17,7 @@ public class Github429Test {
 	public void setUp() throws Exception {
 		// create a model and initialize
 		moduleSpec = new SpecObj(CommonTestCase.BASE_PATH + "Github429.tla", new SimpleFilenameToStream());
-		SANY.frontEndInitialize(moduleSpec, ToolIO.out);
+		SANY.frontEndInitialize();
 	}
 
 	@Test

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestMergeContextError.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestMergeContextError.java
@@ -1,0 +1,67 @@
+package tla2sany.semantic;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tla2sany.drivers.InitException;
+import tla2sany.drivers.SANY;
+import tla2sany.drivers.SemanticException;
+import tla2sany.modanalyzer.SpecObj;
+import tla2sany.parser.ParseException;
+import tlc2.tool.CommonTestCase;
+import util.ToolIO;
+
+/**
+ * This class contains tests to ensure symbol conflict errors in
+ * {@link Context#mergeExtendContext(Context)} are captured appropriately;
+ * comments in various places indicate these errors were being lost in the
+ * past and special code was necessary to surface them.
+ *
+ * The reason the errors were getting lost is because the {@link Context}
+ * class kept a {@link Errors} instance around and reported the errors there.
+ * This was outside usual error reporting channels. It would be better to
+ * report the error through ordinary semantic analysis error channels, so
+ * this class is intended to isolate this error reporting behavior for the
+ * purposes of changing it and ensuring it is captured in a different path.
+ */
+public class TestMergeContextError {
+	
+	private static final String MODULE_DIR = CommonTestCase.BASE_PATH + "/tla2sany/semantic/";
+	
+	/**
+	 * Test warning logged when two different extended modules each contain
+	 * a definition of the same name and same type (both operators).
+	 */
+	@Test
+	public void testSymbolConflictWarning() throws InitException, ParseException, SemanticException {
+		final String path = MODULE_DIR + "TestMergeContextWarning.tla";
+		SpecObj spec = new SpecObj(path, null);
+		SANY.frontEndInitialize(spec, ToolIO.out);
+		SANY.frontEndParse(spec, ToolIO.out);
+		SANY.frontEndSemanticAnalysis(spec, ToolIO.out, true);
+		Context context = spec.getExternalModuleTable().getContextForRootModule();
+		Errors contextErrors = context.getErrors();
+		Assert.assertFalse(contextErrors.isFailure());
+		Assert.assertEquals(1, contextErrors.getWarnings().length);
+		Assert.assertEquals(contextErrors, spec.getGlobalContextErrors());
+	}
+
+	/**
+	 * Test error logged when two different extended modules each contain
+	 * a definition of the same name and different type (one operator, one
+	 * constant).
+	 */
+	@Test
+	public void testSymbolConflictError() throws InitException, ParseException, SemanticException {
+		final String path = MODULE_DIR + "TestMergeContextError.tla";
+		SpecObj spec = new SpecObj(path, null);
+		SANY.frontEndInitialize(spec, ToolIO.out);
+		SANY.frontEndParse(spec, ToolIO.out);
+		SANY.frontEndSemanticAnalysis(spec, ToolIO.out, true);
+		Context context = spec.getExternalModuleTable().getContextForRootModule();
+		Errors contextErrors = context.getErrors();
+		Assert.assertTrue(contextErrors.isFailure());
+		Assert.assertEquals(1, contextErrors.getErrors().length);
+		Assert.assertEquals(contextErrors, spec.getGlobalContextErrors());
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestMergeContextError.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestMergeContextError.java
@@ -3,7 +3,6 @@ package tla2sany.semantic;
 import org.junit.Assert;
 import org.junit.Test;
 
-import tla2sany.drivers.InitException;
 import tla2sany.drivers.SANY;
 import tla2sany.drivers.SemanticException;
 import tla2sany.modanalyzer.SpecObj;
@@ -33,17 +32,15 @@ public class TestMergeContextError {
 	 * a definition of the same name and same type (both operators).
 	 */
 	@Test
-	public void testSymbolConflictWarning() throws InitException, ParseException, SemanticException {
+	public void testSymbolConflictWarning() throws ParseException, SemanticException {
 		final String path = MODULE_DIR + "TestMergeContextWarning.tla";
 		SpecObj spec = new SpecObj(path, null);
-		SANY.frontEndInitialize(spec, ToolIO.out);
+		SANY.frontEndInitialize();
 		SANY.frontEndParse(spec, ToolIO.out);
 		SANY.frontEndSemanticAnalysis(spec, ToolIO.out, true);
-		Context context = spec.getExternalModuleTable().getContextForRootModule();
-		Errors contextErrors = context.getErrors();
+		Errors contextErrors = spec.getSemanticErrors();
 		Assert.assertFalse(contextErrors.isFailure());
 		Assert.assertEquals(1, contextErrors.getWarnings().length);
-		Assert.assertEquals(contextErrors, spec.getGlobalContextErrors());
 	}
 
 	/**
@@ -52,16 +49,14 @@ public class TestMergeContextError {
 	 * constant).
 	 */
 	@Test
-	public void testSymbolConflictError() throws InitException, ParseException, SemanticException {
+	public void testSymbolConflictError() throws ParseException, SemanticException {
 		final String path = MODULE_DIR + "TestMergeContextError.tla";
 		SpecObj spec = new SpecObj(path, null);
-		SANY.frontEndInitialize(spec, ToolIO.out);
+		SANY.frontEndInitialize();
 		SANY.frontEndParse(spec, ToolIO.out);
 		SANY.frontEndSemanticAnalysis(spec, ToolIO.out, true);
-		Context context = spec.getExternalModuleTable().getContextForRootModule();
-		Errors contextErrors = context.getErrors();
+		Errors contextErrors = spec.getSemanticErrors();
 		Assert.assertTrue(contextErrors.isFailure());
 		Assert.assertEquals(1, contextErrors.getErrors().length);
-		Assert.assertEquals(contextErrors, spec.getGlobalContextErrors());
 	}
 }

--- a/toolbox/org.lamport.tla.toolbox/src/org/lamport/tla/toolbox/spec/parser/ModuleParserLauncher.java
+++ b/toolbox/org.lamport.tla.toolbox/src/org/lamport/tla/toolbox/spec/parser/ModuleParserLauncher.java
@@ -25,7 +25,6 @@ import org.lamport.tla.toolbox.util.ResourceHelper;
 import org.lamport.tla.toolbox.util.TLAMarkerHelper;
 import org.lamport.tla.toolbox.util.TLAMarkerInformationHolder;
 
-import tla2sany.drivers.InitException;
 import tla2sany.drivers.SANY;
 import tla2sany.drivers.SemanticException;
 import tla2sany.modanalyzer.ParseUnit;
@@ -153,7 +152,7 @@ public class ModuleParserLauncher
         {
             // should cancel?
             checkCancel(monitor);
-            SANY.frontEndInitialize(moduleSpec, outputStr);
+            SANY.frontEndInitialize();
             // should cancel?
             checkCancel(monitor);
             SANY.frontEndParse(moduleSpec, outputStr, false);
@@ -162,12 +161,6 @@ public class ModuleParserLauncher
             SANY.frontEndSemanticAnalysis(moduleSpec, outputStr, true);
             // should cancel?
             checkCancel(monitor);
-        } catch (InitException e)
-        {
-            // set spec status
-            specStatus = IParseConstants.UNKNOWN_ERROR;
-            return new ParseResult(specStatus, null, parseResource, parseErrors, semanticErrors, parserCallTime);
-
         } catch (ParseException e)
         {
             // I believe that this exception is thrown iff there is a parsing
@@ -189,39 +182,6 @@ public class ModuleParserLauncher
             semanticErrors = moduleSpec.semanticErrors;
             if (semanticErrors != null)
             {
-                // add global context errors to semantic errors because they should
-                // be treated the same way by the toolbox
-                // these errors include defining the same operator
-                // in two different modules that are extended
-                Errors globalContextErrors = moduleSpec.getGlobalContextErrors();
-
-                // globalContextErrors contains errors, aborts, and warnings
-                // each should be added to semanticErrors
-                String[] errors = globalContextErrors.getErrors();
-                for (int i = 0; i < errors.length; i++)
-                {
-                    semanticErrors.addError(null, errors[i]);
-                }
-
-                String[] aborts = globalContextErrors.getAborts();
-                for (int i = 0; i < aborts.length; i++)
-                {
-                    try
-                    {
-                        semanticErrors.addAbort(aborts[i], false);
-                    } catch (AbortException e)
-                    {
-                        Activator.getDefault().logDebug("Abort exception thrown in ModuleParserLauncher."
-                                + "This is a bug. There should not be an AbortException thrown here.");
-                    }
-                }
-
-                String[] warnings = globalContextErrors.getWarnings();
-                for (int i = 0; i < warnings.length; i++)
-                {
-                    semanticErrors.addWarning(null, warnings[i]);
-                }
-
                 if (semanticErrors.getNumMessages() > 0)
                 {
                     if (semanticErrors.isSuccess())


### PR DESCRIPTION
PR #1067 made me realize that SANY has retained its error reporting machinery for initialization failures when those failures are no longer possible due to #1012. So I removed this machinery.

This did result in one functional change: when extending a spec, the new spec's symbols are read into the symbol context of the current spec (see `mergeExtendContext`). If any symbol conflicts occurred these were recorded in the initialization error log path (code comments reveal this behavior was an object of some confusion as these errors were getting "lost" so special code was necessary to report these errors). These errors will now be reported through the well-trodden semantic error log path.