### PR TITLE
Fix typo: change 't0' to 'to' in README

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/README
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/README
@@ -3,7 +3,7 @@ Author: Tomer Libal (2014)
 Here are some instructions of how to use SANY from the command line
 -------------------------------------------------------------------
 
-- In order t0 run SANY: java -cp <tools-jar> tla2sany.SANY <tla-file>
+- In order to run SANY: java -cp <tools-jar> tla2sany.SANY <tla-file>
 
 - In order to include the library modules (Standard modules like Sequences are contained in the jar but other modules like TLAPS are not).
 add the following flag to the java command: -DTLA-Library=<my-library-loc>


### PR DESCRIPTION
       Fix typo in README
       
       In this PR, I have corrected a typo in the project's README file, changing "t0" to "to". 
       Although the change is minor, I hope it helps improve the accuracy and readability of the documentation. 
       Thank you to the maintainers for their hard work!