### PR TITLE
Bogus `Error: The configuration file substitutes constant C with non-constant C2` when C2 is in fact constant.

### DIFF
--- a/tlatools/org.lamport.tlatools/test-model/Github1109.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github1109.tla
@@ -1,0 +1,18 @@
+---------------------------- MODULE Github1109 ---------------------------
+EXTENDS Sequences
+
+Part_Funct(D, R) == UNION {[d -> R] : d \in SUBSET D}
+
+S == {"s"} 
+
+R == Seq(S) \* Cannot be enumerated.
+
+CONSTANTS C
+
+ASSUME DOMAIN C # {} \* Evaluate C to trigger Seq(S). 
+
+C2 == [ s \in [S -> R], p \in {Part_Funct(S, R)} |-> TRUE ]
+==========================================================================
+---------------------------- CONFIG Github1109 ---------------------------
+CONSTANT C <- C2
+==========================================================================

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github1109Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github1109Test.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Microsoft Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class Github1109Test extends ModelCheckerTestCase {
+
+	public Github1109Test() {
+		super("Github1109", new String[] { "-config", "Github1109.tla" }, ExitStatus.VIOLATION_ASSUMPTION);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+
+		assertFalse(recorder.recorded(EC.TLC_CONFIG_SUBSTITUTION_NON_CONSTANT));
+	}
+}


### PR DESCRIPTION
Test case for Github issue #1109
https://github.com/tlaplus/tlaplus/issues/1109

[Bug][TLC]