### PR TITLE
Add LevelNode#levelCheck API for public consumption

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -308,7 +308,7 @@ public class SANY {
   
           // Level check if semantic analysis succeeded and levelCheck is true.
           if (moduleNode != null && semanticErrors.isSuccess() && levelCheck ) {
-            moduleNode.levelCheck(1);
+            moduleNode.levelCheck(semanticErrors);
           }
 
           // Indicate in the externalModuleTable that the last module

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
@@ -298,7 +298,7 @@ public class APSubstInNode extends LevelNode {
 //  private HashSet argLevelParams;
 
   @Override
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
     if (this.levelChecked >= itr) return this.levelCorrect;
     this.levelChecked = itr ;
 
@@ -307,11 +307,11 @@ public class APSubstInNode extends LevelNode {
     * equals substs[i].getExpr().                                          *
     ***********************************************************************/
     this.levelCorrect = true;
-    if (!this.body.levelCheck(itr)) {
+    if (!this.body.levelCheck(itr, errors)) {
       this.levelCorrect = false;
     }
     for (int i = 0; i < this.substs.length; i++) {
-      if (!this.getSubWith(i).levelCheck(itr)) {
+      if (!this.getSubWith(i).levelCheck(itr, errors)) {
 	this.levelCorrect = false;
       }
     }
@@ -356,13 +356,13 @@ public class APSubstInNode extends LevelNode {
       * isConstant.                                                        *
       *********************************************************************/
     this.levelConstraints = Subst.getSubLCSet(this.body, this.substs,
-                                              isConstant, itr);
+                                              isConstant, itr, errors);
       /*********************************************************************
       * levelCheck(itr) has been called on body and the                   *
       * substs[i].getExpr(), as required.                                  *
       *********************************************************************/
     this.argLevelConstraints =
-        Subst.getSubALCSet(this.body, this.substs, itr);
+        Subst.getSubALCSet(this.body, this.substs, itr, errors);
     this.argLevelParams = Subst.getSubALPSet(this.body, this.substs);
       /*********************************************************************
       * levelCheck(itr) has been called on body and the                   *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AnyDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AnyDefNode.java
@@ -32,7 +32,7 @@ import util.UniqueString;
  *
  */
 public interface AnyDefNode {
-    public boolean levelCheck(int itr) ;
+    public boolean levelCheck(int itr, Errors errors) ;
     public int getMaxLevel(int i) ;
     public UniqueString getName() ;
     public int getMinMaxLevel(int i, int j) ;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeNode.java
@@ -83,11 +83,11 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
   /* Level checking */
   int levelChecked = 0 ;
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     if (levelChecked >= iter) {return true ;} ;
     levelChecked = iter;
-    boolean res = this.assumeExpr.levelCheck(iter);
-    if (this.def != null) {res = this.def.levelCheck(iter) && res;};
+    boolean res = this.assumeExpr.levelCheck(iter, errors);
+    if (this.def != null) {res = this.def.levelCheck(iter, errors) && res;};
 
     // Verify that the assumption is constant level
     if (this.assumeExpr.getLevel() != ConstantLevel) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeProveNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeProveNode.java
@@ -195,7 +195,7 @@ public class AssumeProveNode extends LevelNode {
   * reasonable, but I don't know if it's really correct.  -   LL           *
   *************************************************************************/
   @Override
-  public boolean levelCheck(int iter) {
+  public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * Return immediately if this this.levelCheck(i) has already been       *
     * invoked for i >= iter.                                               *
@@ -209,21 +209,21 @@ public class AssumeProveNode extends LevelNode {
     * Level check assumptions.                                             *
     ***********************************************************************/
     for (int i = 0; i < this.assumes.length; i++) {
-      if (this.assumes[i] != null && !this.assumes[i].levelCheck(iter))
+      if (this.assumes[i] != null && !this.assumes[i].levelCheck(iter, errors))
        {this.levelCorrect = false;};
       }; // end for
 
     /***********************************************************************
     * Level check prove expression                                         *
     ***********************************************************************/
-    this.prove.levelCheck(iter) ;
+    this.prove.levelCheck(iter, errors) ;
 
     /***********************************************************************
     * Calculate level.                                                     *
     ***********************************************************************/
     this.level = this.prove.getLevel() ;
     for (int i = 0; i < this.assumes.length; i++) {
-      this.assumes[i].levelCheck(iter) ;
+      this.assumes[i].levelCheck(iter, errors) ;
         /*******************************************************************
         * Must call levelCheck before calling getLevel.                    *
         *******************************************************************/

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AtNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AtNode.java
@@ -76,15 +76,15 @@ public class AtNode extends ExprNode {
 //  private HashSet argLevelParams;
 
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     if (this.levelChecked >= iter) return true;
     this.levelChecked = iter;
 
     ExprOrOpArgNode[] args = this.exceptRef.getArgs();
-    args[0].levelCheck(iter) ;
+    args[0].levelCheck(iter, errors) ;
     this.level = args[0].getLevel();
     for (int i = 1; i < args.length; i++) {
-      args[i].levelCheck(iter) ;
+      args[i].levelCheck(iter, errors) ;
       if (args[i] == this.exceptComponentRef) break;
       this.level = Math.max(this.level, args[i].getLevel());
     }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DecimalNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DecimalNode.java
@@ -75,7 +75,7 @@ public class DecimalNode extends ExprNode {
 
   /* Level checking */
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     levelChecked = iter;
       /*********************************************************************
       * Set it just to show that levelCHeck was called.                    *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DefStepNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DefStepNode.java
@@ -51,7 +51,7 @@ public class DefStepNode extends LevelNode {
   public OpDefNode[] getDefs() {return defs;}
 
   @Override
-  public boolean levelCheck(int iter) {
+  public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * Level check the steps and the instantiated modules coming from       *
     * module definitions.                                                  *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/FormalParamNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/FormalParamNode.java
@@ -71,7 +71,7 @@ public class FormalParamNode extends SymbolNode {
 //  private HashSet levelParams;
 
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     if (levelChecked == 0) {
       /*********************************************************************
       * There's never any need to do this more than once.                  *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/InstanceNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/InstanceNode.java
@@ -124,7 +124,7 @@ public class InstanceNode extends LevelNode {
 //  private SetOfArgLevelConstraints argLevelConstraints;
 //  private HashSet argLevelParams;
 
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
     /***********************************************************************
     * I believe this should only be called once, with itr = 1.            *
     ***********************************************************************/
@@ -141,11 +141,11 @@ public class InstanceNode extends LevelNode {
     * Level check the components this.module and this.substs[i].getExpr(). *
     ***********************************************************************/
     this.levelCorrect = true;
-    if (!this.module.levelCheck(itr)) {
+    if (!this.module.levelCheck(itr, errors)) {
       this.levelCorrect = false;
     }
     for (int i = 0; i < this.substs.length; i++ ) {
-      if (!this.substs[i].getExpr().levelCheck(itr)) {
+      if (!this.substs[i].getExpr().levelCheck(itr, errors)) {
         this.levelCorrect = false;
       }
     }
@@ -154,8 +154,8 @@ public class InstanceNode extends LevelNode {
     for (int i = 0; i < this.substs.length; i++ ) {
       SymbolNode mparam = substs[i].getOp();
       ExprOrOpArgNode mexp = substs[i].getExpr();
-      mexp.levelCheck(itr) ;
-      mparam.levelCheck(itr);
+      mexp.levelCheck(itr, errors) ;
+      mparam.levelCheck(itr, errors);
         /*****************************************************************
         * Have to call levelCheck on these objects before calling        *
         * getLevel.                                                      *
@@ -165,7 +165,7 @@ public class InstanceNode extends LevelNode {
       *********************************************************************/
       if (!this.module.isConstant()) {
         if (mexp.getLevel() > mparam.getLevel()) {
-          if (mexp.levelCheck(itr) && mparam.levelCheck(itr)) {
+          if (mexp.levelCheck(itr, errors) && mparam.levelCheck(itr, errors)) {
             errors.addError(
                this.stn.getLocation(),
                "Level error in instantiating module '" + module.getName() +
@@ -206,7 +206,7 @@ public class InstanceNode extends LevelNode {
       Integer plevel = (Integer)lcSet.get(mparam);
       if (plevel != null &&
           mexp.getLevel() > plevel.intValue()) {
-        if (mexp.levelCheck(itr)) {
+        if (mexp.levelCheck(itr, errors)) {
           errors.addError(this.stn.getLocation(),
             "Level error in instantiating module '" + module.getName() +
             "':\nThe level of the expression or operator substituted for '" +
@@ -221,7 +221,7 @@ public class InstanceNode extends LevelNode {
         for (int j = 0; j < alen; j++) {
           ParamAndPosition pap = new ParamAndPosition(mparam, j);
           Integer alevel = (Integer)alcSet.get(pap);
-          boolean opDefLevelCheck = opDef.levelCheck(itr) ;
+          boolean opDefLevelCheck = opDef.levelCheck(itr, errors) ;
             /***************************************************************
             * Need to call opDef.levelCheck before calling                 *
             * opDef.getMaxLevel.                                           *
@@ -254,7 +254,7 @@ public class InstanceNode extends LevelNode {
           if (alp.op == pi &&
               alp.param == this.substs[j].getOp()) {
             SymbolNode op = ((OpArgNode)this.substs[i].getExpr()).getOp();
-            boolean opLevelCheck = op.levelCheck(itr) ;
+            boolean opLevelCheck = op.levelCheck(itr, errors) ;
                /************************************************************
                * Need to level check before calling op.getMaxLevel.        *
                ************************************************************/
@@ -262,7 +262,7 @@ public class InstanceNode extends LevelNode {
                 this.substs[j].getExpr().getLevel() >
                    ((OpDefNode)op).getMaxLevel(alp.i)) {
               if (opLevelCheck &&
-                  this.substs[j].getExpr().levelCheck(itr)) {
+                  this.substs[j].getExpr().levelCheck(itr, errors)) {
                 errors.addError(
                    this.stn.getLocation(),
                    "Level error when instantiating module '" +
@@ -281,7 +281,7 @@ public class InstanceNode extends LevelNode {
     // Calculate level information.
 //    this.levelConstraints = new SetOfLevelConstraints();
     lcSet = Subst.getSubLCSet(this.module, this.substs,
-                              this.module.isConstant(), itr);
+                              this.module.isConstant(), itr, errors);
       /*********************************************************************
       * At this point, levelCheck(itr) has been called on this.module and  *
       * on all nodes substs[i].getExpr(), which is a precondition for      *
@@ -306,7 +306,7 @@ public class InstanceNode extends LevelNode {
     }
 
 //    this.argLevelConstraints = new SetOfArgLevelConstraints();
-    alcSet = Subst.getSubALCSet(this.module, this.substs, itr);
+    alcSet = Subst.getSubALCSet(this.module, this.substs, itr, errors);
     iter = alcSet.keySet().iterator();
     while (iter.hasNext()) {
       ParamAndPosition pap = (ParamAndPosition)iter.next();

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LabelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LabelNode.java
@@ -217,14 +217,14 @@ public class LabelNode extends ExprNode
   * Level-Checking.                                                        *
   *************************************************************************/
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     if (levelChecked >= iter) {return true ;} ;
     levelChecked = iter;
     boolean retVal = true ;
     for (int i=0; i < params.length; i++) {
-      if (params[i] != null) {params[i].levelCheck(iter);} ;
+      if (params[i] != null) {params[i].levelCheck(iter, errors);} ;
      } ;
-    return this.body.levelCheck(iter) && retVal ;
+    return this.body.levelCheck(iter, errors) && retVal ;
   }
 
   @Override

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LeafProofNode.java
@@ -74,7 +74,7 @@ public class LeafProofNode extends ProofNode {
   public boolean getOnlyFlag() {return isOnly ;} ;
 
   @Override
-  public boolean levelCheck(int iter) {
+  public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * Level checking is performed by level-checking the facts.  Since the  *
     * defs should be defined operators, they have already been level       *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
@@ -110,7 +110,7 @@ implements ExploreNode, LevelConstants {
 
   @Override
   @SuppressWarnings("unchecked")
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
     if (this.levelChecked >= itr) return this.levelCorrect;
     levelChecked = itr ;
 
@@ -123,15 +123,15 @@ implements ExploreNode, LevelConstants {
     * check.)                                                              *
     ***********************************************************************/
       if (   (this.opDefs[i].getKind() != ModuleInstanceKind)
-          && !this.opDefs[i].levelCheck(itr)) {
+          && !this.opDefs[i].levelCheck(itr, errors)) {
         this.levelCorrect = false;
       }
     }
-    if (!this.body.levelCheck(itr)) {
+    if (!this.body.levelCheck(itr, errors)) {
       this.levelCorrect = false;
     }
     for (int i = 0; i < this.insts.length; i++) {
-      if (!this.insts[i].levelCheck(itr)) {
+      if (!this.insts[i].levelCheck(itr, errors)) {
         this.levelCorrect = false;
       }
     }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java
@@ -96,13 +96,22 @@ public int levelChecked   = 0 ;
   * recursively defined operators or functions.                            *
   *************************************************************************/
 
+  /**
+   * Run the level-checking algorithm on this node and all its children.
+   * @param errors A log in which to record any errors which occurred.
+   * @return Whether the level-checking process succeeded.
+   */
+  public boolean levelCheck(Errors errors) {
+    return this.levelCheck(this.levelChecked + 1, errors);
+  }
 
   /**
    * Check whether an expr or opArg is level correct, and if so,
    * calculates the level information for the expression. Returns
    * true iff this is level correct.
+ * @param errors TODO
    */
-  public boolean levelCheck(int iter) {
+  public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * This is called for a node n to calculate the level information for   *
     * n and all its descendants.  It should be overridden by each          *
@@ -156,7 +165,7 @@ public int levelChecked   = 0 ;
         *    This method is called for such a node only when               *
         *    level-checking a proof.                                       *
         *******************************************************************/
-        this.levelCorrect = sub[i].levelCheck(iter) && this.levelCorrect ;
+        this.levelCorrect = sub[i].levelCheck(iter, errors) && this.levelCorrect ;
         if (this.level < sub[i].getLevel()) {this.level = sub[i].getLevel();};
         this.levelParams.addAll(sub[i].getLevelParams());
         this.levelConstraints.putAll(sub[i].getLevelConstraints());

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
@@ -725,7 +725,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
 //  private HashSet argLevelParams;
 
   @Override
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
 
     if (levelChecked >= itr) return this.levelCorrect;
     levelChecked = itr ;
@@ -822,7 +822,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
       for (int i = firstInSectIdx ; i < curNodeIdx ; i++) {
         curNode = opDefsInRecursiveSection.elementAt(i) ;
         if (curNode.inRecursive) {curNode.levelChecked = 0 ;} ;
-        curNode.levelCheck(1) ;
+        curNode.levelCheck(1, errors) ;
 
         if (curNode.inRecursive) {
           /*****************************************************************
@@ -862,7 +862,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
       for (int i = firstInSectIdx ; i < curNodeIdx ; i++) {
         curNode = opDefsInRecursiveSection.elementAt(i) ;
         if (curNode.inRecursive) {curNode.levelChecked = 1;} ;
-        curNode.levelCheck(2) ;
+        curNode.levelCheck(2, errors) ;
        }; // for i
 
       firstInSectIdx = curNodeIdx ;
@@ -876,7 +876,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     this.levelCorrect = true;
     ModuleNode[] mods = this.getInnerModules();
     for (int i = 0; i < mods.length; i++) {
-      if (!mods[i].levelCheck(1)) {
+      if (!mods[i].levelCheck(1, errors)) {
         this.levelCorrect = false;
       }
     }
@@ -890,7 +890,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     for (int i = 0; i < opDefs.length; i++) {
 // System.out.println("opDef, module " + this.getName() + ": "
 // + opDefs[i].getName());
-      if (!opDefs[i].levelCheck(1)) {
+      if (!opDefs[i].levelCheck(1, errors)) {
         this.levelCorrect = false;
       }
     }
@@ -898,7 +898,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     for (int i = 0; i < thmOrAssDefs.length; i++) {
 // System.out.println("opDef, module " + this.getName() + ": "
 // + opDefs[i].getName());
-      if (!thmOrAssDefs[i].levelCheck(1)) {
+      if (!thmOrAssDefs[i].levelCheck(1, errors)) {
         this.levelCorrect = false;
       }
     }
@@ -909,7 +909,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     ***********************************************************************/
     LevelNode[] tpLev = this.getTopLevel() ;
     for (int i = 0; i < tpLev.length; i++) {
-      if (!tpLev[i].levelCheck(1)) {
+      if (!tpLev[i].levelCheck(1, errors)) {
         this.levelCorrect = false;
       }
     } ;
@@ -1037,7 +1037,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     // object rather than using the opDefs array, because we must
     // include all operators not only defined in this module, but also
     // inherited through extention and instantiation
-    this.levelCheck(1) ;
+    this.levelCheck(1, errors) ;
       /*********************************************************************
       * isConstant() can be called from other modules.  We had better be   *
       * sure that it has already been level checked before checking the    *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NewSymbNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NewSymbNode.java
@@ -88,7 +88,7 @@ public class NewSymbNode extends LevelNode {
   * information comes from the `set' expression.                           *
   *************************************************************************/
   @Override
-  public boolean levelCheck(int iter)       {
+  public boolean levelCheck(int iter, Errors errors)       {
 
     if (levelChecked < iter) {
       /*********************************************************************
@@ -99,10 +99,10 @@ public class NewSymbNode extends LevelNode {
       * class is changed to make levelCheck do something.                  *
       *********************************************************************/
       levelChecked = iter ;
-      boolean opDeclLevelCheck = opDeclNode.levelCheck(iter) ;
+      boolean opDeclLevelCheck = opDeclNode.levelCheck(iter, errors) ;
       level = opDeclNode.getLevel() ;
       if (set != null) {
-        levelCorrect = set.levelCheck(iter) ;
+        levelCorrect = set.levelCheck(iter, errors) ;
         level = Math.max(set.getLevel(), level);
         if (level == TemporalLevel) {
           levelCorrect = false;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
@@ -145,7 +145,7 @@ public class NonLeafProofNode extends ProofNode {
   public Context     getContext() {return context ;}
 
   @Override
-  public boolean levelCheck(int iter) {
+  public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * Level check the steps and the instantiated modules coming from       *
     * module definitions.                                                  *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NumeralNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NumeralNode.java
@@ -87,7 +87,7 @@ public class NumeralNode extends ExprNode {
 
   /* Level Checking */
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     levelChecked = iter;
       /*********************************************************************
       * Set it just to show that levelCHeck was called.                    *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
@@ -442,7 +442,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
 // }
 
   @Override
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
     if (this.levelChecked >= itr) return this.levelCorrect;
     this.levelChecked = itr ;
 
@@ -457,7 +457,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
         * Below, this.operands[i] is dereferenced without first checking   *
         * it for null, so I presume it can't be null.                      *
         *******************************************************************/
-          !this.operands[i].levelCheck(itr)) {
+          !this.operands[i].levelCheck(itr, errors)) {
         this.levelCorrect = false;
       }
     }
@@ -468,7 +468,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
         * several places below where this.ranges[i] is dereferenced        *
         * without first checking if it's null.                             *
         *******************************************************************/
-          !this.ranges[i].levelCheck(itr)) {
+          !this.ranges[i].levelCheck(itr, errors)) {
 
         this.levelCorrect = false;
       }
@@ -509,7 +509,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
       *    VariableLevel seems to have no practical effect.                *
       *********************************************************************/
       AnyDefNode opDef = (AnyDefNode)this.operator;
-      boolean opDefLevelCheck = opDef.levelCheck(itr) ;
+      boolean opDefLevelCheck = opDef.levelCheck(itr, errors) ;
         /*******************************************************************
         * Need to call levelCheck before obtaining its level params.       *
         *******************************************************************/
@@ -520,7 +520,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
           *****************************************************************/
         if (opd != null) {
           if (opd.getLevel() > opDef.getMaxLevel(i)) {
-            if (opDefLevelCheck && opd.levelCheck(itr)) {
+            if (opDefLevelCheck && opd.levelCheck(itr, errors)) {
               errors.addError(
                  this.stn.getLocation(),
                  "Level error in applying operator " + opDef.getName() +
@@ -537,7 +537,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
               ((OpArgNode)opd).getOp() instanceof AnyDefNode) {
             AnyDefNode opdDef = (AnyDefNode)((OpArgNode)opd).getOp();
             @SuppressWarnings("unused")  // See below comment block
-            boolean opdDefLevelCheck = opdDef.levelCheck(itr) ;
+            boolean opdDefLevelCheck = opdDef.levelCheck(itr, errors) ;
               /*************************************************************
               * Need to call opdDef.levelCheck before using its level      *
               * parameters.                                                *
@@ -545,7 +545,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
             int alen = opdDef.getArity();
             for (int j = 0; j < alen; j++) {
               if (opdDef.getMaxLevel(j) < opDef.getMinMaxLevel(i, j)) {
-                if (opDefLevelCheck && opd.levelCheck(itr)) {
+                if (opDefLevelCheck && opd.levelCheck(itr, errors)) {
                   errors.addError(this.stn.getLocation(),
                                   "Level error in applying operator "
                                         + opDef.getName() + ":\n" +
@@ -561,8 +561,8 @@ public class OpApplNode extends ExprNode implements ExploreNode {
               for (int k = 0; k < alen; k++) {
                 if (opDef.getOpLevelCond(i, j, k) &&
                     this.operands[j].getLevel() > opdDef.getMaxLevel(k)) {
-                  if (opd.levelCheck(itr) &&
-                      this.operands[j].levelCheck(itr)) {
+                  if (opd.levelCheck(itr, errors) &&
+                      this.operands[j].levelCheck(itr, errors)) {
                     errors.addError(
                        this.stn.getLocation(),
                        "Level error in applying operator " + opDef.getName() +
@@ -580,7 +580,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
       for (int i = 0; i < this.ranges.length; i++) {
         ExprNode range = this.ranges[i];
         if (range != null) {
-          boolean rangeLevelCheck = range.levelCheck(itr) ;
+          boolean rangeLevelCheck = range.levelCheck(itr, errors) ;
           if (range.getLevel() > ActionLevel) {
             if (rangeLevelCheck) {
               errors.addError(
@@ -732,7 +732,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
             opdi instanceof OpArgNode &&
             ((OpArgNode)opdi).getOp() instanceof AnyDefNode) {
           AnyDefNode argDef = (AnyDefNode)((OpArgNode)opdi).getOp();
-          argDef.levelCheck(itr) ;
+          argDef.levelCheck(itr, errors) ;
             /***************************************************************
             * Need to invoke levelCheck before invoking getMaxLevel.       *
             ***************************************************************/
@@ -781,7 +781,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
             arg instanceof OpArgNode &&
             ((OpArgNode)arg).getOp() instanceof AnyDefNode) {
           AnyDefNode argDef = (AnyDefNode)((OpArgNode)arg).getOp();
-          argDef.levelCheck(itr) ;
+          argDef.levelCheck(itr, errors) ;
             /***************************************************************
             * Need to invoke levelCheck before invoking getMaxLevel.       *
             ***************************************************************/
@@ -832,7 +832,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
         ArgLevelParam alp = iter.next();
         ExprOrOpArgNode arg = this.getArg(alp.op);
         if (arg != null) {
-          arg.levelCheck(itr) ;
+          arg.levelCheck(itr, errors) ;
             /***************************************************************
             * Have to invoke levelCheck before invoking getLevel.          *
             ***************************************************************/
@@ -881,7 +881,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
             this.argLevelParams.add(alp);
           }
           else {
-            arg.levelCheck(itr) ;
+            arg.levelCheck(itr, errors) ;
               /*************************************************************
               * Need to invoke levelCheck before invoking getLevelParams.  *
               *************************************************************/
@@ -927,13 +927,13 @@ public class OpApplNode extends ExprNode implements ExploreNode {
     } // if (this.operator instanceof OpDefNode)
     else {
       // Application of a declared operator
-      this.operator.levelCheck(itr) ;
+      this.operator.levelCheck(itr, errors) ;
         /*******************************************************************
         * Need to invoke levelCheck before invoking getLevel.              *
         *******************************************************************/
       this.level = this.operator.getLevel();
       for (int i = 0; i < this.operands.length; i++) {
-        this.operands[i].levelCheck(itr) ;
+        this.operands[i].levelCheck(itr, errors) ;
         this.level = Math.max(this.level, this.operands[i].getLevel());
       } // for
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpArgNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpArgNode.java
@@ -69,10 +69,10 @@ public class OpArgNode extends ExprOrOpArgNode {
 
   /* Level check */
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     if (levelChecked >= iter) {return this.levelCorrect; } ;
     levelChecked = iter ;
-    levelCorrect        = op.levelCheck(iter) ;
+    levelCorrect        = op.levelCheck(iter, errors) ;
     level               = op.getLevel();
     levelParams         = op.getLevelParams();
     allParams           = op.getAllParams();

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDeclNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDeclNode.java
@@ -91,7 +91,7 @@ public class OpDeclNode extends OpDefOrDeclNode {
 //  private HashSet levelParams;
 
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * Level information set by constructor.                                *
     ***********************************************************************/

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -1016,7 +1016,7 @@ public class OpDefNode extends OpDefOrDeclNode
   }
 
   @Override
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
     if (   (this.levelChecked >= itr)
         || (    (! inRecursiveSection)
              && (this.levelChecked > 0))) return this.levelCorrect;
@@ -1034,12 +1034,12 @@ public class OpDefNode extends OpDefOrDeclNode
       *********************************************************************/
       LevelNode[] subs = new LevelNode[1] ;
       subs[0] = stepNode ;
-      this.levelCorrect = this.stepNode.levelCheck(itr);
+      this.levelCorrect = this.stepNode.levelCheck(itr, errors);
       return this.levelCheckSubnodes(itr, subs) ;
      }
 
     // Level check the body:
-      this.levelCorrect = this.body.levelCheck(itr);
+      this.levelCorrect = this.body.levelCheck(itr, errors);
     /***********************************************************************
     * Modified for recursive checking so the level never decreases with    *
     * repeated computation.                                                *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/StringNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/StringNode.java
@@ -50,7 +50,7 @@ public class StringNode extends ExprNode implements ExploreNode {
 
   /* Level Checking */
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     levelChecked = iter;
       /*********************************************************************
       * Set it just to show that levelCHeck was called.                    *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Subst.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Subst.java
@@ -110,10 +110,13 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
     return res;
   }
 
-  public static SetOfLevelConstraints getSubLCSet(LevelNode body,
-						  Subst[] subs,
-						  boolean isConstant,
-                                                  int itr) {
+  public static SetOfLevelConstraints getSubLCSet(
+      LevelNode body,
+      Subst[] subs,
+      boolean isConstant,
+      int itr,
+      Errors errors
+    ) {
     /***********************************************************************
     * This should only be called after level checking has been called on   *
     * body and on all subs[i].getExpr().  The itr argument is the          *
@@ -146,7 +149,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
       if (sub != null &&
 	  sub.getOp() instanceof OpDefNode) {
 	OpDefNode subDef = (OpDefNode)sub.getOp();
-        subDef.levelCheck(itr);
+        subDef.levelCheck(itr, errors);
           /*****************************************************************
           * The call of getMaxLevel should be made only to a node that     *
           * has been level checked.  But this node has come from looking   *
@@ -166,7 +169,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
   }
 
   public static SetOfArgLevelConstraints getSubALCSet(
-                  LevelNode body, Subst[] subs, int itr) {
+                  LevelNode body, Subst[] subs, int itr, Errors errors) {
     /***********************************************************************
     * Can be called only after levelCheck has been called on body.  The    *
     * argument itr is the argument for calling levelCheck.                 *
@@ -199,7 +202,7 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
 	SymbolNode op = (subOp == null) ? alp.op : ((OpArgNode)subOp).getOp();
 	if (op.isParam()) {
 	  ParamAndPosition pap = new ParamAndPosition(op, alp.i);
-          subParam.levelCheck(itr) ;
+          subParam.levelCheck(itr, errors) ;
             /***************************************************************
             * Must invoke levelCheck before invoking getLevel              *
             ***************************************************************/

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -312,7 +312,7 @@ public class SubstInNode extends ExprNode {
 
   @Override
   @SuppressWarnings("unchecked")
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
     if (this.levelChecked >= itr) return this.levelCorrect;
     this.levelChecked = itr ;
 
@@ -321,11 +321,11 @@ public class SubstInNode extends ExprNode {
     * equals substs[i].getExpr().                                          *
     ***********************************************************************/
     this.levelCorrect = true;
-    if (!this.body.levelCheck(itr)) {
+    if (!this.body.levelCheck(itr, errors)) {
       this.levelCorrect = false;
     }
     for (int i = 0; i < this.substs.length; i++) {
-      if (!this.getSubWith(i).levelCheck(itr)) {
+      if (!this.getSubWith(i).levelCheck(itr, errors)) {
 	this.levelCorrect = false;
       }
     }
@@ -438,13 +438,13 @@ public class SubstInNode extends ExprNode {
       * isConstant.                                                        *
       *********************************************************************/
     this.levelConstraints = Subst.getSubLCSet(this.body, this.substs,
-                                              isConstant, itr);
+                                              isConstant, itr, errors);
       /*********************************************************************
       * levelCheck(itr) has been called on body and the                   *
       * substs[i].getExpr(), as required.                                  *
       *********************************************************************/
     this.argLevelConstraints =
-        Subst.getSubALCSet(this.body, this.substs, itr);
+        Subst.getSubALCSet(this.body, this.substs, itr, errors);
     this.argLevelParams = Subst.getSubALPSet(this.body, this.substs);
       /*********************************************************************
       * levelCheck(itr) has been called on body and the                   *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/TheoremNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/TheoremNode.java
@@ -116,7 +116,7 @@ public class TheoremNode extends LevelNode {
  * @see tla2sany.semantic.LevelNode#levelCheck(int)
  */
   @Override
-  public final boolean levelCheck(int iter) {
+  public final boolean levelCheck(int iter, Errors errors) {
     if (levelChecked >= iter) {return true ;} ;
     levelChecked = iter;
     LevelNode sub[] ;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
@@ -420,7 +420,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
     * of opArg.                                                            *
     ***********************************************************************/
   @Override
-  public final boolean levelCheck(int itr) {
+  public final boolean levelCheck(int itr, Errors errors) {
       if (this.levelChecked >= itr) { return this.levelCorrect; }
       this.levelChecked = itr ;
 
@@ -440,7 +440,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
 
 
    // Level check the body:
-      this.levelCorrect = this.body.levelCheck(itr);
+      this.levelCorrect = this.body.levelCheck(itr, errors);
       this.level = this.body.getLevel();
 
       SetOfLevelConstraints lcSet = this.body.getLevelConstraints();

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/UseOrHideNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/UseOrHideNode.java
@@ -105,7 +105,7 @@ public class UseOrHideNode extends LevelNode {
   }
 
   @Override
-  public boolean levelCheck(int iter) {
+  public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
     * Level checking is performed by level-checking the facts.  Since the  *
     * defs should be defined operators, they have already been level       *

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestLevelChecking.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestLevelChecking.java
@@ -200,27 +200,20 @@ public class TestLevelChecking {
   }
 
   /**
-   * Runs the level-checking algorithm on a semantic tree.
-   *
-   * @param semanticTree The semantic tree to level-check.
-   * @return Whether level checking succeeded.
-   */
-  private static boolean checkLevel(ModuleNode semanticTree) {
-    return semanticTree.levelCheck(1);
-  }
-
-  /**
    * Runs all level-checker tests in the corpus.
    */
   @Test
   public void testAll() {
     for (LevelCheckingTestCase testCase : TestLevelChecking.TestCases) {
-      Errors log = new Errors();
       TreeNode parseTree = checkSyntax(testCase.Input);
-      ModuleNode semanticTree = checkSemantic(parseTree, log);
-      boolean actualLevelCheckingResult = checkLevel(semanticTree);
-      Assert.assertEquals(testCase.summarize(log), log.isSuccess(), actualLevelCheckingResult);
-      Assert.assertEquals(testCase.summarize(log), testCase.ExpectedLevelCheckingResult, actualLevelCheckingResult);
+      Errors semanticLog = new Errors();
+      ModuleNode semanticTree = checkSemantic(parseTree, semanticLog);
+      Assert.assertTrue(testCase.summarize(semanticLog), semanticLog.isSuccess());
+      Errors levelCheckingLog = new Errors();
+      boolean actualLevelCheckingResult = semanticTree.levelCheck(levelCheckingLog);
+      Assert.assertTrue(testCase.summarize(semanticLog), semanticLog.isSuccess());
+      Assert.assertEquals(testCase.summarize(levelCheckingLog), levelCheckingLog.isSuccess(), actualLevelCheckingResult);
+      Assert.assertEquals(testCase.summarize(levelCheckingLog), testCase.ExpectedLevelCheckingResult, actualLevelCheckingResult);
     }
   }
 }


### PR DESCRIPTION
This was suggested by @lemmy in #1099 and I think it's a good idea so splitting it off into its own PR.

These changes do something a bit more advanced, which is add an `Errors` log parameter to enable users of this API to split logging of the level-checking process off from the semantic checking process.

Before these changes, all semantic and level-checking error logging were co-mingled in an annoying static global log in `SemanticNode#errors`. This has to be initialized with a static call to `SemanticNode#setError` before running semantic or level-checking analysis. While these changes do not get rid of this static log, it reduces the number of times it is used in the codebase from 49 to 32. Hopefully future changes can chip away at this and get it down to zero, thus reducing the number of incantations that must be done before parsing a TLA+ module.

Currently the only non-test consumer of this API is in `tla2sany.drivers.SANY#frontEndSemanticAnalysis`; it expects the semantic & level-checking logs to be co-mingled so that's what we keep doing, passing `semanticErrors` as the error logging parameter to `LevelNode#levelCheck`.

These changes were mostly done using Eclipse's nice automated method refactoring functionality.

Ref #891