### PR TITLE
For any string `str`, `TLCGet("-D" \o str)` equal the value that the Java system property `str` equals.  Equals `"-D" \o str` if no system property by the name of `str` is defined.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TLCGetSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TLCGetSet.java
@@ -435,6 +435,8 @@ public class TLCGetSet implements ValueConstants {
 			} else if (TLCGlobals.simulator != null) {
 				return TLCGlobals.simulator.getAllValues();
 			}
+		} else if (sv.val.startsWith("-D")) {
+			return new StringValue(System.getProperty(sv.val.substring(2), sv.val.toString()));
 		}
 		throw new EvalException(EC.TLC_MODULE_TLCGET_UNDEFINED, String.valueOf(sv.val));
 	}

--- a/tlatools/org.lamport.tlatools/test-model/Github866.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github866.tla
@@ -92,6 +92,9 @@ PostCondition ==
 				  
 Constraint == x \in Nat
 ActionConstraint == x' \in Nat
+
+ASSUME TLCGet("-Dfile.separator") \in {"/", "\\"}
+ASSUME TLCGet("-Dasdiftb872w7t4ergvsivc") = "-Dasdiftb872w7t4ergvsivc"
 ==========================================================================
 ---------------------------- CONFIG Github866 ----------------------------
 SPECIFICATION Spec


### PR DESCRIPTION
[Feature][TLC]