### PR TITLE
Changed funding link to TLA⁺ Foundation website

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://www.microsoft.com/en-us/research/']
+custom: ['https://foundation.tlapl.us/']


### PR DESCRIPTION
It was still pointing to the MSR website.