### PR TITLE
Correct the predecessors and level of *all* states after dropping  *finite* stuttering steps.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -381,10 +381,10 @@ public class Simulator {
 						error.errorCode = ((LiveException)error.exception).errorCode;
 					} else if (error.exception instanceof TLCRuntimeException) {
 						final TLCRuntimeException exception = (TLCRuntimeException)error.exception;
-						printBehavior(exception, error.state, error.stateTrace);
+						printBehavior(exception, error.stateTrace);
 						error.errorCode = exception.errorCode;
 					} else {
-						printBehavior(EC.GENERAL, new String[] { MP.ECGeneralMsg("", error.exception) }, error.state,
+						printBehavior(EC.GENERAL, new String[] { MP.ECGeneralMsg("", error.exception) },
 								error.stateTrace);
 						error.errorCode = EC.GENERAL;
 					}
@@ -430,36 +430,30 @@ public class Simulator {
 		return result;
 	}
 
-	protected final void printBehavior(final TLCRuntimeException exception, final TLCState state, final StateVec stateTrace) {
+	protected final void printBehavior(final TLCRuntimeException exception, final StateVec stateTrace) {
 		MP.printTLCRuntimeException(exception);
-		printBehavior(state, stateTrace);
+		printBehavior(stateTrace);
 	}
 
 	protected final void printBehavior(SimulationWorkerError error) {
-		printBehavior(error.errorCode, error.parameters, error.state, error.stateTrace);
+		printBehavior(error.errorCode, error.parameters, error.stateTrace);
 	}
 
 	/**
 	 * Prints out the simulation behavior, in case of an error. (unless we're at
 	 * maximum depth, in which case don't!)
 	 */
-	protected final void printBehavior(final int errorCode, final String[] parameters, final TLCState state, final StateVec stateTrace) {
+	protected final void printBehavior(final int errorCode, final String[] parameters, final StateVec stateTrace) {
 		MP.printError(errorCode, parameters);
-		printBehavior(state, stateTrace);
+		printBehavior(stateTrace);
 		this.printSummary();
 	}
 	
-	private final void printBehavior(final TLCState state, final StateVec stateTrace) {
+	private final void printBehavior(final StateVec stateTrace) {
 		if (this.traceDepth == Integer.MAX_VALUE) {
 			MP.printMessage(EC.TLC_ERROR_STATE);
-			StatePrinter.printStandaloneErrorState(state);
+			StatePrinter.printStandaloneErrorState(stateTrace.last());
 		} else {
-			if (!stateTrace.isLastElement(state)) {
-				// MAK 09/24/2019: this method is called with state being the stateTrace's
-				// last element or not.
-				stateTrace.addElement(state);
-			}
-			
 			MP.printError(EC.TLC_BEHAVIOR_UP_TO_THIS_POINT);
 			// MAK 09/24/2019: For space reasons, TLCState does not store the state's action.
 			// This is why the loop below creates TLCStateInfo instances out of the pair cur

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -814,15 +814,6 @@ public class Simulator {
 		}
 	}
 
-	public final StateVec getTrace() {
-		if (Thread.currentThread() instanceof SimulationWorker) {
-			final SimulationWorker w = (SimulationWorker) Thread.currentThread();
-			return w.getTrace();
-		} else {
-			return workers.get(0).getTrace();
-		}
-	}
-
 	public TLCStateInfo[] getTraceInfo(final int level) {
 		if (Thread.currentThread() instanceof SimulationWorker) {
 			final SimulationWorker w = (SimulationWorker) Thread.currentThread();

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SingleThreadedSimulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SingleThreadedSimulator.java
@@ -102,10 +102,10 @@ public class SingleThreadedSimulator extends Simulator {
 						error.errorCode = ((LiveException) error.exception).errorCode;
 					} else if (error.exception instanceof TLCRuntimeException) {
 						final TLCRuntimeException exception = (TLCRuntimeException) error.exception;
-						printBehavior(exception, error.state, error.stateTrace);
+						printBehavior(exception, error.stateTrace);
 						error.errorCode = exception.errorCode;
 					} else {
-						printBehavior(EC.GENERAL, new String[] { MP.ECGeneralMsg("", error.exception) }, error.state,
+						printBehavior(EC.GENERAL, new String[] { MP.ECGeneralMsg("", error.exception) },
 								error.stateTrace);
 						error.errorCode = EC.GENERAL;
 					}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/StateVec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/StateVec.java
@@ -76,16 +76,13 @@ public final class StateVec implements IStateFunctor, INextStateFunctor {
   }
 
   public final TLCState elementAt(int i) { return this.v[i]; }
-
-  public boolean isLastElement(final TLCState state) {
-	  if (isEmpty()) {
-		  return false;
-	  }
-	  return this.elementAt(size() - 1) == state;
-  }
   
   public TLCState first() {
 	return elementAt(0);
+  }
+  
+  public TLCState last() {
+	  return elementAt(size() - 1);
   }
 
   public final void clear() {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/SimulatorTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/SimulatorTest.java
@@ -24,7 +24,9 @@ public class SimulatorTest extends CommonTestCase {
                 new HashMap<>(), new StandaloneConstExpressionDebugger()), null,
                 "", false, -1, 0, null,
                 new RandomGenerator(0), 0, new SimpleFilenameToStream(), 0);
-        simulator.printBehavior(new Assert.TLCRuntimeException("TestException"), TLCStateMut.Empty.createEmpty(), new StateVec(0));
+        final StateVec stateVec = new StateVec(1);
+        stateVec.addElement(TLCStateMut.Empty.createEmpty());
+		simulator.printBehavior(new Assert.TLCRuntimeException("TestException"), stateVec);
         assertTrue(recorder.recorded(EC.TLC_ERROR_STATE));
     }
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
@@ -10,11 +10,9 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import tlc2.TLCGlobals;
 import tlc2.TestMPRecorder;
 import tlc2.output.EC;
 import tlc2.tool.CommonTestCase;
@@ -29,7 +27,6 @@ import tlc2.tool.impl.Tool;
 import tlc2.tool.impl.Tool.Mode;
 import tlc2.tool.liveness.ILiveCheck;
 import tlc2.tool.liveness.NoOpLiveCheck;
-import util.FileUtil;
 import util.SimpleFilenameToStream;
 import util.TLAConstants;
 import util.ToolIO;
@@ -91,6 +88,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
 		assertEquals(4, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		final StateVec st1 = err.stateTrace;
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> st1.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -115,6 +115,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
 		assertEquals(4, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		final StateVec st2 = err.stateTrace;
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> st2.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -132,6 +135,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
 		assertEquals(4, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		final StateVec st3 = err.stateTrace;
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> st3.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -170,6 +176,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR, err.errorCode);
 		assertEquals(3, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		final StateVec st1 = err.stateTrace;
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> st1.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -188,6 +197,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR, err.errorCode);
 		assertEquals(3, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		final StateVec st2 = err.stateTrace;
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> st2.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -220,6 +232,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_INVARIANT_EVALUATION_FAILED, err.errorCode);
 		assertEquals(2, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> err.stateTrace.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -270,6 +284,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_STATE_NOT_COMPLETELY_SPECIFIED_NEXT, err.errorCode);
 		assertEquals(2, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> err.stateTrace.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -299,7 +315,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_DEADLOCK_REACHED, err.errorCode);
 		
 		assertEquals(7, err.stateTrace.size());
-		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());	
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> err.stateTrace.elementAt(i).getLevel() == i + 1));
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -384,6 +402,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
 		assertEquals(4, err.stateTrace.size());
 		assertTrue(err.stateTrace.elementAt(0).isInitial());
+		assertTrue(java.util.stream.IntStream.range(0, err.stateTrace.size())
+				.allMatch(i -> err.stateTrace.elementAt(i).getLevel() == i + 1));
 		
 		// Cancel the worker.
 		worker.interrupt();

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
@@ -89,7 +89,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		SimulationWorkerError err = res.error();
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
-		assertEquals(3, err.stateTrace.size());
+		assertEquals(4, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -101,8 +102,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals("1", getStateVal(err.stateTrace.elementAt(2), "depth"));
 		assertEquals("6", getStateVal(err.stateTrace.elementAt(2), "branch"));
 		
-		assertEquals("2", getStateVal(err.state, "depth"));
-		assertEquals("6", getStateVal(err.state, "branch"));
+		assertEquals("2", getStateVal(err.stateTrace.last(), "depth"));
+		assertEquals("6", getStateVal(err.stateTrace.last(), "branch"));
 		
 		// The worker should continue to generate random traces even after an invariant violation, so we should be
 		// able to receive more results. The worker should generate 2 more results before hitting the maximum trace count.
@@ -112,7 +113,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		err = res.error();
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
-		assertEquals(3, err.stateTrace.size());
+		assertEquals(4, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -128,7 +130,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		err = res.error();
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
-		assertEquals(3, err.stateTrace.size());
+		assertEquals(4, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -139,6 +142,9 @@ public class SimulationWorkerTest extends CommonTestCase {
 		
 		assertEquals("1", getStateVal(err.stateTrace.elementAt(2), "depth"));
 		assertEquals("5", getStateVal(err.stateTrace.elementAt(2), "branch"));
+		
+		assertEquals("2", getStateVal(err.stateTrace.elementAt(3), "depth"));
+		assertEquals("5", getStateVal(err.stateTrace.elementAt(3), "branch"));
 		
 		// The worker should push one final OK result onto the queue upon termination.
 		res = resultQueue.take();
@@ -162,7 +168,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		SimulationWorkerError err = res.error();
 		assertEquals(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR, err.errorCode);
-		assertEquals(2, err.stateTrace.size());
+		assertEquals(3, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -171,15 +178,16 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(1), "depth"));
 		assertEquals("6", getStateVal(err.stateTrace.elementAt(1), "branch"));
 		
-		assertEquals("1", getStateVal(err.state, "depth"));
-		assertEquals("6", getStateVal(err.state, "branch"));
+		assertEquals("1", getStateVal(err.stateTrace.last(), "depth"));
+		assertEquals("6", getStateVal(err.stateTrace.last(), "branch"));
 		
 		// Check another result.
 		res = resultQueue.take();
 		assertTrue(res.isError());
 		err = res.error();
 		assertEquals(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR, err.errorCode);
-		assertEquals(2, err.stateTrace.size());
+		assertEquals(3, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -188,8 +196,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(1), "depth"));
 		assertEquals("10", getStateVal(err.stateTrace.elementAt(1), "branch"));
 		
-		assertEquals("1", getStateVal(err.state, "depth"));
-		assertEquals("10", getStateVal(err.state, "branch"));		
+		assertEquals("1", getStateVal(err.stateTrace.last(), "depth"));
+		assertEquals("10", getStateVal(err.stateTrace.last(), "branch"));		
 				
 		worker.join();
 		assertFalse(worker.isAlive());
@@ -210,14 +218,15 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		SimulationWorkerError err = res.error();
 		assertEquals(EC.TLC_INVARIANT_EVALUATION_FAILED, err.errorCode);
-		assertEquals(1, err.stateTrace.size());
+		assertEquals(2, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "branch"));
 
-		assertEquals("0", getStateVal(err.state, "depth"));
-		assertEquals("1", getStateVal(err.state, "branch"));
+		assertEquals("0", getStateVal(err.stateTrace.last(), "depth"));
+		assertEquals("1", getStateVal(err.stateTrace.last(), "branch"));
 
 		worker.join();
 		assertFalse(worker.isAlive());
@@ -259,14 +268,15 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		SimulationWorkerError err = res.error();
 		assertEquals(EC.TLC_STATE_NOT_COMPLETELY_SPECIFIED_NEXT, err.errorCode);
-		assertEquals(1, err.stateTrace.size());
+		assertEquals(2, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "branch"));
 				
-		assertEquals(null, err.state.getVals().get(UniqueString.uniqueStringOf("depth")));
-		assertEquals("0", getStateVal(err.state, "branch"));
+		assertEquals(null, err.stateTrace.last().getVals().get(UniqueString.uniqueStringOf("depth")));
+		assertEquals("0", getStateVal(err.stateTrace.last(), "branch"));
 
 		worker.join();
 		assertFalse(worker.isAlive());
@@ -288,8 +298,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		SimulationWorkerError err = res.error();
 		assertEquals(EC.TLC_DEADLOCK_REACHED, err.errorCode);
 		
-		System.out.println(err.stateTrace.toString());
 		assertEquals(7, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Check the generated trace.
 		assertEquals("0", getStateVal(err.stateTrace.elementAt(0), "depth"));
@@ -372,7 +382,8 @@ public class SimulationWorkerTest extends CommonTestCase {
 		assertTrue(res.isError());
 		SimulationWorkerError err = res.error();
 		assertEquals(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR, err.errorCode);
-		assertEquals(3, err.stateTrace.size());
+		assertEquals(4, err.stateTrace.size());
+		assertTrue(err.stateTrace.elementAt(0).isInitial());
 		
 		// Cancel the worker.
 		worker.interrupt();


### PR DESCRIPTION
To simplify the counterexample, simulation removes finite stuttering steps (1f9f3cb59854937547a24d59e057cec02d476d5f), reducing traces like `<<a, a, a, b, b, c>>` to `<<a, b, c>>`. This PR ensures that e.g. `TLCGet("level")` correctly evaluates in an ALIAS or POSTCONDITION to 1, 2, and 3 for the three respective states. Previously, it incorrectly evaluated to something like 1, 4, and 6.  This is done by [refactoring the code to consistently append](https://github.com/tlaplus/tlaplus/pull/1080/commits/584d80050a53289b3f4c28001619620923c2af6c) the final `TLCState` to the `stateTrace`, and [iterating over the trace and resetting the predecessor](https://github.com/tlaplus/tlaplus/pull/1080/files#diff-bd04d84aca8a7e75ede389a9ce669443a04f037ea49425d2cf3e88371c6da98dR793-R796) for each state in the sequence (except the init state).

Like https://github.com/tlaplus/tlaplus/pull/1071 but for safety violations.