### PR TITLE
Warning: DiskFPSet.mergeNewEntries: xxx is already on disk with hangup following

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OpenAddressing.ConcurrentFlusher.tla
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OpenAddressing.ConcurrentFlusher.tla
@@ -84,6 +84,18 @@ OrderedSequences(set) == UNION {{perm \in [1..Cardinality(set) -> set]:
      };
      
   mrg2:
+        if (a = b) {
+           O := Append(O, a);
+           aLength := aLength - 1;
+           if (aLength > 0) {
+             Consume(a, A);
+           };
+           bLength := bLength - 1;
+           if (bLength > 0) {
+             Consume(b, B);
+           };
+        };
+  mrg2a:
         if (aLength > 0 /\ (a < b \/ bLength = 0)) {
            O := Append(O, a);
            aLength := aLength - 1;
@@ -111,7 +123,7 @@ OrderedSequences(set) == UNION {{perm \in [1..Cardinality(set) -> set]:
 }
 
 ***     this ends the comment containg the pluscal code      **********)
-\* BEGIN TRANSLATION (chksum(pcal) = "7c28162a" /\ chksum(tla) = "cf7e0f27")
+\* BEGIN TRANSLATION (chksum(pcal) = "7c28162a" /\ chksum(tla) = "8099c642")
 VARIABLES pc, history, a, aLength, A, b, bLength, B, O
 
 (* define statement *)
@@ -167,7 +179,7 @@ mrg1 == /\ pc = "mrg1"
         /\ UNCHANGED << history, aLength, bLength, O >>
 
 mrg2 == /\ pc = "mrg2"
-        /\ IF aLength > 0 /\ (a < b \/ bLength = 0)
+        /\ IF a = b
               THEN /\ O' = Append(O, a)
                    /\ aLength' = aLength - 1
                    /\ IF aLength' > 0
@@ -175,10 +187,30 @@ mrg2 == /\ pc = "mrg2"
                               /\ A' = Tail(A)
                          ELSE /\ TRUE
                               /\ UNCHANGED << a, A >>
+                   /\ bLength' = bLength - 1
+                   /\ IF bLength' > 0
+                         THEN /\ b' = Head(B)
+                              /\ B' = Tail(B)
+                         ELSE /\ TRUE
+                              /\ UNCHANGED << b, B >>
               ELSE /\ TRUE
-                   /\ UNCHANGED << a, aLength, A, O >>
-        /\ pc' = "mrg2b"
-        /\ UNCHANGED << history, b, bLength, B >>
+                   /\ UNCHANGED << a, aLength, A, b, bLength, B, O >>
+        /\ pc' = "mrg2a"
+        /\ UNCHANGED history
+
+mrg2a == /\ pc = "mrg2a"
+         /\ IF aLength > 0 /\ (a < b \/ bLength = 0)
+               THEN /\ O' = Append(O, a)
+                    /\ aLength' = aLength - 1
+                    /\ IF aLength' > 0
+                          THEN /\ a' = Head(A)
+                               /\ A' = Tail(A)
+                          ELSE /\ TRUE
+                               /\ UNCHANGED << a, A >>
+               ELSE /\ TRUE
+                    /\ UNCHANGED << a, aLength, A, O >>
+         /\ pc' = "mrg2b"
+         /\ UNCHANGED << history, b, bLength, B >>
 
 mrg2b == /\ pc = "mrg2b"
          /\ IF bLength > 0 /\ (b < a \/ aLength = 0)
@@ -202,18 +234,18 @@ mrg3 == /\ pc = "mrg3"
 
 mrg4 == /\ pc = "mrg4"
         /\ Assert(bLength = 0 /\ aLength = 0, 
-                  "Failure of assertion at line 106, column 8.")
+                  "Failure of assertion at line 119, column 8.")
         /\ Assert(Len(O) = Cardinality(history), 
-                  "Failure of assertion at line 107, column 8.")
+                  "Failure of assertion at line 120, column 8.")
         /\ Assert(Image(O) = history, 
-                  "Failure of assertion at line 108, column 8.")
+                  "Failure of assertion at line 121, column 8.")
         /\ pc' = "Done"
         /\ UNCHANGED << history, a, aLength, A, b, bLength, B, O >>
 
 (* Allow infinite stuttering to prevent deadlock on termination. *)
 Terminating == pc = "Done" /\ UNCHANGED vars
 
-Next == init \/ hstry \/ mrg1 \/ mrg2 \/ mrg2b \/ mrg3 \/ mrg4
+Next == init \/ hstry \/ mrg1 \/ mrg2 \/ mrg2a \/ mrg2b \/ mrg3 \/ mrg4
            \/ Terminating
 
 Spec == /\ Init /\ [][Next]_vars

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OpenAddressing.ConcurrentFlusher.tla
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OpenAddressing.ConcurrentFlusher.tla
@@ -110,15 +110,15 @@ OrderedSequences(set) == UNION {{perm \in [1..Cardinality(set) -> set]:
 }
 
 ***     this ends the comment containg the pluscal code      **********)
-\* BEGIN TRANSLATION
-VARIABLES history, a, aLength, A, b, bLength, B, O, pc
+\* BEGIN TRANSLATION (chksum(pcal) = "7c28162a" /\ chksum(tla) = "727f78c7")
+VARIABLES pc, history, a, aLength, A, b, bLength, B, O
 
 (* define statement *)
 Inv == /\ Image(O) \subseteq history
        /\ IsOrdered(O)
 
 
-vars == << history, a, aLength, A, b, bLength, B, O, pc >>
+vars == << pc, history, a, aLength, A, b, bLength, B, O >>
 
 Init == (* Global variables *)
         /\ history = {}
@@ -208,16 +208,18 @@ mrg4 == /\ pc = "mrg4"
         /\ pc' = "Done"
         /\ UNCHANGED << history, a, aLength, A, b, bLength, B, O >>
 
+(* Allow infinite stuttering to prevent deadlock on termination. *)
+Terminating == pc = "Done" /\ UNCHANGED vars
+
 Next == init \/ hstry \/ mrg1 \/ mrg2 \/ mrg2b \/ mrg3 \/ mrg4
-           \/ (* Disjunct to prevent deadlock on termination *)
-              (pc = "Done" /\ UNCHANGED vars)
+           \/ Terminating
 
 Spec == /\ Init /\ [][Next]_vars
         /\ WF_vars(Next)
 
 Termination == <>(pc = "Done")
 
-\* END TRANSLATION
+\* END TRANSLATION 
 
 =============================================================================
 \* Modification History

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OpenAddressing.ConcurrentFlusher.tla
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OpenAddressing.ConcurrentFlusher.tla
@@ -43,6 +43,7 @@ OrderedSequences(set) == UNION {{perm \in [1..Cardinality(set) -> set]:
     define {
        Inv == /\ Image(O) \subseteq history
               /\ IsOrdered(O)
+       NoDuplicates == Image(A) \cap Image(B) = {}
     }
     
     macro Consume(var, seq) {
@@ -51,10 +52,10 @@ OrderedSequences(set) == UNION {{perm \in [1..Cardinality(set) -> set]:
     }
   {
 
-  (* Initialize a and b with all possible combination of sorted sequences. *)
+  (* Initialize A and B with all possible combination of sorted sequences. *)
   init:           
     with (r \in SUBSET Nat \ {{}}) {
-       with (s \in ((SUBSET (Nat \ r)) \ {{}})) {
+       with (s \in ((SUBSET (Nat)) \ {{}})) {
            with (t \in OrderedSequences(s) \cup {<<>>}) {
                B := t;
                bLength := Len(B);
@@ -110,12 +111,13 @@ OrderedSequences(set) == UNION {{perm \in [1..Cardinality(set) -> set]:
 }
 
 ***     this ends the comment containg the pluscal code      **********)
-\* BEGIN TRANSLATION (chksum(pcal) = "7c28162a" /\ chksum(tla) = "727f78c7")
+\* BEGIN TRANSLATION (chksum(pcal) = "7c28162a" /\ chksum(tla) = "cf7e0f27")
 VARIABLES pc, history, a, aLength, A, b, bLength, B, O
 
 (* define statement *)
 Inv == /\ Image(O) \subseteq history
        /\ IsOrdered(O)
+NoDuplicates == Image(A) \cap Image(B) = {}
 
 
 vars == << pc, history, a, aLength, A, b, bLength, B, O >>
@@ -133,7 +135,7 @@ Init == (* Global variables *)
 
 init == /\ pc = "init"
         /\ \E r \in SUBSET Nat \ {{}}:
-             \E s \in ((SUBSET (Nat \ r)) \ {{}}):
+             \E s \in ((SUBSET (Nat)) \ {{}}):
                \E t \in OrderedSequences(s) \cup {<<>>}:
                  /\ B' = t
                  /\ bLength' = Len(B')
@@ -223,5 +225,20 @@ Termination == <>(pc = "Done")
 
 =============================================================================
 \* Modification History
-\* Last modified Tue Jun 06 20:39:04 CEST 2017 by markus
+\* Last modified Fri Jan 10 20:39:04 CEST 2025 by markus
 \* Created Mon Jun 05 23:14:05 CEST 2017 by markus
+
+----- CONFIG Merge -----
+SPECIFICATION
+    Spec
+
+INVARIANT
+    Inv
+    \* NoDuplicates
+
+PROPERTIES 
+    Termination
+
+CONSTANT
+    Nat = {1,2,3,4,5}
+======


### PR DESCRIPTION
This PR addresses the issue in https://github.com/tlaplus/tlaplus/issues/1112 where the `DiskFPSet.mergeNewEntries` method enters an infinite loop when it encounters the `fp = value` (see the TLA+ counterexample below). While this PR doesn’t resolve the root cause of duplicate fingerprints, it will aid us in understanding the frequency of such occurrences.

```tla
TLC2 Version 2.20 of Day Month 20?? (rev: https://github.com/tlaplus/tlaplus/commit/66d04b7817b76939c8504a4fb3f0bada22a1bf6e)
Running breadth-first search Model-Checking with fp 88 and seed -3725596570278802435 with 1 worker on 10 cores with 7282MB heap and 64MB offheap memory [pid: 87860] (Mac OS X 15.2 aarch64, Homebrew 23.0.1 x86_64, MSBDiskFPSet, DiskStateQueue).
Parsing file /Users/markus/src/TLA/_specs/examples/specifications/FiniteMonotonic/Merge.tla
Parsing file /private/var/folders/7d/4x6z2cc91jl588ysynlc1tfc0000gn/T/tlc-9464973494116297331/Integers.tla (jar:file:/Applications/TLA+%20Toolbox.app/Contents/Eclipse/tla2tools.jar!/tla2sany/StandardModules/Integers.tla)
Parsing file /private/var/folders/7d/4x6z2cc91jl588ysynlc1tfc0000gn/T/tlc-9464973494116297331/TLC.tla (jar:file:/Applications/TLA+%20Toolbox.app/Contents/Eclipse/tla2tools.jar!/tla2sany/StandardModules/TLC.tla)
Parsing file /private/var/folders/7d/4x6z2cc91jl588ysynlc1tfc0000gn/T/tlc-9464973494116297331/Sequences.tla (jar:file:/Applications/TLA+%20Toolbox.app/Contents/Eclipse/tla2tools.jar!/tla2sany/StandardModules/Sequences.tla)
Parsing file /private/var/folders/7d/4x6z2cc91jl588ysynlc1tfc0000gn/T/tlc-9464973494116297331/FiniteSets.tla (jar:file:/Applications/TLA+%20Toolbox.app/Contents/Eclipse/tla2tools.jar!/tla2sany/StandardModules/FiniteSets.tla)
Parsing file /private/var/folders/7d/4x6z2cc91jl588ysynlc1tfc0000gn/T/tlc-9464973494116297331/Naturals.tla (jar:file:/Applications/TLA+%20Toolbox.app/Contents/Eclipse/tla2tools.jar!/tla2sany/StandardModules/Naturals.tla)
Semantic processing of module Naturals
Semantic processing of module Integers
Semantic processing of module Sequences
Semantic processing of module FiniteSets
Semantic processing of module TLC
Semantic processing of module Merge
Starting... (2025-01-10 16:19:46)
Implied-temporal checking--satisfiability problem has 1 branches.
Computing initial states...
Finished computing initial states: 1 distinct state generated at 2025-01-10 16:19:46.
Progress(2) at 2025-01-10 16:19:49: 3,845 states generated (3,845 s/min), 1,025 distinct states found (1,025 ds/min), 1,024 states left on queue.
Progress(20) at 2025-01-10 16:20:30: 10,227 states generated, 6,383 distinct states found, 0 states left on queue.
Checking temporal properties for the complete state space with 6383 total distinct states at (2025-01-10 16:20:30)
Error: Temporal properties were violated.

Error: The following behavior constitutes a counter-example:

State 1: <Initial predicate>
/\ aLength = 0
/\ A = <<>>
/\ B = <<>>
/\ bLength = 0
/\ O = <<>>
/\ history = {}
/\ a = 0
/\ b = 0
/\ pc = "init"

State 2: <init line 136, col 9 to line 146, col 43 of module Merge>
/\ aLength = 2
/\ A = <<2, 3>>
/\ B = <<2, 3, 5>>
/\ bLength = 3
/\ O = <<>>
/\ history = {}
/\ a = 0
/\ b = 0
/\ pc = "hstry"

State 3: <hstry line 148, col 10 to line 153, col 59 of module Merge>
/\ aLength = 2
/\ A = <<2, 3>>
/\ B = <<2, 3, 5>>
/\ bLength = 3
/\ O = <<>>
/\ history = {2, 3, 5}
/\ a = 0
/\ b = 0
/\ pc = "mrg1"

State 4: <mrg1 line 155, col 9 to line 167, col 55 of module Merge>
/\ aLength = 2
/\ A = <<3>>
/\ B = <<3, 5>>
/\ bLength = 3
/\ O = <<>>
/\ history = {2, 3, 5}
/\ a = 2
/\ b = 2
/\ pc = "mrg2"

State 5: <mrg2 line 169, col 9 to line 181, col 49 of module Merge>
/\ aLength = 2
/\ A = <<3>>
/\ B = <<3, 5>>
/\ bLength = 3
/\ O = <<>>
/\ history = {2, 3, 5}
/\ a = 2
/\ b = 2
/\ pc = "mrg2b"

State 6: <mrg2b line 183, col 10 to line 195, col 50 of module Merge>
/\ aLength = 2
/\ A = <<3>>
/\ B = <<3, 5>>
/\ bLength = 3
/\ O = <<>>
/\ history = {2, 3, 5}
/\ a = 2
/\ b = 2
/\ pc = "mrg3"

Back to state 4: <mrg3 line 197, col 9 to line 201, col 67 of module Merge>

Finished checking temporal properties in 00s at 2025-01-10 16:20:30
10227 states generated, 6383 distinct states found, 0 states left on queue.
The depth of the complete state graph search is 20.
Finished in 44s at (2025-01-10 16:20:30)
```