### PR TITLE
SANY: Remove most static error logging usage

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -493,7 +493,7 @@ public class SANY {
 
             if (doDebugging) {
               // Run the Semantic Graph Exploration tool
-              Explorer explorer = new Explorer(spec.getExternalModuleTable());
+              Explorer explorer = new Explorer(spec.getExternalModuleTable(), spec.getSemanticErrors());
               try {
                 explorer.main(args);
               }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import tla2sany.semantic.Errors;
 import tla2sany.semantic.ExternalModuleTable;
 import tla2sany.semantic.FormalParamNode;
 import tla2sany.semantic.Generator;
@@ -39,8 +40,6 @@ import util.UniqueString;
 
 public class Explorer {
 
-	public Generator generator;
-
 	// Next three vars used in reading commands from keyboard
 	private final InputStreamReader inStream = new InputStreamReader(System.in);
 	private final int inCapacity = 100;
@@ -59,11 +58,13 @@ public class Explorer {
 	private ExploreNode obj;
 
 	private ExternalModuleTable mt;
+	private final Errors errors;
 
 	// Constructor
-	public Explorer(ExternalModuleTable mtarg) {
+	public Explorer(ExternalModuleTable mtarg, Errors errors) {
 
 		mt = mtarg;
+		this.errors = errors;
 
 	}
 
@@ -237,9 +238,9 @@ public class Explorer {
 				// Print the semantic graph, rooted in the Module Table
 				// excluding built-ins and ops defined in module Naturals
 				if (icmd2 != null) {
-					mt.printExternalModuleTable(icmd2.intValue(), false);
+					mt.printExternalModuleTable(icmd2.intValue(), false, errors);
 				} else {
-					mt.printExternalModuleTable(2, false);
+					mt.printExternalModuleTable(2, false, errors);
 				}
 
 			} else if (firstToken.toLowerCase().equals("mt*")) {
@@ -247,9 +248,9 @@ public class Explorer {
 				// Print the semantic graph, rooted in the Module Table
 				// including builtins and ops defined in Naturals
 				if (icmd2 != null) {
-					mt.printExternalModuleTable(icmd2.intValue(), true);
+					mt.printExternalModuleTable(icmd2.intValue(), true, errors);
 				} else {
-					mt.printExternalModuleTable(2, true);
+					mt.printExternalModuleTable(2, true, errors);
 				}
 
 			} else if (firstToken.equalsIgnoreCase("dot")) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
@@ -63,7 +63,7 @@ public class APSubstInNode extends LevelNode {
      // The module being instantiated
 
   private APSubstInNode(TreeNode treeNode, Subst[] subs, LevelNode expr,
-		     ModuleNode ingmn, ModuleNode edmn) {
+		     ModuleNode ingmn, ModuleNode edmn, Errors errors) {
     super(APSubstInKind, treeNode);
     this.substs = subs;
     this.body = expr;
@@ -76,8 +76,8 @@ public class APSubstInNode extends LevelNode {
   }
   
   public APSubstInNode(TreeNode treeNode, SubstInNode subst, LevelNode expr,
-		     ModuleNode ingmn, ModuleNode edmn) {
-	  this(treeNode, subst.getSubsts(), expr, ingmn, edmn);
+		     ModuleNode ingmn, ModuleNode edmn, Errors errors) {
+	  this(treeNode, subst.getSubsts(), expr, ingmn, edmn, errors);
   }
 
   /**
@@ -203,7 +203,7 @@ public class APSubstInNode extends LevelNode {
    */
   @SuppressWarnings("unused")	// TODO final else block is dead code 
   final void addExplicitSubstitute(Context instanceCtxt, UniqueString lhs,
-                                   TreeNode stn, ExprOrOpArgNode sub) {
+                                   TreeNode stn, ExprOrOpArgNode sub, Errors errors) {
     int index;
     for (index = 0; index < this.substs.length; index++) {
       if (lhs == this.substs[index].getOp().getName()) break;
@@ -267,7 +267,7 @@ public class APSubstInNode extends LevelNode {
    * possible, because X is not defined in the instantiating module,
    * then we have an error.
    */
-  final void matchAll(Vector decls) {
+  final void matchAll(Vector decls, Errors errors) {
     for (int i = 0; i < decls.size(); i++) {
       // Get the name of the i'th operator that must be substituted for
       UniqueString opName = ((OpDeclNode)decls.elementAt(i)).getName();
@@ -350,7 +350,7 @@ public class APSubstInNode extends LevelNode {
         *******************************************************************/
     }
 
-    boolean isConstant = this.instantiatedModule.isConstant();
+    boolean isConstant = this.instantiatedModule.isConstant(errors);
       /*********************************************************************
       * It is not necessary to invoke levelCheck before invoking           *
       * isConstant.                                                        *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DefStepNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DefStepNode.java
@@ -56,7 +56,7 @@ public class DefStepNode extends LevelNode {
     * Level check the steps and the instantiated modules coming from       *
     * module definitions.                                                  *
     ***********************************************************************/
-    return this.levelCheckSubnodes(iter, defs) ;
+    return this.levelCheckSubnodes(iter, defs, errors) ;
    }
 
   @Override

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ExternalModuleTable.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ExternalModuleTable.java
@@ -32,10 +32,10 @@ public class ExternalModuleTable implements ExploreNode {
 
     public ModuleNode getModuleNode() { return moduleNode; }
 
-    public void printMTE(int depth, boolean b) {
+    public void printMTE(int depth, boolean b, Errors errors) {
       if (moduleNode != null) {
         System.out.print(Strings.indent(2, "\nModule: ")); 
-        moduleNode.print(2,depth,b);
+        moduleNode.print(2,depth,b, errors);
       }
       else {
         System.out.print(Strings.indent(2, "\nModule: " + 
@@ -158,7 +158,7 @@ public class ExternalModuleTable implements ExploreNode {
     return "\nModule Table:" + Strings.indent(2,ret);
   }
 
-  public void printExternalModuleTable(int depth, boolean b) {
+  public void printExternalModuleTable(int depth, boolean b, Errors errors) {
     System.out.print("\nExternal Module Table:");
 
     for (int i = 0; i < moduleNodeVector.size(); i++) {
@@ -166,7 +166,7 @@ public class ExternalModuleTable implements ExploreNode {
 
       if (mn != null) {
         System.out.print(Strings.indent(2, "\nModule: ")); 
-        mn.print(2,depth,b);
+        mn.print(2,depth,b, errors);
       } else {
         System.out.print(Strings.indent(2, "\nModule: " + 
                          Strings.indent(2, "\n***Null ExternalModuleTable entry; " + 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/FormalParamNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/FormalParamNode.java
@@ -51,7 +51,7 @@ public class FormalParamNode extends SymbolNode {
 
   public final ModuleNode getModuleNode() { return this.moduleNode; }
 
-  public final boolean match( OpApplNode test, ModuleNode mn ) {
+  public final boolean match( OpApplNode test, ModuleNode mn, Errors errors ) {
     /***********************************************************************
     * True iff the current object has the same arity as the node operator  *
     * of the OpApplNode test.                                              *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
@@ -1800,10 +1800,10 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			Object substOb = substInPrefix.elementAt(temp - 1);
 			if (substOb instanceof SubstInNode) {
 				SubstInNode subst = (SubstInNode) substOb;
-				curExprNode = new SubstInNode(subst, curExprNode);
+				curExprNode = new SubstInNode(subst, curExprNode, errors);
 			} else {
 				APSubstInNode subst = (APSubstInNode) substOb;
-				curExprNode = new SubstInNode(subst, curExprNode);
+				curExprNode = new SubstInNode(subst, curExprNode, errors);
 			}
 			temp = temp - 1;
 		}
@@ -2080,7 +2080,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			case N_UseOrHide:
 				checkIfInRecursiveSection(definitions[lvi], "A USE or HIDE");
 				UseOrHideNode uohn = generateUseOrHide(definitions[lvi], currentModule);
-				uohn.factCheck();
+				uohn.factCheck(errors);
 				// Added 4 Mar 2009.
 				if (uohn.facts.length + uohn.defs.length == 0) {
 					errors.addError(definitions[lvi].getLocation(), "Empty USE or HIDE statement.");
@@ -4541,7 +4541,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 						// above, but with a body from the OpDefNode in the module
 						// being instantiated
 						SubstInNode substInNode = new SubstInNode(treeNode, substIn, odn.getBody(), cm,
-								instanceeModule);
+								instanceeModule, errors);
 
 						// MAK 02/2021: Store the individual segments of the compound id to not rely on
 						// ad-hoc parsing later when a feature such as the debugger needs to know each
@@ -4629,7 +4629,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 					// above, but with a body from the ThmOrAssumpDefNode in the module
 					// being instantiated
 					APSubstInNode substInNode = new APSubstInNode(treeNode, substIn, taOdn.getBody(), cm,
-							instanceeModule);
+							instanceeModule, errors);
 
 					// Create the ThmOrAssumpDefNode for the new instance of this
 					// definition; because of the new operator name, cm is the
@@ -4903,7 +4903,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 			// Overwrite an implicit substitution if there is one, or add a new one,
 			// checking for duplicate substitutions for the same symbol
-			substIn.addExplicitSubstitute(instanceeCtxt, sc[0].getUS(), sc[2], substRHS);
+			substIn.addExplicitSubstitute(instanceeCtxt, sc[0].getUS(), sc[2], substRHS, errors);
 		}
 
 		// Check that all remaining implicit substitutions have the correct arity.  The
@@ -4916,7 +4916,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		// Check if substitution is complete, i.e. that all constants and vars
 		// have been substituted for.
-		substIn.matchAll(decls);
+		substIn.matchAll(decls, errors);
 		return substIn;
 	} // end processSubst
 
@@ -5086,7 +5086,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 					// but with a body from the OpDefNode in the module being
 					// instantiated
 					substInTemplate = new SubstInNode(treeNode, subst, odn.getBody(), cm,
-							instanceeModuleNode);
+							instanceeModuleNode, errors);
 					newOdn = new OpDefNode(odn.getName(), UserDefinedOpKind, odn.getParams(), localness,
 							substInTemplate, cm, symbolTable, treeNode, true, odn.getSource());
 					newOdn.setLabels(odn.getLabelsHT());
@@ -5181,7 +5181,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 					// but with a body from the ThmOrAssumpDefNode in the module being
 					// instantiated
 					tasubstInTemplate = new APSubstInNode(treeNode, subst, tadn.getBody(), cm,
-							instanceeModuleNode);
+							instanceeModuleNode, errors);
 					newTadn = new ThmOrAssumpDefNode(tadn.getName(), tadn.isTheorem(), tasubstInTemplate, cm,
 							symbolTable, treeNode, tadn.getParams(), instanceeModuleNode, tadn.getSource());
 					// Following if/else added by LL on 30 Oct 2012 to handle locally
@@ -5624,7 +5624,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 					errors.addError(stepBodySTN.getLocation(), "Empty USE or HIDE statement.");
 				}
 				;
-				uohn.factCheck();
+				uohn.factCheck(errors);
 				// Added 4 Mar 2009.
 				pfNumNode = uohn;
 				steps[i - offset] = pfNumNode;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/InstanceNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/InstanceNode.java
@@ -163,7 +163,7 @@ public class InstanceNode extends LevelNode {
       /*********************************************************************
       * Check level constraints for a constant module.                     *
       *********************************************************************/
-      if (!this.module.isConstant()) {
+      if (!this.module.isConstant(errors)) {
         if (mexp.getLevel() > mparam.getLevel()) {
           if (mexp.levelCheck(itr, errors) && mparam.levelCheck(itr, errors)) {
             errors.addError(
@@ -281,7 +281,7 @@ public class InstanceNode extends LevelNode {
     // Calculate level information.
 //    this.levelConstraints = new SetOfLevelConstraints();
     lcSet = Subst.getSubLCSet(this.module, this.substs,
-                              this.module.isConstant(), itr, errors);
+                              this.module.isConstant(errors), itr, errors);
       /*********************************************************************
       * At this point, levelCheck(itr) has been called on this.module and  *
       * on all nodes substs[i].getExpr(), which is a precondition for      *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LeafProofNode.java
@@ -81,7 +81,7 @@ public class LeafProofNode extends ProofNode {
     * checked.                                                             *
     ***********************************************************************/
     if (this.levelChecked >= iter) return this.levelCorrect;
-    return this.levelCheckSubnodes(iter, facts) ;
+    return this.levelCheckSubnodes(iter, facts, errors) ;
    }
 
   /*

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java
@@ -138,7 +138,7 @@ public int levelChecked   = 0 ;
                  " node not implemented.");
    }
 
-  public boolean levelCheckSubnodes(int iter, LevelNode[] sub) {
+  public boolean levelCheckSubnodes(int iter, LevelNode[] sub, Errors errors) {
     /***********************************************************************
     * Performs levelCheck(iter) for a node whose level information is      *
     * computed by combining the level information from the array sub of    *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
@@ -665,7 +665,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
    * Just a stub method; one cannot resolve against a ModuleNode.
    * This method is here only to satisfy the SymbolNode interface.
    */
-  public final boolean match( OpApplNode sn, ModuleNode mn ) { return false; }
+  public final boolean match( OpApplNode sn, ModuleNode mn, Errors errors ) { return false; }
 
   /**
    * Returns an array of all the theorems that appear in this module,
@@ -946,7 +946,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
 //    this.levelConstraints = new SetOfLevelConstraints();
 //    this.argLevelConstraints = new SetOfArgLevelConstraints();
 //    this.argLevelParams = new HashSet();
-    if (!this.isConstant()) {
+    if (!this.isConstant(errors)) {
       for (int i = 0; i < decls.length; i++) {
         this.levelConstraints.put(decls[i], Levels[ConstantLevel]);
       }
@@ -1025,8 +1025,10 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
    * 3. It extends and instantiates only constant modules.
    *
    * NOTE: Can only be called after calling levelCheck
+   *
+   * @param errors Log into which to emit errors.
    */
-  public final boolean isConstant() {
+  public final boolean isConstant(Errors errors) {
     // if the module contains any VARIABLE declarations, it is not a
     // constant module
     if (this.getVariableDecls().length > 0) return false;
@@ -1136,7 +1138,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     visitor.postVisit(this);
   }
 
-  public final void print(int indent, int depth, boolean b) {
+  public final void print(int indent, int depth, boolean b, Errors errors) {
     if (depth <= 0) return;
 
     System.out.print(
@@ -1159,7 +1161,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
 
     String ret =
       "\n*ModuleNode: " + name + "  " + super.toString(depth) +
-      "  constant module: " + this.isConstant() +
+      "  constant module: " + this.isConstant(errors) +
       "  errors: " + (errors == null
                         ? "null"
                         : (errors.getNumErrors() == 0

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
@@ -154,7 +154,7 @@ public class NonLeafProofNode extends ProofNode {
     LevelNode[] ln = new LevelNode[steps.length + insts.length] ;
     System.arraycopy(steps, 0, ln, 0, steps.length) ;
     System.arraycopy(insts, 0, ln, steps.length, insts.length) ;
-    return this.levelCheckSubnodes(iter, ln) ;
+    return this.levelCheckSubnodes(iter, ln, errors) ;
    }
 
   /*

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
@@ -159,7 +159,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
 
     // Call the match method for the operator in this op application,
     // with this OpApplNode as argument
-    op.match( this, mn );
+    op.match( this, mn, errors );
   }
 
   /* constructor 3

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDeclNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDeclNode.java
@@ -75,7 +75,7 @@ public class OpDeclNode extends OpDefOrDeclNode {
 
   public final int getArity() { return this.arity; }
 
-  public final boolean match(OpApplNode oa, ModuleNode mn) {
+  public final boolean match(OpApplNode oa, ModuleNode mn, Errors errors) {
     ExprOrOpArgNode[] args = oa.getArgs();
 
     if (args == null || arity != args.length) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -734,12 +734,6 @@ public class OpDefNode extends OpDefOrDeclNode
    //              params[i].getArity() == ((OpArgNode)arg).getArity());
   }
 
-  /* This method shortens the match() method right after it */
-  private boolean errReport(Location loc, String s) {
-    errors.addError(loc, s);
-    return false;
-  }
-
   /**
    * This method is called at the end of OpApplNode constructors to
    * make sure the OpApplNode is correct by "matching" the argument
@@ -755,7 +749,7 @@ public class OpDefNode extends OpDefOrDeclNode
    * to oan (i.e args[]) match the argument pattern required by THIS
    * OpDefNode in terms of arity, etc.
    */
-  public final boolean match(OpApplNode oanParent, ModuleNode mn) throws AbortException {
+  public final boolean match(OpApplNode oanParent, ModuleNode mn, Errors errors) throws AbortException {
     ExprOrOpArgNode[] args       = oanParent.getArgs();  // arg expr's that THIS operator is being applied to
     boolean           result     = true;                 // Remains true unless an error is detected
     boolean           tempResult = true;
@@ -1035,7 +1029,7 @@ public class OpDefNode extends OpDefOrDeclNode
       LevelNode[] subs = new LevelNode[1] ;
       subs[0] = stepNode ;
       this.levelCorrect = this.stepNode.levelCheck(itr, errors);
-      return this.levelCheckSubnodes(itr, subs) ;
+      return this.levelCheckSubnodes(itr, subs, errors) ;
      }
 
     // Level check the body:

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -66,7 +66,7 @@ public class SubstInNode extends ExprNode {
      // The module being instantiated
 
   private SubstInNode(TreeNode treeNode, Subst[] subs, ExprNode expr,
-		     ModuleNode ingmn, ModuleNode edmn) {
+		     ModuleNode ingmn, ModuleNode edmn, Errors errors) {
     super(SubstInKind, treeNode);
     this.substs = subs;
     this.body = expr;
@@ -78,19 +78,19 @@ public class SubstInNode extends ExprNode {
     }
   }
 
-  public SubstInNode(final SubstInNode subst, final ExprNode expr) {
+  public SubstInNode(final SubstInNode subst, final ExprNode expr, Errors errors) {
 	  this(subst.stn, subst.getSubsts(), expr, subst.getInstantiatingModule(),
-				subst.getInstantiatedModule());
+				subst.getInstantiatedModule(), errors);
   }
   
-  public SubstInNode(final APSubstInNode subst, final ExprNode expr) {
+  public SubstInNode(final APSubstInNode subst, final ExprNode expr, Errors errors) {
 	  this(subst.stn, subst.getSubsts(), expr, subst.getInstantiatingModule(),
-				subst.getInstantiatedModule());
+				subst.getInstantiatedModule(), errors);
   }
   
   public SubstInNode(TreeNode treeNode, SubstInNode subst, ExprNode expr,
-		     ModuleNode ingmn, ModuleNode edmn) {
-	  this(treeNode, subst.getSubsts(), expr, ingmn, edmn);
+		     ModuleNode ingmn, ModuleNode edmn, Errors errors) {
+	  this(treeNode, subst.getSubsts(), expr, ingmn, edmn, errors);
   }
 
   /**
@@ -216,7 +216,7 @@ public class SubstInNode extends ExprNode {
    */
   @SuppressWarnings("unused")	// TODO final else block is dead code 
   final void addExplicitSubstitute(Context instanceCtxt, UniqueString lhs,
-                                   TreeNode stn, ExprOrOpArgNode sub) {
+                                   TreeNode stn, ExprOrOpArgNode sub, Errors errors) {
     int index;
     for (index = 0; index < this.substs.length; index++) {
       if (lhs == this.substs[index].getOp().getName()) break;
@@ -279,8 +279,9 @@ public class SubstInNode extends ExprNode {
    * implicitly subject to the substitution X <- X.  If that is not
    * possible, because X is not defined in the instantiating module,
    * then we have an error.
+   * @param errors Log into which to emit errors.
    */
-  final void matchAll(Vector<OpDeclNode> decls) {
+  final void matchAll(Vector<OpDeclNode> decls, Errors errors) {
     for (int i = 0; i < decls.size(); i++) {
       // Get the name of the i'th operator that must be substituted for
       UniqueString opName = decls.elementAt(i).getName();
@@ -432,7 +433,7 @@ public class SubstInNode extends ExprNode {
 //
 //    } // while
 
-    boolean isConstant = this.instantiatedModule.isConstant();
+    boolean isConstant = this.instantiatedModule.isConstant(errors);
       /*********************************************************************
       * It is not necessary to invoke levelCheck before invoking           *
       * isConstant.                                                        *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SymbolNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SymbolNode.java
@@ -60,7 +60,7 @@ public abstract class SymbolNode extends LevelNode {
    * Returns true iff the OpApplNode test has the proper types of
    * arguments for the operator as declared in module mn.
    */
-  public abstract boolean match(OpApplNode test, ModuleNode mn) throws AbortException ;
+  public abstract boolean match(OpApplNode test, ModuleNode mn, Errors errors) throws AbortException ;
 
   public final boolean occur(SymbolNode[] params) {
     for (int i = 0; i < params.length; i++) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/TheoremNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/TheoremNode.java
@@ -127,7 +127,7 @@ public class TheoremNode extends LevelNode {
     else { sub = new LevelNode[1];} ;
     if (this.def != null) {sub[0] = this.def;}
     else {sub[0] = this.theoremExprOrAssumeProve;} ;
-    boolean retVal = levelCheckSubnodes(iter, sub);
+    boolean retVal = levelCheckSubnodes(iter, sub, errors);
 
     if  (this.theoremExprOrAssumeProve == null) { return retVal; } ;
       /*********************************************************************
@@ -210,7 +210,7 @@ public class TheoremNode extends LevelNode {
    * Added 3 Mar 2009.                                                     *
    ************************************************************************/
    if (this.theoremExprOrAssumeProve.level == TemporalLevel){
-       LevelCheckTemporal(this.proof);
+       LevelCheckTemporal(this.proof, errors);
    };
    return retVal;
   }
@@ -230,7 +230,7 @@ public class TheoremNode extends LevelNode {
   * the CASE statement.                                                    *
   * Added 4 Mar 2009.                                                      *
   *************************************************************************/
-  private final static void LevelCheckTemporal(ProofNode pn) {
+  private final static void LevelCheckTemporal(ProofNode pn, Errors errors) {
      /**********************************************************************
      * Return if this is not a NonLeafProof.                               *
      **********************************************************************/
@@ -277,10 +277,10 @@ public class TheoremNode extends LevelNode {
                  oanode.stn.getLocation(),
                  "Non-constant CASE for temporal goal.") ;
              };
-           LevelCheckTemporal(tnode.getProof()) ;
+           LevelCheckTemporal(tnode.getProof(), errors) ;
          } else
          if (name == OP_qed) {
-           LevelCheckTemporal(tnode.getProof()) ;
+           LevelCheckTemporal(tnode.getProof(), errors) ;
          }
        }; // if (oanode != null)
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
@@ -277,7 +277,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
 
 //  public final ModuleNode getModuleNode() { return this.moduleNode; }
 
-  public final boolean match( OpApplNode test, ModuleNode mn ) {
+  public final boolean match( OpApplNode test, ModuleNode mn, Errors errors ) {
     /***********************************************************************
     * True iff the current object has the same arity as the node operator  *
     * of the OpApplNode test.                                              *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/UseOrHideNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/UseOrHideNode.java
@@ -90,7 +90,7 @@ public class UseOrHideNode extends LevelNode {
   * It was modified on 1 Jul 2009 to allow the use of expressions as       *
   * facts in a USE.                                                        *
   *************************************************************************/
-  public void factCheck() {
+  public void factCheck(Errors errors) {
     if (this.facts == null || this.getKind() == UseKind) { return; };
     for (int i = 0; i < this.facts.length; i++) {
       if (    (this.facts[i].getKind() == OpApplKind)
@@ -112,7 +112,7 @@ public class UseOrHideNode extends LevelNode {
     * checked.                                                             *
     ***********************************************************************/
     if (this.levelChecked >= iter) return this.levelCorrect;
-    return this.levelCheckSubnodes(iter, facts) ;
+    return this.levelCheckSubnodes(iter, facts, errors) ;
    }
 
   @Override

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Specs.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Specs.java
@@ -28,6 +28,7 @@ package tlc2.tool;
 import java.util.HashSet;
 import java.util.Iterator;
 
+import tla2sany.semantic.Errors;
 import tla2sany.semantic.ExprNode;
 import tla2sany.semantic.LevelNode;
 import tla2sany.semantic.OpDefNode;
@@ -85,7 +86,7 @@ public abstract class Specs {
 	    while (!subs.isEmpty())
 	    {
 	        SubstInNode sn = (SubstInNode) subs.car();
-	        res = new SubstInNode(sn, res);
+	        res = new SubstInNode(sn, res, new Errors());
 	        subs = subs.cdr();
 	    }
 	    return res;

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/coverage/OpApplNodeWrapperTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/coverage/OpApplNodeWrapperTest.java
@@ -32,6 +32,7 @@ import org.w3c.dom.Element;
 
 import tla2sany.parser.SyntaxTreeNode;
 import tla2sany.semantic.AbortException;
+import tla2sany.semantic.Errors;
 import tla2sany.semantic.ModuleNode;
 import tla2sany.semantic.OpApplNode;
 import tla2sany.semantic.SymbolNode;
@@ -162,7 +163,7 @@ public class OpApplNodeWrapperTest {
 		}
 
 		@Override
-		public boolean match(OpApplNode test, ModuleNode mn) throws AbortException {
+		public boolean match(OpApplNode test, ModuleNode mn, Errors errors) throws AbortException {
 			throw new UnsupportedOperationException("not implemented");
 		}
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/TBParTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/TBParTest.java
@@ -34,6 +34,7 @@ import org.w3c.dom.Element;
 
 import tla2sany.parser.SyntaxTreeNode;
 import tla2sany.semantic.AbortException;
+import tla2sany.semantic.Errors;
 import tla2sany.semantic.ModuleNode;
 import tla2sany.semantic.OpApplNode;
 import tla2sany.semantic.SymbolNode;
@@ -204,7 +205,7 @@ public class TBParTest {
 			}
 			
 			@Override
-			public boolean match(OpApplNode test, ModuleNode mn) throws AbortException {
+			public boolean match(OpApplNode test, ModuleNode mn, Errors errors) throws AbortException {
 				throw new UnsupportedOperationException("not implemented");
 			}
 			

--- a/tlatools/org.lamport.tlatools/test/tlc2/util/ContextTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/util/ContextTest.java
@@ -35,6 +35,7 @@ import org.w3c.dom.Element;
 
 import tla2sany.parser.SyntaxTreeNode;
 import tla2sany.semantic.AbortException;
+import tla2sany.semantic.Errors;
 import tla2sany.semantic.ModuleNode;
 import tla2sany.semantic.OpApplNode;
 import tla2sany.semantic.SymbolNode;
@@ -184,7 +185,7 @@ public class ContextTest {
 			return false;
 		}
 		
-		public boolean match(OpApplNode test, ModuleNode mn) throws AbortException {
+		public boolean match(OpApplNode test, ModuleNode mn, Errors errors) throws AbortException {
 			return false;
 		}
 


### PR DESCRIPTION
Reduce usage of static SemanticNode.errors field
Some additional places of use remain but this is a good incremental effort. Reduced usage count from 32 to 7.

This was all fairly mechanical (adding `Errors` parameters to methods) except for two places:
1. When constructing the SANY `Explorer` instance which is used to print out the SANY parse tree from the command line, provide `spec.getSemanticErrors()` which is the same `Errors` logging instance as the `SemanticNode.errors` field whose usage is being replaced
2.  In `tlatools/org.lamport.tlatools/src/tlc2/tool/Specs.java`, which is the only non-SANY part of the codebase calling into a `tla2sany.semantic` class constructor requiring an `Errors` instance (`SubstInNode`), I provide a new blank `Errors` instance; this means if an error is logged (which would only seem to happen if one of the other constructor parameters is null) it will be ignored, but that error is already being ignored because nothing checks the `SemanticNode.errors` field that far into the model-checking process.

[Refactoring][SANY]
Ref #891 