### PR TITLE
Do not abort recover but continue recovery if it encounters a duplicate fingerprint and `-Dtlc2.tool.fp.DiskFPSet.error2warning=true` is given.

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/AbstractHeapBasedDiskFPSetTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/AbstractHeapBasedDiskFPSetTest.java
@@ -133,6 +133,23 @@ public abstract class AbstractHeapBasedDiskFPSetTest {
 			fpSet.recoverFP(fp);
 		}
 	}
+	
+	@Test
+	public void testFPSetRecoveryDuplicate() throws IOException {
+		final String metadir = System.getProperty("java.io.tmpdir");
+		final String filename = this.getClass().getCanonicalName() + "testFPSetRecoveryDuplicate";
+		
+		final DiskFPSet fpSet = getDiskFPSet(new FPSetConfiguration());
+		fpSet.init(1, metadir, filename);
+
+		// Make sure the FPSet tries to flush to disk.
+		fpSet.forceFlush();
+		
+		System.setProperty("tlc2.tool.fp.DiskFPSet.error2warning", Boolean.TRUE.toString());
+		
+		fpSet.recoverFP(1);
+		fpSet.recoverFP(1);
+	}
 
 	/* Helper */
 


### PR DESCRIPTION
Do not abort recover but continue recovery if it encounters a duplicate fingerprint and `-Dtlc2.tool.fp.DiskFPSet.error2warning=true` is given.

Part of Github issue #1113
https://github.com/tlaplus/tlaplus/issues/1113

[Bug][TLC]