### PR TITLE
SANY: Finally remove global static semantic error log

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -222,8 +222,6 @@ public class SANY {
     Errors      semanticErrors = spec.semanticErrors;
 
     try {
-      SemanticNode.setError(semanticErrors);
-      
       // Go through the semanticAnalysisVector, and generate the
       // semantic graph for each external module in it, adding at each
       // iteration what was generated (i.e. <context, node>) to

--- a/tlatools/org.lamport.tlatools/src/tla2sany/explorer/ExploreNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/explorer/ExploreNode.java
@@ -2,6 +2,8 @@
 package tla2sany.explorer;
 import java.util.Hashtable;
 
+import tla2sany.semantic.Errors;
+
 /**
  * implemented by the following classes (as well as various abstract and  superclasses):
  *
@@ -11,7 +13,7 @@ import java.util.Hashtable;
 
 public interface ExploreNode {
 
-  public String toString(int depth);
+  public String toString(int depth, Errors errors);
     /***********************************************************************
     * This displays the node as a string.  Apparently, the string should   *
     * begin with "\n" to start a new line.  The depth parameter is         *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
@@ -19,7 +19,6 @@ import java.util.StringTokenizer;
 import tla2sany.semantic.Errors;
 import tla2sany.semantic.ExternalModuleTable;
 import tla2sany.semantic.FormalParamNode;
-import tla2sany.semantic.Generator;
 import tla2sany.semantic.OpDefOrDeclNode;
 import tla2sany.semantic.SemanticNode;
 import tla2sany.semantic.SymbolNode;
@@ -102,7 +101,7 @@ public class Explorer {
 		// See if the object requested is already in the table
 		if ((obj = (ExploreNode) semNodesTable.get(icmd)) != null) {
 			// Print tree to depth of icmd2
-			System.out.println(((ExploreNode) obj).toString(depth));
+			System.out.println(((ExploreNode) obj).toString(depth, errors));
 			System.out.print("\n" + ((ExploreNode) obj).levelDataToString());
 		} else {
 			// object requested is not in semNodesTable
@@ -170,8 +169,7 @@ public class Explorer {
 			} else if (sym instanceof FormalParamNode) {
 				System.out.print("Module: " + ((FormalParamNode) sym).getModuleNode().getName());
 			}
-			System.out.println(((ExploreNode) (symbolVect.elementAt(i))).toString(100));
-			System.out.println();
+			System.out.println(((ExploreNode) (symbolVect.elementAt(i))).toString(100, errors) + "\n");
 		}
 
 	}

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
@@ -85,12 +85,12 @@ public class APSubstInNode extends LevelNode {
    * substitutions is to be produced.
    */
   public APSubstInNode(TreeNode treeNode, SymbolTable instancerST,
-		     Vector instanceeDecls, ModuleNode ingmn, ModuleNode edmn)
+		     Vector instanceeDecls, ModuleNode ingmn, ModuleNode edmn, Errors errors)
   throws AbortException {
     super(APSubstInKind, treeNode);
     this.instantiatingModule = ingmn;
     this.instantiatedModule = edmn;
-    constructSubst(instanceeDecls, instancerST, treeNode);
+    constructSubst(instanceeDecls, instancerST, treeNode, errors);
     this.body = null;
   }
 
@@ -136,7 +136,7 @@ public class APSubstInNode extends LevelNode {
    * VARIABLE OpDeclNode in vector v.
    */
   final void constructSubst(Vector instanceeDecls, SymbolTable instancerST,
-			    TreeNode treeNode)
+			    TreeNode treeNode, Errors errors)
   throws AbortException {
     Vector vtemp = new Vector();
 
@@ -173,7 +173,7 @@ public class APSubstInNode extends LevelNode {
 	  // an OpApplNode with zero arguments
           vtemp.addElement(
              new Subst(decl,
-		       new OpApplNode(symb, new ExprOrOpArgNode[0], treeNode, instantiatingModule),
+		       new OpApplNode(symb, new ExprOrOpArgNode[0], treeNode, instantiatingModule, errors),
 		       null, true));
         }
 	else {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
@@ -401,11 +401,11 @@ public class APSubstInNode extends LevelNode {
 //  }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
     String ret = "\n*APSubstInNode: "
-                 + super.toString(depth)
+                 + super.toString(depth, errors)
 	         + "\n  instantiating module: " + instantiatingModule.getName()
                  + ", instantiated module: " + instantiatedModule.getName()
                  + Strings.indent(2, "\nSubstitutions:");
@@ -414,7 +414,7 @@ public class APSubstInNode extends LevelNode {
         ret += Strings.indent(2,
                       Strings.indent(2, "\nSubst:" +
                         (this.substs[i] != null ?
-                         Strings.indent(2, this.substs[i].toString(depth-1)) :
+                         Strings.indent(2, this.substs[i].toString(depth-1, errors)) :
                          "<null>")));
       }
     }
@@ -422,7 +422,7 @@ public class APSubstInNode extends LevelNode {
       ret += Strings.indent(2, "<null>");
     }
     ret += Strings.indent(2, "\nBody:"
-			  + Strings.indent(2, (body == null ? "<null>" : body.toString(depth-1))));
+			  + Strings.indent(2, (body == null ? "<null>" : body.toString(depth-1, errors))));
     return ret;
   }
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeNode.java
@@ -153,20 +153,20 @@ public AssumeNode(TreeNode stn, ExprNode expr, ModuleNode mn,
    * of the tree that is displayed.
    */
   @Override
-  public final String toString (int depth) {
+  public final String toString (int depth, Errors errors) {
     if (depth <= 0) return "";
     String res =
        Strings.indent(
          2,
-         "\n*AssumeNode " + super.toString( depth ) +
+         "\n*AssumeNode " + super.toString( depth, errors ) +
 //                        "   local: " + localness +
          ((assumeExpr != null)  ?
-             Strings.indent(2,assumeExpr.toString(depth-1)) : "" ));
+             Strings.indent(2,assumeExpr.toString(depth-1, errors)) : "" ));
    if (def != null) {
       res = res + Strings.indent(
                       4,
                       "\n def: " +
-                      Strings.indent(2, this.def.toString(depth-1)));
+                      Strings.indent(2, this.def.toString(depth-1, errors)));
      } ;
     return res ;
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeProveNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AssumeProveNode.java
@@ -372,21 +372,21 @@ public class AssumeProveNode extends LevelNode {
    * parameter is a bound on the depth of the portion of the tree that is displayed.
    */
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String assumeStr = "" ;
     int i = 0 ;
     while (i < assumes.length) {
-      assumeStr = assumeStr + Strings.indent(4, assumes[i].toString(depth-1)) ;
+      assumeStr = assumeStr + Strings.indent(4, assumes[i].toString(depth-1, errors)) ;
       i = i+1;
      } ;
     String goalStr = "null" ;
-    if (goal != null) {goalStr = Strings.indent(4, goal.toString(1));};
+    if (goal != null) {goalStr = Strings.indent(4, goal.toString(1, errors));};
     return "\n*AssumeProveNode: "
-             + super.toString(depth)  // Seems to print stn.getLocation() where stn is the
+             + super.toString(depth, errors)  // Seems to print stn.getLocation() where stn is the
                                       // corresponding syntax tree node.
              + "\n  " + (isBoxAssumeProve ? "[]" : "") + "Assumes: " + assumeStr
-             + "\n  " + (isBoxAssumeProve ? "[]" : "") + "Prove: " + Strings.indent(4, prove.toString(depth-1))
+             + "\n  " + (isBoxAssumeProve ? "[]" : "") + "Prove: " + Strings.indent(4, prove.toString(depth-1, errors))
              + "\n  Goal: "  + goalStr
              + ((suffices) ? "\n  SUFFICES" : "") ;
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AtNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/AtNode.java
@@ -165,9 +165,9 @@ public class AtNode extends ExprNode {
    * parameter is a bound on the depth of the portion of the tree that is displayed.
    */
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
-    return "\n*AtNode: " + super.toString(depth) +
+    return "\n*AtNode: " + super.toString(depth, errors) +
            Strings.indent(2, "\nExceptRef: " + exceptRef.getUid() +
                              "\nExceptComponent: " + exceptComponentRef.getUid());
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Context.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Context.java
@@ -472,7 +472,7 @@ public class Context implements ExploreNode {
    */
   public String levelDataToString() { return "Dummy level string"; }
 
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     return "Please use Context.getContextEntryStringVector()" +
       " instead of Context.toString()";
   }
@@ -483,9 +483,9 @@ public class Context implements ExploreNode {
   * When trying to use SANY's -d (debug) option, this method throws a      *
   * NullPointerException if the spec has an inner module.  See the         *
   * comment in the walkGraph method of this file for a bit more            *
-  * information.                                                           *
+  * information.                                                           
   *************************************************************************/
-  public Vector<String> getContextEntryStringVector(int depth, boolean b) {
+  public Vector<String> getContextEntryStringVector(int depth, boolean b, Errors errors) {
     Vector<String> ctxtEntries = new Vector<>(100);  // vector of Strings
     Context naturalsContext =
                exMT.getContext(UniqueString.uniqueStringOf("Naturals"));
@@ -504,7 +504,7 @@ public class Context implements ExploreNode {
         SymbolNode symbNode  = ((Pair)(table.get(key))).info;
 	ctxtEntries.addElement("\nContext Entry: " + key.toString() + "  "
                     + String.valueOf(((SemanticNode)symbNode).myUID).toString() + " "
-                    + Strings.indentSB(2,(symbNode.toString(depth-1))));
+                    + Strings.indentSB(2,(symbNode.toString(depth-1, errors))));
       }
       p = p.link;
     }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DecimalNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DecimalNode.java
@@ -130,9 +130,9 @@ public class DecimalNode extends ExprNode {
    * of the tree that is displayed.
    */
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
-    return( "\n*DecimalNode" + super.toString(depth) + "Mantissa: "
+    return( "\n*DecimalNode" + super.toString(depth, errors) + "Mantissa: "
             + mantissa + "; exponent: " + exponent
             + "; big value: " + (bigVal != null ? bigVal.toString() : "<null>")
             + "\n; image = " + image

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DefStepNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/DefStepNode.java
@@ -81,13 +81,13 @@ public class DefStepNode extends LevelNode {
    }
   
   @Override
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String ret = "\n*DefStepNode:\n"
-                  + super.toString(depth)
+                  + super.toString(depth, errors)
                   + Strings.indent(2, "\ndefs:") ;
     for (int i = 0 ; i < this.defs.length; i++) {
-        ret += Strings.indent(4, this.defs[i].toString(depth-1)) ;
+        ret += Strings.indent(4, this.defs[i].toString(depth-1, errors)) ;
       } ;
     return ret;
    }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ExternalModuleTable.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ExternalModuleTable.java
@@ -55,11 +55,11 @@ public class ExternalModuleTable implements ExploreNode {
       if (ctxt != null)      ctxt.walkGraph(moduleNodesTable, visitor);
     } // end walkGraph()
 
-    public String toString(int depth) {
+    public String toString(int depth, Errors errors) {
       if (depth <= 0) return "";
       
       if (moduleNode != null) {
-	return Strings.indent(2, "\nModule: " + Strings.indent(2,moduleNode.toString(depth)) );
+	return Strings.indent(2, "\nModule: " + Strings.indent(2,moduleNode.toString(depth, errors)) );
       } else {
 	return Strings.indent(2, "\nModule: " + Strings.indent(2, "\n***Null ExternalModuleTable entry; " + 
 							       "module contained error and was not created."));
@@ -180,14 +180,14 @@ public class ExternalModuleTable implements ExploreNode {
    */
   public String levelDataToString() { return "Dummy level string"; }
 
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
     String ret = "";
     for (int i = 0; i < moduleNodeVector.size(); i++) {
       ModuleNode mn = (ModuleNode)moduleNodeVector.elementAt(i);
       if (mn != null) {
-        ret += Strings.indent(2, "\nModule: " + Strings.indent(2, mn.toString(depth)) );
+        ret += Strings.indent(2, "\nModule: " + Strings.indent(2, mn.toString(depth, errors)) );
       } else {
 	String str = "\n***Null ExternalModuleTable entry; module contained error and was not created.";
 	ret += Strings.indent(2, "\nModule: " + Strings.indent(2, str));

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/FormalParamNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/FormalParamNode.java
@@ -126,10 +126,10 @@ public class FormalParamNode extends SymbolNode {
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     return ("\n*FormalParamNode: " + this.getName().toString() +
-	    "  " + super.toString(depth) + "  arity: " + arity);
+	    "  " + super.toString(depth, errors) + "  arity: " + arity);
   }
 
   protected String getNodeRef() {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
@@ -290,7 +290,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		public final String toString(int n) {
 			String ret = "compound ID: " + compoundID.toString() + "\nargs: " + args.length + "\n";
 			for (int i = 0; i < args.length; i++) {
-				ret += Strings.indent(2, args[i].toString(n));
+				ret += Strings.indent(2, args[i].toString(n, errors));
 			}
 			return ret;
 		}

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
@@ -1603,7 +1603,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 					/*****************************************************************
 					 * Formal parameter eoag is an ordinary (non-operator) parameter. *
 					 *****************************************************************/
-					eoag = new OpApplNode(newpm, new ExprNode[0], sel.selSTN, cm);
+					eoag = new OpApplNode(newpm, new ExprNode[0], sel.selSTN, cm, errors);
 				} else {
 					/*****************************************************************
 					 * Formal parameter eoag is an operator parameter. *
@@ -1618,7 +1618,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			SymbolNode curSymNode = (SymbolNode) curNode;
 			curNode = new OpApplNode(curSymNode, temp, // opDefArgArray,
 					sel.selSTN, // TreeNode
-					cm);
+					cm, errors);
 
 		}
 		;// if (prevMode == FindingOpName) ...
@@ -1665,7 +1665,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 				}
 				; // for
 				curNode = new OpApplNode(curOpArgNode.getOp(), opDefArgArray, sel.selSTN, // TreeNode
-						cm);
+						cm, errors);
 			}
 			; // if (params.size() + ...)
 
@@ -1747,7 +1747,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 				/*******************************************************************
 				 * expectedArity = 0 *
 				 *******************************************************************/
-				OpApplNode oan = new OpApplNode(curSymbolNode, opDefArgArray, sel.selSTN, cm);
+				OpApplNode oan = new OpApplNode(curSymbolNode, opDefArgArray, sel.selSTN, cm, errors);
 				oan.subExpressionOf = subExprOf;
 				return oan;
 			} // if (expectedArity > 0)
@@ -1887,7 +1887,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		}
 		;
 
-		OpApplNode oan = new OpApplNode(newLambda, allArgsArray, sel.selSTN, cm);
+		OpApplNode oan = new OpApplNode(newLambda, allArgsArray, sel.selSTN, cm, errors);
 		oan.subExpressionOf = subExprOf;
 		return oan;
 
@@ -2844,7 +2844,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 			sns[0] = generateExpression(children[0], cm);
 			sns[1] = generateExpression(children[2], cm);
-			return new OpApplNode(opn, sns, treeNode, cm);
+			return new OpApplNode(opn, sns, treeNode, cm, errors);
 
 		case N_PrefixExpr:
 			// 1 get gen operator node
@@ -2863,7 +2863,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			}
 
 			sns[0] = generateExpression(children[1], cm);
-			return new OpApplNode(opn, sns, treeNode, cm); // constructor 2
+			return new OpApplNode(opn, sns, treeNode, cm, errors); // constructor 2
 
 		case N_PostfixExpr:
 			genID = generateGenID(children[1], cm);
@@ -2877,7 +2877,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			}
 
 			sns[0] = generateExpression(children[0], cm);
-			return new OpApplNode(opn, sns, treeNode, cm); // constructor 2
+			return new OpApplNode(opn, sns, treeNode, cm, errors); // constructor 2
 
 		case N_Times: // or cartesian product
 			sns = new ExprNode[(children.length + 1) / 2];
@@ -4383,7 +4383,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		// return an OpApplNode constructed from the fully-qualified
 		// operator and the final arg list
-		return new OpApplNode(genID.getFullyQualifiedOp(), finalArgList, syntaxTreeNode, cm);
+		return new OpApplNode(genID.getFullyQualifiedOp(), finalArgList, syntaxTreeNode, cm, errors);
 	} // end generateOpAppl()
 
 	/**
@@ -4885,7 +4885,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		// must be passed to this constructor because with a default substitution
 		// LHS<-RHS the LHS is resolved in the instanceeCtxt, (done
 		// in the previous line) and the RHS is resolved in the instancerST.
-		SubstInNode substIn = new SubstInNode(treeNode, instancerST, decls, mn, instanceeModule);
+		SubstInNode substIn = new SubstInNode(treeNode, instancerST, decls, mn, instanceeModule, errors);
 
 		// For each explicit substitution in the syntax tree, overwrite or add
 		// the corresponding default entry in SubstInNode just created
@@ -5762,7 +5762,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 								ExprNode[] nopArgs = new ExprNode[1];
 								nopArgs[0] = prevRHS;
 								sns[0] = new OpApplNode(OP_nop, nopArgs, curLHS, cm);
-								body = new OpApplNode(opn, sns, curExpr, cm);
+								body = new OpApplNode(opn, sns, curExpr, cm, errors);
 							} // if ( prevIsInfix ...)
 							else { // this is not an @-step
 								body = generateExpression(curExpr, cm);

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/InstanceNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/InstanceNode.java
@@ -413,17 +413,17 @@ public class InstanceNode extends LevelNode {
     visitor.postVisit(this);
   }
 
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
-    String ret = "\n*InstanceNode " + super.toString(depth) +
+    String ret = "\n*InstanceNode " + super.toString(depth, errors) +
                  "  InstanceName = " + (name == null ? "(none)" : name.toString()) +
                  Strings.indent(2, "\nModule: " + module.getName())
    +             Strings.indent(2, "\nlocal: " + this.local);
     if (params.length > 0) {
       ret += Strings.indent(2,"\nInstance parameters:");
       for ( int i = 0; i < params.length; i++ ) {
-        ret += Strings.indent(4,params[i].toString(depth-1));
+        ret += Strings.indent(4,params[i].toString(depth-1, errors));
       }
     }
 
@@ -433,7 +433,7 @@ public class InstanceNode extends LevelNode {
         ret += Strings.indent(2,
                               Strings.indent(2, "\nSubst:" +
                                              (substs[i] != null ?
-                                              Strings.indent(2, substs[i].toString(depth-1)) :
+                                              Strings.indent(2, substs[i].toString(depth-1, errors)) :
                                               "<null>")));
       }
     }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LabelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LabelNode.java
@@ -296,19 +296,19 @@ public class LabelNode extends ExprNode
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
-    String ret = "\n*LabelNode: " + super.toString(depth);
+    String ret = "\n*LabelNode: " + super.toString(depth, errors);
     ret += Strings.indent(2, "\nname: " + name.toString()) ;
     for (int i = 0; i < params.length; i++) {
       ret += Strings.indent(2,
                             "\nparam[" + i + "]:" +
                                  Strings.indent(2,
-                                                params[i].toString(depth-1)));
+                                                params[i].toString(depth-1, errors)));
      } ;
     ret += Strings.indent(2, "\nisAssumeProve: " + isAssumeProve) ;
     ret += Strings.indent(2, "\nBody:" +
-                               Strings.indent(2, body.toString(depth-1)));
+                               Strings.indent(2, body.toString(depth-1, errors)));
 
     /***********************************************************************
     * The following is the same for all classes that implement the         *
@@ -324,10 +324,10 @@ public class LabelNode extends ExprNode
     else {ret += "\n  Labels: null";} ;
     if (this.subExpressionOf != null) {
        ret += Strings.indent(2, "\nsubExpressionOf: " +
-                  Strings.indent(2, this.subExpressionOf.toString(1))) ;} ;
+                  Strings.indent(2, this.subExpressionOf.toString(1, errors))) ;} ;
 
     if (goal != null) {
-      ret += "\n goal: " + Strings.indent(4, this.goal.toString(1)) +
+      ret += "\n goal: " + Strings.indent(4, this.goal.toString(1, errors)) +
              "\n goalClause: " + goalClause ;
      } ;
     return ret;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LeafProofNode.java
@@ -117,17 +117,17 @@ public class LeafProofNode extends ProofNode {
    }
 
   @Override
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String ret = "\n*LeafProofNode:\n"
-                  + super.toString(depth)
+                  + super.toString(depth, errors)
                   + Strings.indent(2, "\nfacts:") ;
     for (int i = 0 ; i < this.facts.length; i++) {
-        ret += Strings.indent(4, this.facts[i].toString(depth-1)) ;
+        ret += Strings.indent(4, this.facts[i].toString(depth-1, errors)) ;
       } ;
     ret += Strings.indent(2, "\ndefs:") ;
     for (int i = 0 ; i < this.defs.length; i++) {
-        ret += Strings.indent(4, this.defs[i].toString(depth-1)) ;
+        ret += Strings.indent(4, this.defs[i].toString(depth-1, errors)) ;
       } ;
     ret += Strings.indent(2, "\nomitted: " + this.omitted)
             + Strings.indent(2, "\nonlyFlag: " + this.isOnly);

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
@@ -263,14 +263,14 @@ implements ExploreNode, LevelConstants {
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
-    String ret = "\n*LetInNode: " + super.toString(depth);
+    String ret = "\n*LetInNode: " + super.toString(depth, errors);
     /***********************************************************************
     * Print context.                                                       *
     ***********************************************************************/
-    Vector contextEntries = context.getContextEntryStringVector(1,false);
+    Vector contextEntries = context.getContextEntryStringVector(1,false, errors);
       /*********************************************************************
       * The depth argument 1 of getContextEntryStringVector causes only    *
       * the name and node uid of the entry and not the node itself to be   *
@@ -292,7 +292,7 @@ implements ExploreNode, LevelConstants {
 //    for (int i = 0; i < opDefs.length; i++) {
 //      ret += Strings.indent(2,"\nDef:" + Strings.indent(2, opDefs[i].toString(depth-1)));
 //    }
-    ret += Strings.indent(2, "\nBody:" + Strings.indent(2, body.toString(depth-1)));
+    ret += Strings.indent(2, "\nBody:" + Strings.indent(2, body.toString(depth-1, errors)));
     return ret;
   }
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LevelNode.java
@@ -109,7 +109,6 @@ public int levelChecked   = 0 ;
    * Check whether an expr or opArg is level correct, and if so,
    * calculates the level information for the expression. Returns
    * true iff this is level correct.
- * @param errors TODO
    */
   public boolean levelCheck(int iter, Errors errors) {
     /***********************************************************************
@@ -354,7 +353,7 @@ public int levelChecked   = 0 ;
      * Abstract method for subclasses of LevelNode to add their information
      * */
   protected Element getLevelElement(Document doc, SymbolContext context) {
-      throw new UnsupportedOperationException("xml export is not yet supported for: " + getClass() + " with toString: " + toString(100));
+      throw new UnsupportedOperationException("xml export is not yet supported for: " + getClass());
     }
 
 }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
@@ -1159,25 +1159,25 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     if (depth <= 0) return;
 
     System.out.print(
-      "*ModuleNode: " + name + "  " + super.toString(depth)
+      "*ModuleNode: " + name + "  " + super.toString(depth, errors)
       + "  errors: " + (errors == null
                            ? "null"
                            : (errors.getNumErrors() == 0
                                  ? "none"
                                  : "" +errors.getNumErrors())));
 
-    Vector contextEntries = ctxt.getContextEntryStringVector(depth-1, b);
+    Vector contextEntries = ctxt.getContextEntryStringVector(depth-1, b, errors);
     for (int i = 0; i < contextEntries.size(); i++) {
       System.out.print(Strings.indent(2+indent, (String)contextEntries.elementAt(i)) );
     }
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
     String ret =
-      "\n*ModuleNode: " + name + "  " + super.toString(depth) +
+      "\n*ModuleNode: " + name + "  " + super.toString(depth, errors) +
       "  constant module: " + this.isConstant(errors) +
       "  errors: " + (errors == null
                         ? "null"
@@ -1185,7 +1185,7 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
                               ? "none"
                               : "" + errors.getNumErrors()));
 
-    Vector contextEntries = ctxt.getContextEntryStringVector(depth-1,false);
+    Vector contextEntries = ctxt.getContextEntryStringVector(depth-1,false, errors);
     if (contextEntries != null) {
       for (int i = 0; i < contextEntries.size(); i++) {
         if (contextEntries.elementAt(i) != null) {
@@ -1204,28 +1204,28 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     if ( instanceVec.size() > 0 ) {
       ret += Strings.indent(2, "\nInstantiations:");
       for (int i = 0; i < instanceVec.size(); i++) {
-        ret += Strings.indent(4, ((InstanceNode)(instanceVec.elementAt(i))).toString(1));
+        ret += Strings.indent(4, ((InstanceNode)(instanceVec.elementAt(i))).toString(1, errors));
       }
     }
 
     if ( assumptionVec.size() > 0 ) {
       ret += Strings.indent(2, "\nAssumptions:");
       for (int i = 0; i < assumptionVec.size(); i++) {
-        ret += Strings.indent(4, ((AssumeNode)(assumptionVec.elementAt(i))).toString(1));
+        ret += Strings.indent(4, ((AssumeNode)(assumptionVec.elementAt(i))).toString(1, errors));
       }
     }
 
     if ( theoremVec.size() > 0 ) {
       ret += Strings.indent(2, "\nTheorems:");
       for (int i = 0; i < theoremVec.size(); i++) {
-        ret += Strings.indent(4, ((TheoremNode)(theoremVec.elementAt(i))).toString(1));
+        ret += Strings.indent(4, ((TheoremNode)(theoremVec.elementAt(i))).toString(1, errors));
       }
     }
 
     if ( topLevelVec.size() > 0 ) {
       ret += Strings.indent(2, "\ntopLevelVec: ");
       for (int i = 0; i < topLevelVec.size(); i++) {
-        ret += Strings.indent(4, ((LevelNode) topLevelVec.elementAt(i)).toString(1));
+        ret += Strings.indent(4, ((LevelNode) topLevelVec.elementAt(i)).toString(1, errors));
         }
       };
     return ret;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NewSymbNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NewSymbNode.java
@@ -181,18 +181,18 @@ public class NewSymbNode extends LevelNode {
    }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String setString = "" ;
     if (this.set != null) {
       setString = Strings.indent(2,
-                   "\nSet:" + Strings.indent(2, this.set.toString(depth-1)));
+                   "\nSet:" + Strings.indent(2, this.set.toString(depth-1, errors)));
      }
     return "\n*NewSymbNode: " +
-	    "  " + super.toString(depth) +
+	    "  " + super.toString(depth, errors) +
              Strings.indent(2, "\nKind: " + this.getKind() +
                           "\nopDeclNode:" + Strings.indent(2,
-                                this.opDeclNode.toString(depth-1)) +
+                                this.opDeclNode.toString(depth-1, errors)) +
              setString);
    }
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
@@ -195,20 +195,20 @@ public class NonLeafProofNode extends ProofNode {
    }
 
   @Override
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String ret = "\n*ProofNode:\n"
-                  + super.toString(depth)
+                  + super.toString(depth, errors)
                   + Strings.indent(2, "\nsteps:") ;
     for (int i = 0 ; i < this.steps.length; i++) {
-        ret += Strings.indent(4, this.steps[i].toString(depth-1)) ;
+        ret += Strings.indent(4, this.steps[i].toString(depth-1, errors)) ;
       } ;
 
     /***********************************************************************
     * The following code for printing the context field copied without     *
     * understanding from ModuleNode.java.                                  *
     ***********************************************************************/
-    Vector contextEntries = context.getContextEntryStringVector(depth-1,false);
+    Vector contextEntries = context.getContextEntryStringVector(depth-1,false, errors);
     if (contextEntries != null) {
       for (int i = 0; i < contextEntries.size(); i++) {
         if (contextEntries.elementAt(i) != null) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NumeralNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NumeralNode.java
@@ -132,10 +132,10 @@ public class NumeralNode extends ExprNode {
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
-    return("\n*NumeralNode: " + super.toString(depth) + " Value: " + value +
+    return("\n*NumeralNode: " + super.toString(depth, errors) + " Value: " + value +
 	   (bigValue != null ? ("; big value: " + bigValue.toString()) : "") +
 	   "; image: " + image);
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
@@ -1212,7 +1212,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
   }
 
   // Used in implementation of toString() below
-  private String toStringBody(int depth) {
+  private String toStringBody(int depth, Errors errors) {
     if (depth <= 1) return "";
 
     String ret;
@@ -1227,7 +1227,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
     if (unboundedBoundSymbols!=null && unboundedBoundSymbols.length > 0) {
       ret += "\nUnbounded bound symbols:  ";
       for (int i = 0; i < unboundedBoundSymbols.length; i++) {
-        ret += Strings.indent(2,unboundedBoundSymbols[i].toString(depth-1));
+        ret += Strings.indent(2,unboundedBoundSymbols[i].toString(depth-1, errors));
       }
     }
 
@@ -1237,7 +1237,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
         if (boundedBoundSymbols[i] != null && boundedBoundSymbols[i].length > 0) {
           for (int j = 0; j < boundedBoundSymbols[i].length; j++) {
             ret += Strings.indent(2, "\n[" + i + "," + j + "]" +
-                      Strings.indent(2,boundedBoundSymbols[i][j].toString(depth-1)));
+                      Strings.indent(2,boundedBoundSymbols[i][j].toString(depth-1, errors)));
           }
         }
       }
@@ -1247,7 +1247,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
       ret += "\nRanges: ";
       for (int i = 0; i < ranges.length; i++)
         ret += Strings.indent(2,(ranges[i] != null ?
-                                     ranges[i].toString(depth-1) : "null" ));
+                                     ranges[i].toString(depth-1, errors) : "null" ));
     }
 
     if (tupleOrs != null && tupleOrs.length > 0 /* && tupleOrs[0] */) {
@@ -1262,7 +1262,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
         ret += "\nOperands: " + operands.length;
         for (int i = 0; i < operands.length; i++) {
           ret += Strings.indent(2,
-                    (operands[i] == null ? "\nnull" : operands[i].toString(depth-1)));
+                    (operands[i] == null ? "\nnull" : operands[i].toString(depth-1, errors)));
         }
       }
     }
@@ -1277,16 +1277,16 @@ public class OpApplNode extends ExprNode implements ExploreNode {
    * parameter is a bound on the depth of the portion of the tree that is displayed.
    */
   @Override
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String sEO = "" ;
     if (this.subExpressionOf != null) {
      sEO = Strings.indent(2,
               "\nsubExpressionOf: " +
-              Strings.indent(2, this.subExpressionOf.toString(1))) ;} ;
-    return "\n*OpApplNode: " + operator.getName() + "  " + super.toString(depth+1)
+              Strings.indent(2, this.subExpressionOf.toString(1, errors))) ;} ;
+    return "\n*OpApplNode: " + operator.getName() + "  " + super.toString(depth+1, errors)
            + "  errors: " + (errors != null ? "non-null" : "null")
-           + toStringBody(depth) + sEO ;
+           + toStringBody(depth, errors) + sEO ;
   }
 
     @Override

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
@@ -147,7 +147,7 @@ public class OpApplNode extends ExprNode implements ExploreNode {
    * Generator.
    */
   public OpApplNode(SymbolNode op, ExprOrOpArgNode[] oprands, TreeNode stn,
-                    ModuleNode mn) throws AbortException {
+                    ModuleNode mn, Errors errors) throws AbortException {
     super(OpApplKind, stn);
     this.operator = op;
     this.operands = oprands;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpArgNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpArgNode.java
@@ -133,11 +133,11 @@ public class OpArgNode extends ExprOrOpArgNode {
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
     return "\n*OpArgNode: " + ( name != null ? name.toString() : "null") +
-      "  " + super.toString(depth) +
+      "  " + super.toString(depth, errors) +
       "  arity: " + arity +
       "  op: " + (op != null ? "" + ((SemanticNode)op).getUid() : "null" );
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDeclNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDeclNode.java
@@ -162,9 +162,9 @@ public class OpDeclNode extends OpDefOrDeclNode {
 	}
 
   @Override
-  public final String toString (int depth) {
+  public final String toString (int depth, Errors errors) {
     if (depth <= 0) return "";
-    return "\n*OpDeclNode: " + this.getName() + "  " + super.toString(depth)
+    return "\n*OpDeclNode: " + this.getName() + "  " + super.toString(depth, errors)
            + "\n  originallyDefinedInModule: " +
                             (originallyDefinedInModule != null
                              ? originallyDefinedInModule.getName().toString()

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -1365,12 +1365,12 @@ public class OpDefNode extends OpDefOrDeclNode
    * of the tree that is displayed.
    */
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
     String ret = "\n*OpDefNode: " + this.getName().toString()
                 + "\n  "
-                + super.toString(depth)
+                + super.toString(depth, errors)
                 + "\n  local: " + local
                 + "\n  letInLevel: " + letInLevel
                 + "\n  inRecursive: " + inRecursive
@@ -1387,7 +1387,7 @@ public class OpDefNode extends OpDefOrDeclNode
                           " (uid: " + originallyDefinedInModule.myUID + ")"))
                 + ((stepNode == null) ? "" :
                         ("\n  stepNode: " +
-                          Strings.indent(4,stepNode.toString(depth-3))))
+                          Strings.indent(4,stepNode.toString(depth-3, errors))))
                                                    ;
 
 //  nextDependency has been removed.
@@ -1398,7 +1398,7 @@ public class OpDefNode extends OpDefOrDeclNode
       String tempString = "\n  Formal params: " + params.length;
       for (int i = 0; i < params.length; i++) {
         tempString += Strings.indent(4, ((params[i] != null)
-                                         ? params[i].toString(depth-1)
+                                         ? params[i].toString(depth-1, errors)
                                          : "\nnull"));
       }
       ret += tempString;
@@ -1417,7 +1417,7 @@ public class OpDefNode extends OpDefOrDeclNode
       }
     }
     if (body != null) {
-      ret += Strings.indent(2,"\nBody:" + Strings.indent(2,body.toString(depth-1)));
+      ret += Strings.indent(2,"\nBody:" + Strings.indent(2,body.toString(depth-1, errors)));
     }
     else {
       ret += Strings.indent(2,"\nBody: null");

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefOrDeclNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefOrDeclNode.java
@@ -73,9 +73,9 @@ public abstract class OpDefOrDeclNode extends SymbolNode {
    * toString() method; part of implementation of ExploreNode
    * interface
    */
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
-    return super.toString(depth) 
+    return super.toString(depth, errors) 
            + "  arity: " + arity 
            + "  orgDefInModule: " + (originallyDefinedInModule != null 
                              ? originallyDefinedInModule.getName().toString() 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SemanticNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SemanticNode.java
@@ -380,7 +380,7 @@ public abstract class SemanticNode
    * of SemanticNode for implementing ExploreNode interface; the depth
    * parameter is a bound on the depth of the tree that is converted to String.
    */
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     return ("  uid: " + myUID +
 	    "  kind: " + (kind == -1 ? "<none>" : kinds[kind])
@@ -505,7 +505,7 @@ public abstract class SemanticNode
      */
 
   protected Element getSemanticElement(Document doc, tla2sany.xml.SymbolContext context) {
-      throw new UnsupportedOperationException("xml export is not yet supported for: " + getClass() + " with toString: " + toString(100));
+      throw new UnsupportedOperationException("xml export is not yet supported for: " + getClass());
     }
 
     /**

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SemanticNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SemanticNode.java
@@ -41,8 +41,6 @@ public abstract class SemanticNode
 
   private static final AtomicInteger uid = new AtomicInteger();  // the next unique ID for any semantic node
 
-  protected static Errors errors;
-
   public    final int      myUID;    // the unique ID of THIS semantic node
   public    TreeNode stn;      // the concrete syntax tree node associated with THIS semantic node
   private   Object[] tools;    // each tool has a location in this array where
@@ -56,8 +54,6 @@ public abstract class SemanticNode
     this.stn = stn;
     this.tools = EmptyArr;
   }
-
-  public static void setError(Errors errs) { errors = errs; }
 
   public static String levelToString(int level) {
     switch (level) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/StringNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/StringNode.java
@@ -125,9 +125,9 @@ public class StringNode extends ExprNode implements ExploreNode {
    }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
-    return "\n*StringNode: " + super.toString(depth)
+    return "\n*StringNode: " + super.toString(depth, errors)
                              + "Value: '" + PrintVersion(value.toString()) +
                              "'" + " Length: " + value.length();
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Subst.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Subst.java
@@ -250,10 +250,10 @@ public class Subst implements LevelConstants, ASTConstants, ExploreNode, XMLExpo
     visitor.postVisit(this);
   }
 
-  public final String toString(int depth) {
-    return "\nOp: " + Strings.indent(2,(op!=null ? op.toString(depth-1) :
+  public final String toString(int depth, Errors errors) {
+    return "\nOp: " + Strings.indent(2,(op!=null ? op.toString(depth-1, errors) :
                                            "<null>" )) +
-           "\nExpr: " + Strings.indent(2,(expr!=null ? expr.toString(depth-1) : "<null>"));
+           "\nExpr: " + Strings.indent(2,(expr!=null ? expr.toString(depth-1, errors) : "<null>"));
   }
 
   public Element export(Document doc, SymbolContext context) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -98,12 +98,12 @@ public class SubstInNode extends ExprNode {
    * substitutions is to be produced.
    */
   public SubstInNode(TreeNode treeNode, SymbolTable instancerST,
-		     Vector<OpDeclNode> instanceeDecls, ModuleNode ingmn, ModuleNode edmn)
+		     Vector<OpDeclNode> instanceeDecls, ModuleNode ingmn, ModuleNode edmn, Errors errors)
   throws AbortException {
     super(SubstInKind, treeNode);
     this.instantiatingModule = ingmn;
     this.instantiatedModule = edmn;
-    constructSubst(instanceeDecls, instancerST, treeNode);
+    constructSubst(instanceeDecls, instancerST, treeNode, errors);
     this.body = null;
   }
 
@@ -149,7 +149,7 @@ public class SubstInNode extends ExprNode {
    * VARIABLE OpDeclNode in vector v.
    */
   final void constructSubst(Vector<OpDeclNode> instanceeDecls, SymbolTable instancerST,
-			    TreeNode treeNode)
+			    TreeNode treeNode, Errors errors)
   throws AbortException {
     Vector<Subst> vtemp = new Vector<>();
 
@@ -186,7 +186,7 @@ public class SubstInNode extends ExprNode {
 	  // an OpApplNode with zero arguments
           vtemp.addElement(
              new Subst(decl,
-		       new OpApplNode(symb, new ExprOrOpArgNode[0], treeNode, instantiatingModule),
+		       new OpApplNode(symb, new ExprOrOpArgNode[0], treeNode, instantiatingModule, errors),
 		       null, true));
         }
 	else {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -483,11 +483,11 @@ public class SubstInNode extends ExprNode {
 //  }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
 
     String ret = "\n*SubstInNode: "
-                 + super.toString(depth)
+                 + super.toString(depth, errors)
 	         + "\n  instantiating module: " + instantiatingModule.getName()
                  + ", instantiated module: " + instantiatedModule.getName()
                  + Strings.indent(2, "\nSubstitutions:");
@@ -496,7 +496,7 @@ public class SubstInNode extends ExprNode {
         ret += Strings.indent(2,
                       Strings.indent(2, "\nSubst:" +
                         (this.substs[i] != null ?
-                         Strings.indent(2, this.substs[i].toString(depth-1)) :
+                         Strings.indent(2, this.substs[i].toString(depth-1, errors)) :
                          "<null>")));
       }
     }
@@ -504,7 +504,7 @@ public class SubstInNode extends ExprNode {
       ret += Strings.indent(2, "<null>");
     }
     ret += Strings.indent(2, "\nBody:"
-			  + Strings.indent(2, (body == null ? "<null>" : body.toString(depth-1))));
+			  + Strings.indent(2, (body == null ? "<null>" : body.toString(depth-1, errors))));
     return ret;
   }
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SymbolTable.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SymbolTable.java
@@ -246,7 +246,7 @@ public class SymbolTable implements ASTConstants {
 
     for (int c = contextStack.size()-1; c >= 0; c--) {
       Context ct = (Context) contextStack.elementAt(c);
-      Vector v = ct.getContextEntryStringVector(1,true);
+      Vector v = ct.getContextEntryStringVector(1,true, errors);
 
       for (int i = 0; i < v.size(); i++) {
         ret += (String)v.elementAt(i);

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/TheoremNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/TheoremNode.java
@@ -332,18 +332,18 @@ public class TheoremNode extends LevelNode {
   }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String res =
-             "\n*TheoremNode " + super.toString( depth ) +
+             "\n*TheoremNode " + super.toString( depth, errors ) +
             ((theoremExprOrAssumeProve != null)  ?
-              Strings.indent(2, theoremExprOrAssumeProve.toString(depth-1))
+              Strings.indent(2, theoremExprOrAssumeProve.toString(depth-1, errors))
                : "");
     if (def != null) {
       res = res + Strings.indent(
                       2,
                       "\n def: " +
-                      Strings.indent(2, this.def.toString(depth-1)));
+                      Strings.indent(2, this.def.toString(depth-1, errors)));
      } ;
     if (suffices) {
       res = res + Strings.indent(
@@ -355,7 +355,7 @@ public class TheoremNode extends LevelNode {
       res = res + Strings.indent(
                       2,
                       "\n proof: " +
-                      Strings.indent(2, this.proof.toString(depth-1)));
+                      Strings.indent(2, this.proof.toString(depth-1, errors)));
      } ;
     return res ;
   }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
@@ -592,11 +592,11 @@ public class ThmOrAssumpDefNode extends SymbolNode
    }
 
   @Override
-  public final String toString(int depth) {
+  public final String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String ret =
           "\n*ThmOrAssumpDefNode: " + this.getName().toString() +
-            "  " + super.toString(depth) +
+            "  " + super.toString(depth, errors) +
             " arity: " + this.arity +
             " module: " + (originallyDefinedInModule != null
                              ? originallyDefinedInModule.getName().toString()
@@ -607,7 +607,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
       String tempString = "\nFormal params: " + params.length;
       for (int i = 0; i < params.length; i++) {
         tempString += Strings.indent(2, ((params[i] != null)
-                                        ? params[i].toString(depth-1)
+                                        ? params[i].toString(depth-1, errors)
                                          : "\nnull"));
         } ;
       ret += Strings.indent(2,tempString);
@@ -616,7 +616,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
         ret += Strings.indent(2,
                              "\nisTheorem(): " + theorem +
                              "\nBody:" +
-                              Strings.indent(2, this.body.toString(depth-1)) +
+                              Strings.indent(2, this.body.toString(depth-1, errors)) +
                              "\nsuffices: " + this.isSuffices());
       } // if
     /***********************************************************************

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/UseOrHideNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/UseOrHideNode.java
@@ -148,18 +148,18 @@ public class UseOrHideNode extends LevelNode {
    }
 
   @Override
-  public String toString(int depth) {
+  public String toString(int depth, Errors errors) {
     if (depth <= 0) return "";
     String ret = "\n*UseOrHideNode:\n"
-                  + super.toString(depth)
+                  + super.toString(depth, errors)
                   + Strings.indent(2, "\nisOnly: " + this.isOnly)
                   + Strings.indent(2, "\nfacts:") ;
     for (int i = 0 ; i < this.facts.length; i++) {
-        ret += Strings.indent(4, this.facts[i].toString(1)) ;
+        ret += Strings.indent(4, this.facts[i].toString(1, errors)) ;
       } ;
     ret += Strings.indent(2, "\ndefs:") ;
     for (int i = 0 ; i < this.defs.length; i++) {
-        ret += Strings.indent(4, this.defs[i].toString(1)) ;
+        ret += Strings.indent(4, this.defs[i].toString(1, errors)) ;
       } ;
     return ret;
    }

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebuggerExpression.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebuggerExpression.java
@@ -113,7 +113,6 @@ public abstract class TLCDebuggerExpression {
 		}
 
 		Errors semanticLog = new Errors();
-		SemanticNode.setError(semanticLog);
 		Generator semanticChecker = new Generator(processor.getModuleTbl(), semanticLog);
 		ModuleNode bpModule = null;
 		try {
@@ -132,7 +131,6 @@ public abstract class TLCDebuggerExpression {
 		// Run level-checking. The operator should be restricted to
 		// action-level or below.
 		Errors levelCheckingErrors = new Errors();
-		SemanticNode.setError(levelCheckingErrors);
 		boolean levelCheckingSuccess = bpModule.levelCheck(levelCheckingErrors);
 		if (!levelCheckingSuccess || levelCheckingErrors.isFailure() || !bpModule.levelCorrect) {
 			ToolIO.err.println(levelCheckingErrors.toString());

--- a/tlatools/org.lamport.tlatools/test/util/ParserAPI.java
+++ b/tlatools/org.lamport.tlatools/test/util/ParserAPI.java
@@ -33,7 +33,6 @@ import tla2sany.semantic.Context;
 import tla2sany.semantic.Errors;
 import tla2sany.semantic.Generator;
 import tla2sany.semantic.ModuleNode;
-import tla2sany.semantic.SemanticNode;
 
 /**
  * A simple API for parsing self-contained TLA+ modules, for use in tests. This
@@ -107,7 +106,6 @@ public abstract class ParserAPI {
     // These two lines are annoying incantations to set global static state
     // that will hopefully be made unnecessary in the future.
     Context.reInit();
-    SemanticNode.setError(log);
     // The null parameter here is the {@link ExternalModuleTable}, which will
     // need to be resolved & populated if this API is to one day support TLA+
     // modules that EXTEND or INSTANCE other TLA+ modules.
@@ -130,7 +128,6 @@ public abstract class ParserAPI {
    * @return Whether levels in parse tree are correct.
    */
   public static boolean checkLevel(ModuleNode semanticRoot, Errors log) {
-    SemanticNode.setError(log);
     boolean levelOk = semanticRoot.levelCheck(log);
     return levelOk && log.isSuccess();
   }


### PR DESCRIPTION
Finally remove the necessity of calling `SemanticNode.setError()` before doing any parsing. One incantation down, many more to go.

The only place this changes behavior is in the SANY parse tree debug explorer, where instead of the `ModuleNode.toString()` method accessing the static semantic error log to print out some stuff, we move that access into the `Explorer` class itself. This slightly changes output; for example currently, if parsing the following module in SANY with the `-d` flag to open the debug prompt:
```tla
---- MODULE Test ----
VARIABLE x
op ≜ ◇[1]_x
====
```
then running `d Test` or `304` (the module UID) in the debug shell will print out:
```
*ModuleNode: Test    uid: 304  kind: ModuleKind  constant module: false  errors: 1
| Context Entry: x  305 
| | *OpDeclNode: x    uid: 305  kind: VariableDeclKind  arity: 0  orgDefInModule: Test
| |   originallyDefinedInModule: Test
...
```
but after these changes it will print out:
```
Constant module: false
Module errors: 1
*ModuleNode: Test    uid: 304  kind: ModuleKind
| Context Entry: x  305 
| | *OpDeclNode: x    uid: 305  kind: VariableDeclKind  arity: 0  orgDefInModule: Test
| |   originallyDefinedInModule: Test
...
```
To my knowledge no tool actually depends on the precise text output of the SANY debug shell so this should be fine (actually the specific debug shell command used here isn't even documented in the SANY CLI help text).

Ref #891 #1101 #1100