### PR TITLE
Add java property '-Dtlc2.tool.impl.ModelConfig.nosymmetry'

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
@@ -723,7 +723,7 @@ public class ModelConfig implements ValueConstants, Serializable {
 
     public synchronized final String getSymmetry()
     {
-        return (String) this.configTbl.get(Symmetry);
+        return Boolean.getBoolean("nosymmetry") ? "" : (String) this.configTbl.get(Symmetry);
     }
 
     public synchronized final Vect getInvariants()

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ModelConfig.java
@@ -723,7 +723,7 @@ public class ModelConfig implements ValueConstants, Serializable {
 
     public synchronized final String getSymmetry()
     {
-        return Boolean.getBoolean("nosymmetry") ? "" : (String) this.configTbl.get(Symmetry);
+        return Boolean.getBoolean("tlc2.tool.impl.ModelConfig.nosymmetry") ? "" : (String) this.configTbl.get(Symmetry);
     }
 
     public synchronized final Vect getInvariants()


### PR DESCRIPTION
This pull request introduces a new Java system property, `-Dnosymmetry`, which allows users to ignore the SYMMETRY declaration in .cfg files during model checking. This feature is designed to simplify the use of a single .cfg file for both safety and liveness property checks, without requiring manual modifications to the file.

Usage :

After building the custom `tla2tools.jar` containing the enhancement:
```bash
java -Dtlc2.tool.impl.ModelConfig.nosymmetry=true -cp tla2tools.jar tlc2.TLC MySpec.tla
```
This will run the spec as if no `SYMMETRY` field was specified in `.cfg` file.
The `.cfg` files without `SYMMETRY` will not change their behavior.


To run the spec as usual (i.e. with `SYMMETRY` if there are) you can type as usual:
```bash
java -cp tla2tools.jar tlc2.TLC MySpec.tla
```
or
```bash
java -Dtlc2.tool.impl.ModelConfig.nosymmetry=false -cp tla2tools.jar tlc2.TLC MySpec.tla
```
This will run the spec as usual

Issue Related : https://github.com/tlaplus/tlaplus/issues/1075