### PR TITLE
When run with the `-dump dot,constrained ...` option, TLC does not verify invariants or action properties for states that are considered unreachable due to state or action constraints

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
@@ -451,7 +451,6 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 						this.allStateWriter.writeState(curState, succState, IStateWriter.IsNotInModel, action, constraints[i]);				
 			    	}
 			    }
-			    return true;
 			}
 			
 			// Check if succState violates any invariant:

--- a/tlatools/org.lamport.tlatools/test-model/DotConstrained.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/DotConstrained.cfg
@@ -1,0 +1,4 @@
+INIT Init
+NEXT Next
+CONSTRAINT Constraint
+INVARIANT Inv

--- a/tlatools/org.lamport.tlatools/test-model/Github602.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github602.tla
@@ -13,6 +13,8 @@ B == x' = x + 1
 Next == A \/ B
 
 Constraint ==  x \in Nat
+
+Inv == x >= 0
 ====
 
 ---- CONFIG Github602 ----

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/DotConstrainedTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/DotConstrainedTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Microsoft Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+import util.FileUtil;
+
+public class DotConstrainedTest extends ModelCheckerTestCase {
+
+	public DotConstrainedTest() {
+		super("Github602",
+				new String[] { "-config", "DotConstrained.cfg", "-dump", "dot,constrained",
+						"${metadir}" + FileUtil.separator + DotConstrainedTest.class.getCanonicalName() + ".dot" },
+				ExitStatus.VIOLATION_SAFETY);
+	}
+
+	@Override
+	protected boolean doDump() {
+		// Explicitly passed -dump command in constructor.
+		return false;
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "4", "2", "0"));
+
+		// Assert it has found the temporal violation and also a counter example
+		assertTrue(recorder.recorded(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR));
+
+		// Assert the error trace
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(3);
+		expectedTrace.add("x = 0");
+		expectedTrace.add("x = 1");
+		expectedTrace.add("x = -1");
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace);
+		
+		assertZeroUncovered();
+	}
+}


### PR DESCRIPTION
TLC does not verify invariants or action properties for states that are considered unreachable due to state or action constraints when run with the `-dump dot,constrained ...` option.

The "constrained" feature was introduced on February 5, 2024, in commit 312518885c0f4688fceb1b30d27c2aed61a6628f. It is an undocumented feature primarily utilized for trace validation. Therefore, I believe there is no reason to alarm the community about this bug.

[Bug][TLC]