### PR TITLE
ArrayIndexOutOfBoundsException in TLA+ debugger during simulation if simulator eliminated finite stuttering from current trace.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStateStackFrame.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStateStackFrame.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.lsp4j.debug.EvaluateResponse;
 import org.eclipse.lsp4j.debug.Scope;
@@ -160,7 +161,12 @@ public class TLCStateStackFrame extends TLCStackFrame {
 
 					final TLCStateInfo[] prefix;
 					if (TLCGlobals.simulator != null) {
-						prefix = TLCGlobals.simulator.getTraceInfo(t.getLevel() - 1);
+						// Filtering allAssigned is expected to remove only the final state from the
+						// trace, which is the state equal to 't'. If other states are also removed, it
+						// indicates an issue, but it is likely preferable to crashing.
+						prefix = TLCGlobals.simulator.getTrace(t).stream().filter(s -> s.allAssigned())
+								.map(s -> new TLCStateInfo(s)).collect(Collectors.toList())
+								.toArray(TLCStateInfo[]::new);
 					} else {
 						// B) Suffix from s_f to either an initial state or a state whose predecessor
 						// has to be looked up from disk (s_d).

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
@@ -802,17 +802,6 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 		
 		return new StateVec(trace.toArray(TLCState[]::new));
 	}
-	
-	public final TLCStateInfo[] getTraceInfo(final int level) {
-		final StateVec stateTrace = getTrace(this.curState);
-		assert 0 < level && level <= stateTrace.size();
-		final TLCStateInfo[] trace = new TLCStateInfo[level];
-		for (int i = 0; i < trace.length; i++) {
-			final TLCState s = stateTrace.elementAt(i);
-			trace[i] = new TLCStateInfo(s);
-		}
-		return trace;
-	}
 
 	public void setInitialStates(StateVec initStates) {
 		this.initStates = initStates;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -807,15 +807,6 @@ public class Simulator {
 			return workers.get(0).getTrace(s);
 		}
 	}
-
-	public TLCStateInfo[] getTraceInfo(final int level) {
-		if (Thread.currentThread() instanceof SimulationWorker) {
-			final SimulationWorker w = (SimulationWorker) Thread.currentThread();
-			return w.getTraceInfo(level);
-		} else {
-			return workers.get(0).getTraceInfo(level);
-		}
-	}
 	
 	public void stop() {
 		for (SimulationWorker worker : workers) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/StateVec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/StateVec.java
@@ -5,7 +5,9 @@
 
 package tlc2.tool;
 
+import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.stream.Stream;
 
 import tlc2.TLCGlobals;
 import tlc2.output.EC;
@@ -211,5 +213,9 @@ public final class StateVec implements IStateFunctor, INextStateFunctor {
   
   public final boolean hasStates() {
 	  return !isEmpty();
+  }
+  
+  public Stream<TLCState> stream() {
+	return Arrays.stream(this.v, 0, this.size);
   }
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
@@ -392,8 +392,9 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			// Reverse the trace to traverse from initial to end in the following loops
 			Collections.reverse(trace);
 			
-			// Assert that the variables' numbers in trace are strictly monotonic.
-			for (int i = 0; i < trace.size(); i++) {
+			// Assert that the variables' numbers in trace are strictly monotonic for all
+			// but the last state.
+			for (int i = 0; i < trace.size() - 1; i++) {
 				assertTrue(trace.get(i).getName().startsWith(Integer.toString(i + 1) + ":"));
 			}
 


### PR DESCRIPTION
ArrayIndexOutOfBoundsException in TLA+ debugger during simulation if simulator eliminated finite stuttering from current trace.

```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 82 out of
bounds for length 82
        at tlc2.tool.StateVec.elementAt(StateVec.java:78)
        at tlc2.tool.SimulationWorker.getTraceInfo(SimulationWorker.java:811)
        at tlc2.tool.Simulator.getTraceInfo(Simulator.java:816)
        at tlc2.debug.TLCStateStackFrame.lambda$getVariables$2(TLCStateStackFrame.java:163)
        at tlc2.tool.impl.DebugTool.eval(DebugTool.java:686)
        at tlc2.debug.TLCStateStackFrame.getVariables(TLCStateStackFrame.java:141)
        at tlc2.debug.TLCDebugger.variables(TLCDebugger.java:547)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        ... 13 more
```

Related to git commit 1f9f3cb59854937547a24d59e057cec02d476d5f. Due to this commit, the "Action" node in the debugger's variable view is no longer guaranteed to show ordinal n+1 if the topmost state in the debugger's "Trace" node shows n. Instead, depending on the number of stuttering steps, that number can be lower. This is a feature. :-)

<img width="566" alt="image" src="https://github.com/user-attachments/assets/97c3e981-280d-439d-ac3e-da0b754c9eae" />
