### PR TITLE
Warning: DiskFPSet.mergeNewEntries: xxx is already on disk with hangup following.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -129,6 +129,7 @@ public interface EC
     public static final int SYSTEM_METADIR_EXISTS = 2162;
     public static final int SYSTEM_METADIR_CREATION_ERROR = 2163;
     public static final int SYSTEM_UNABLE_TO_OPEN_FILE = 2167;
+    public static final int SYSTEM_FINGERPRINT_OVERFLOW_ERROR = 2254;
     public static final int TLC_BUG = 2128; // TODO Bad description
     public static final int TLC_FINGERPRINT_EXCEPTION = 2147;
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -430,6 +430,13 @@ public class MP
         case EC.SYSTEM_METADIR_CREATION_ERROR:
             b.append("TLC could not make a directory %1% for the disk files it needs to write.");
             break;
+		case EC.SYSTEM_FINGERPRINT_OVERFLOW_ERROR:
+			b.append(
+					"The requested fingerprint set size is too large, which could result in precision "
+					+ "or overflow errors. To resolve this, either increase the fingerprint size to "
+					+ "the next power of two (ensuring safe bit-shifting) or adjust the fpbits "
+					+ "parameter to a higher value.");
+			break;
         /* ----------------------------------------------------------------- */
         case EC.WRONG_COMMANDLINE_PARAMS_TLC:
             b.append("%1%\nUsage: java tlc2.TLC [-help] [-option] inputfile");

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OffHeapDiskFPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OffHeapDiskFPSet.java
@@ -610,7 +610,7 @@ public final class OffHeapDiskFPSet extends NonCheckpointableDiskFPSet implement
 		public Indexer(final long positions, final int fpBits, final long maxFingerprint) {
 			this.positions = positions;
 			// (position-1L) because array is zero indexed.
-			this.tblScalingFactor = (positions - 1L) / ((maxFingerprint - minFingerprint) * 1f);
+			this.tblScalingFactor = (positions - 1L) / ((maxFingerprint - minFingerprint) * 1d);
 		}
 		
 		protected long getIdx(final long fp) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OffHeapDiskFPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/OffHeapDiskFPSet.java
@@ -604,6 +604,7 @@ public final class OffHeapDiskFPSet extends NonCheckpointableDiskFPSet implement
 		
 		public Indexer(final long positions, final int fpBits) {
 			this(positions, fpBits, 0xFFFFFFFFFFFFFFFFL >>> fpBits);
+			Assert.check(positions < Integer.MAX_VALUE, EC.SYSTEM_FINGERPRINT_OVERFLOW_ERROR);
 			assert fpBits > 0;
 		}
 
@@ -628,7 +629,7 @@ public final class OffHeapDiskFPSet extends NonCheckpointableDiskFPSet implement
 		private final int rShift;
 
 		public BitshiftingIndexer(final long positions, final int fpBits) throws RemoteException {
-			super(positions, fpBits);
+			super(positions, fpBits, 0xFFFFFFFFFFFFFFFFL >>> fpBits);
 			
 			this.prefixMask = 0xFFFFFFFFFFFFFFFFL >>> fpBits;
 			

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/LongArraysTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/LongArraysTest.java
@@ -622,8 +622,8 @@ public class LongArraysTest {
 		final List<Long> expected = new ArrayList<Long>();
 		expected.add(1L);
 		expected.add(0L);
-		expected.add(4L);
 		expected.add(0L);
+		expected.add(4L);
 		expected.add(6L);
 		expected.add(0L);
 		expected.add(0L);

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/OffHeapIndexerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/OffHeapIndexerTest.java
@@ -32,6 +32,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import tlc2.tool.fp.OffHeapDiskFPSet.Indexer;
+import util.Assert.TLCRuntimeException;
 
 public class OffHeapIndexerTest {
 
@@ -233,5 +234,24 @@ public class OffHeapIndexerTest {
 			Assert.assertEquals(l, indexer.getIdx(fpNext));
 		}
 		Assert.assertEquals(0, indexer.getIdx(positions << (Long.SIZE - logPos)));
+	}
+	
+	@Test
+	public void testOverflowErrorArithmetic() {
+		try {
+			new OffHeapDiskFPSet.Indexer(Integer.MAX_VALUE + 1L, 1);
+		} catch (TLCRuntimeException e) {
+			return;
+		}
+		Assert.fail("Creation of Indexer didn't throw an exception");
+	}
+	
+	@Test
+	public void testNoOverflowErrorBitShifting() throws RemoteException {
+		try {
+			new OffHeapDiskFPSet.BitshiftingIndexer(Integer.MAX_VALUE + 1L, 1);
+		} catch (TLCRuntimeException e) {
+			Assert.fail("Creation of BitshiftingIndexer threw an exception: " + e.getMessage());
+		}
 	}
 }


### PR DESCRIPTION
Warning: DiskFPSet.mergeNewEntries: xxx is already on disk with hangup following. 

Use double precision when calculating `tblScalingFactor` to avoid rounding issues in `Indexer#getIdx`. These rounding issues can lead to critical errors, such as the largest fingerprints being incorrectly mapped to lower indices instead of the highest index.  This problem occurs intermittently for specific ranges of positions within the interval `(0, Integer.MAX_VALUE)`.

Part of Github issue #1112
https://github.com/tlaplus/tlaplus/issues/1112

[Bug][TLC]