### PR TITLE
Add unicode support to state / value serialization

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskByteArrayQueue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskByteArrayQueue.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 
@@ -589,7 +590,7 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 		  }
 	}
 	
-	static final class ByteValueOutputStream implements IValueOutputStream, IDataOutputStream {
+	public static final class ByteValueOutputStream implements IValueOutputStream, IDataOutputStream {
 
 		private byte[] bytes;
 		
@@ -738,19 +739,15 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 		 */
 		@Override
 		public final void writeString(String str) throws IOException {
-			final int length = str.length();
-			ensureCapacity(idx + length);
-			
-			final char[] c = new char[length];
-			str.getChars(0, length, c, 0);
-			
-			for (int i = 0; i < c.length; i++) {
-				this.bytes[idx++] = (byte) c[i];
-			}
+			final byte[] strBytes = str.getBytes(StandardCharsets.UTF_8);
+			this.writeInt(strBytes.length);
+			ensureCapacity(this.idx + strBytes.length);
+			System.arraycopy(strBytes, 0, this.bytes, this.idx, strBytes.length);
+			this.idx += strBytes.length;
 		}
 	}
 	
-	static final class ByteValueInputStream implements ValueConstants, IValueInputStream, IDataInputStream {
+	public static final class ByteValueInputStream implements ValueConstants, IValueInputStream, IDataInputStream {
 
 		private final byte[] bytes;
 		
@@ -925,12 +922,21 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 		 * @see util.IDataInputStream#readString(int)
 		 */
 		@Override
-		public final String readString(int length) throws IOException {
-			final char[] s = new char[length];
-			for (int i = 0; i < s.length; i++) {
-				s[i] = (char) this.bytes[idx++];
+		public final String readString() throws IOException {
+			final int length = readInt();
+			if(length == 0) {
+				return "";
 			}
-			return new String(s);
+			assert length > 0;
+			// UTF-8 unicode
+			final String result = new String(this.bytes, this.idx, length, StandardCharsets.UTF_8);
+			this.idx += length;
+			return result;
+		}
+		
+		@Override
+		public final boolean atEOF() {
+			return this.idx == this.bytes.length;
 		}
 	}
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/IValueInputStream.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/IValueInputStream.java
@@ -58,4 +58,9 @@ public interface IValueInputStream {
 	IDataInputStream getInputStream();
 
 	UniqueString getValue(int idx);
+	
+	/**
+	 * @return whether the underlying data source is exhausted
+	 */
+	boolean atEOF();
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/ValueInputStream.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/ValueInputStream.java
@@ -222,6 +222,11 @@ public final class ValueInputStream implements ValueConstants, IValueInputStream
 	public final UniqueString getValue(int idx) {
 		return (UniqueString) this.handles.getValue(idx);
 	}
+	
+	@Override
+	public final boolean atEOF() {
+		return dis.atEOF();
+	}
 
   // @see ValueOutputStream#put
   private static class HandleTable {

--- a/tlatools/org.lamport.tlatools/src/util/BufferedDataOutputStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/BufferedDataOutputStream.java
@@ -7,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 /** A <code>BufferedDataOutputStream</code> is an optimized
     combination of a <code>java.io.BufferedOutputStream</code>
@@ -184,60 +185,9 @@ public final class BufferedDataOutputStream extends FilterOutputStream implement
 	    this.writeLong(Double.doubleToLongBits(d));
     }
 
-    /** Write the characters of the string <code>s</code> to this
-        stream as a sequence of bytes. */
     public final void writeString(String s) throws IOException {
-        int n = s.length();
-        int off = 0;
-        while (n > 0) {
-            int toCopy = Math.min(n, this.buff.length - this.len);
-            s.getBytes(off, off + toCopy, this.buff, this.len);
-            this.len += toCopy; off += toCopy; n -= toCopy;
-            if (this.buff.length == this.len) {
-                // write buffer to underlying stream
-                this.out.write(this.buff, 0, this.len);
-                this.len = 0;
-            }
-        }
+        final byte[] strBytes = s.getBytes(StandardCharsets.UTF_8);
+        writeInt(strBytes.length);
+        this.write(strBytes, 0, strBytes.length);
     }
-    
-    /** Write <code>n</code> characters of <code>chars</code> starting 
-        at offset <code>off</code> to this stream as a sequence of bytes. */
-    public final void writeChars(char[] chars, int off, int n) throws IOException {
-        int finOff = off + n;
-        while (off < finOff) {
-            // Copy (part of) chars to this.buff
-            int endOff = Math.min(finOff, off + this.buff.length - this.len);
-            while (off < endOff) this.buff[this.len++] = (byte)chars[off++];
-
-            // If this.buff is full, write it out
-            if (this.buff.length == this.len) {
-                // write buffer to underlying stream
-                this.out.write(this.buff, 0, this.len);
-                this.len = 0;
-            }
-        }        
-    }
-    
-    /** Write the string <code>s</code> to the stream in such a way that it
-        can be read back by <code>BufferedDataInputStream.readAnyString</code>,
-        even if <code>s</code> is <code>null</code> or if it contains newline 
-        characters. */
-    public final void writeAnyString(String s) throws IOException {
-      if (s == null) {
-	this.writeInt(-1);
-      }
-      else {
-	this.writeInt(s.length());
-	this.writeString(s);
-      }
-    }
-    
-    /** Write the characters of the string <code>s</code> to this
-        stream as a sequence of bytes, followed by a newline. */
-    public final void writeLine(String s) throws IOException {
-        this.writeString(s);
-        this.writeByte((byte) '\n');
-    }
-
 }

--- a/tlatools/org.lamport.tlatools/src/util/IDataInputStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/IDataInputStream.java
@@ -32,6 +32,7 @@ public interface IDataInputStream {
 
 	int readInt() throws IOException, EOFException;
 
-	String readString(int slen) throws IOException;
+	/** Reads a length-prefixed UTF-8 string **/
+	String readString() throws IOException;
 
 }

--- a/tlatools/org.lamport.tlatools/src/util/IDataOutputStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/IDataOutputStream.java
@@ -31,6 +31,7 @@ public interface IDataOutputStream {
 
 	void writeInt(int varLoc) throws IOException;
 
+	/** Write the string as length-prefixed UTF-8 **/
 	void writeString(String s) throws IOException;
 
 }

--- a/tlatools/org.lamport.tlatools/src/util/UniqueString.java
+++ b/tlatools/org.lamport.tlatools/src/util/UniqueString.java
@@ -312,7 +312,6 @@ public final class UniqueString implements Serializable
         dos.writeInt(this.tok);
         dos.writeInt(this. getVarLoc()); 
          // Above changed from dos.writeInt(this.loc); by Yuan Yu on 17 Mar 2010
-        dos.writeInt(this.s.length());
         dos.writeString(this.s);
     }
 
@@ -328,8 +327,7 @@ public final class UniqueString implements Serializable
     {
         int tok1 = dis.readInt();
         int loc1 = dis.readInt();
-        int slen = dis.readInt();
-        String str = dis.readString(slen);
+        String str = dis.readString();
         return new UniqueString(str, tok1, loc1);
     }
     
@@ -337,8 +335,7 @@ public final class UniqueString implements Serializable
     {
         dis.readInt(); // skip, because invalid for the given internTbl
         dis.readInt(); // skip, because invalid for the given internTbl
-        final int slen = dis.readInt();
-        final String str = dis.readString(slen);
+        final String str = dis.readString();
         return UniqueString.uniqueStringOf(str);
     }
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/CodePlexBug08EWD840FL2FromCheckpointTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/CodePlexBug08EWD840FL2FromCheckpointTest.java
@@ -66,6 +66,14 @@ public class CodePlexBug08EWD840FL2FromCheckpointTest extends ModelCheckerTestCa
 			 * 4) Locate the directory with the checkpoint data
 			 * 5) Replace the content of checkpoint.zip with the content of 4)
 			 * 6) Update the number below on states found...
+			 * 
+			 * Note from last updater:
+			 * To get a checkpoint, it may be more reliable to hardcode TLCGlobals.forceChkpt = true.
+			 * 
+			 * Worker count may also vary; if TLC fails with a missing file error, it means the worker count
+			 * is different between checkpoint and recover. You can adjust using -workers.
+			 * As a result, a detail or two of the counter-example may change.
+			 * 
 			 */
 			String prefix = BASE_DIR + File.separator + TEST_MODEL + "CodePlexBug08" + File.separator;
 			ZipFile zipFile = new ZipFile(prefix + "checkpoint.zip");
@@ -105,11 +113,11 @@ public class CodePlexBug08EWD840FL2FromCheckpointTest extends ModelCheckerTestCa
 	@Test
 	public void testSpec() {
 		assertTrue(recorder.recorded(EC.TLC_CHECKPOINT_RECOVER_START));
-		// Recovery completed. 1032 states examined. 996 states on queue.
+		// Recovery completed. 1510 states examined. 39 states on queue.
 		assertTrue(recorder.recordedWithStringValues(EC.TLC_CHECKPOINT_RECOVER_END, "1510", "39"));
 		// ModelChecker has finished and generated the expected amount of states
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
-		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2334", "1566","0"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2334", "1566", "0"));
 		assertFalse(recorder.recorded(EC.GENERAL));
 
 		assertNoTESpec();


### PR DESCRIPTION
Fixes #1076.

This change replaces the serialization of TLA+ string values, so that TLC's binary serialization format supports unicode. The existing approach uses length-prefixed ASCII, and this change rewrites those methods to read and write length-prefixed UTF-8 instead.

Remind me to squash before merge. Currently the commits mark a history of the conversation here, but I can consolidate once we're sure things make sense.

## Incidental changes

1. Change the interface of `IDataInputStream#readString()` and `IDataOutputStream#writeString()`. They originally relied on the length prefix being read/written by the caller, which assumes a specific encoding. As I change the encoding, rather than update the callsites (though our UTF-8 encoding coincidentally keeps the same length prefix value), I moved the choice of length prefix inside those functions.
2. Delete `BufferedDataInputStream#readLine()` and `BufferedDataOutputStream#writeLine()`, which are ASCII-only and are unused throughout the codebase.
3. Delete `BufferedDataOutputStream#writeAnyString()` and `BufferedDataOutputStream#writeChars()`, which have no read- equivalent and are unused throughout the codebase. They are also ASCII-only.
4. Make `DiskByteArrayQueue.ByteValueInputStream` and `DiskByteArrayQueue.ByteValueOutputStream` public, so they can be instantiated during testing without dealing with `TLCState` objects.
5. Add `IValueInputStream#atEOF()`, which exposes a check for whether the entire input has been consumed. This enables asserting that no trailing bytes are left over after reading a value back during test, and is trivial to implement for both implementations of that interface.
6. Update the comments on the checkpointing test in `CodePlexBug08`, adding some notes explaining more details on how to do that. One version of these changes required a fair bit of problem solving there, so even though no change is required anymore, the comment seems valuable.

## Attempted alternatives

1. Encode the strings as UTF-8 using `ByteBuffer` and co, which is naturally compatible with ASCII. The content-dependent number of bytes the output would contain means that emitting a length-prefixed byte stream with the correct length is not possible. The resulting buffer manipulation and workarounds were complicated, and turned out to be unacceptably slow under test.
2. Write ASCII when the string could be represented using ASCII, and UTF-16 otherwise. This can be done by using the sign bit in the length prefix to indicate which encoding it is. Advantage: backwards compatible, acceptably efficient, and theoretically saves 50% space on many common strings. Disadvantage: 2 code paths per read/write, saves no space over always using UTF-16 and relying on gzip compression, backwards compatibility not a priority since serialization is generally short-lived.
3. Always encode UTF-16, which leads to very simple code that mirrors the original version but stores both bytes of every char. It is a mystery to me why this turned out to be measurably slower than calling `String#getBytes(StandardCharsets.UTF_8)`. Perhaps the JVM optimizes the array allocation in that method, or perhaps the overhead of writing 2x the bytes, gzip or no, dominates somehow. The benchmarks have spoken, so `getBytes` seems to be the way to go, as it is both faster and backwards-compatible.