### PR TITLE
Refactor Errors log class to keep error deserialized internally

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Errors.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Errors.java
@@ -28,31 +28,66 @@ import tla2sany.st.Location;
 
 public class Errors {
 
-  private List<String> warnings = new ArrayList<String>();
-  private List<String> errors   = new ArrayList<String>();
-  private List<String> aborts   = new ArrayList<String>();
+  public static class ErrorDetails {
+
+    public final Location location;
+
+    public final String message;
+
+    public ErrorDetails(Location location, String message) {
+      this.location = location;
+      this.message = message;
+    }
+
+    @Override
+    public String toString() {
+      return this.location.toString() + "\n\n" + this.message;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof ErrorDetails)) {
+        return false;
+      }
+      final ErrorDetails other = (ErrorDetails)o;
+      return this.location.equals(other.location)
+          && this.message.equals(other.message);
+    }
+  }
+
+  private List<ErrorDetails> warnings = new ArrayList<ErrorDetails>();
+  private List<ErrorDetails> errors   = new ArrayList<ErrorDetails>();
+  private List<ErrorDetails> aborts   = new ArrayList<ErrorDetails>();
 
   /*************************************************************************
   * The following methods to return the warnings, errors, and aborts in a  *
   * sane way were added by LL on 12 May 2008.                              *
   *************************************************************************/
-  public String[] getAborts()   { return this.aborts.toArray(String[]::new); }
-  public String[] getErrors()   { return this.errors.toArray(String[]::new); }
-  public String[] getWarnings() { return this.warnings.toArray(String[]::new); }
+  public String[] getAborts()   { return this.aborts.stream().map(ErrorDetails::toString).toArray(String[]::new); }
+  public String[] getErrors()   { return this.errors.stream().map(ErrorDetails::toString).toArray(String[]::new); }
+  public String[] getWarnings() { return this.warnings.stream().map(ErrorDetails::toString).toArray(String[]::new); }
+
+  public List<ErrorDetails> getAbortDetails()   { return new ArrayList<ErrorDetails>(this.aborts); }
+  public List<ErrorDetails> getErrorDetails()   { return new ArrayList<ErrorDetails>(this.errors); }
+  public List<ErrorDetails> getWarningDetails() { return new ArrayList<ErrorDetails>(this.warnings); }
 
   public final void addWarning( Location loc, String str ) {
-    if (loc == null) loc = Location.nullLoc;
-    final String message = loc.toString() + "\n\n" + str;
-    if (!this.warnings.contains(message)) {
-      this.warnings.add(message);
+    if (loc == null) {
+      loc = Location.nullLoc;
+    }
+    final ErrorDetails error = new ErrorDetails(loc, str);
+    if (!this.warnings.contains(error)) {
+      this.warnings.add(error);
     }
   }
 
   public final void addError(Location loc, String str) {
-    if (loc == null) loc = Location.nullLoc;
-    final String message = loc.toString() + "\n\n" + str;
-    if (!this.errors.contains(message)) {
-      this.errors.add(message);
+    if (loc == null) {
+      loc = Location.nullLoc;
+    }
+    final ErrorDetails error = new ErrorDetails(loc, str);
+    if (!this.errors.contains(error)) {
+      this.errors.add(error);
     }
   }
 
@@ -64,10 +99,12 @@ public class Errors {
    * @throws AbortException
    */
   public final void addAbort(Location loc, String str, boolean abort) throws AbortException {
-    if (loc == null) loc = Location.nullLoc;
-    final String message = loc.toString() + "\n\n" + str;
-    if (!this.aborts.contains(message)) {
-      this.aborts.add(message);
+    if (loc == null) {
+      loc = Location.nullLoc;
+    }
+    final ErrorDetails error = new ErrorDetails(loc, str);
+    if (!this.aborts.contains(error)) {
+      this.aborts.add(error);
     }
 
     if (abort){
@@ -103,18 +140,18 @@ public class Errors {
     StringBuffer ret = new StringBuffer("");
 
     ret.append((this.aborts.size() > 0) ? "*** Abort messages: " + this.aborts.size() + "\n\n" : "");
-    for (final String message : this.aborts)   {
-      ret.append(message + "\n\n\n");
+    for (final ErrorDetails error : this.aborts)   {
+      ret.append(error.toString() + "\n\n\n");
     }
 
     ret.append((this.errors.size() > 0) ? "*** Errors: " + this.errors.size() + "\n\n" : "");
-    for (final String message : this.errors)   {
-      ret.append(message + "\n\n\n");
+    for (final ErrorDetails error : this.errors)   {
+      ret.append(error.toString() + "\n\n\n");
     }
 
     ret.append((this.warnings.size() > 0) ? "*** Warnings: " + this.warnings.size() + "\n\n" : "");
-    for (final String message : this.warnings) {
-      ret.append(message + "\n\n\n");
+    for (final ErrorDetails error : this.warnings) {
+      ret.append(error.toString() + "\n\n\n");
     }
 
     return ret.toString();

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Errors.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Errors.java
@@ -93,6 +93,7 @@ public class Errors {
    * @throws AbortException
    */
   public final void addAbort(Location loc, String str, boolean abort) throws AbortException {
+    if (loc == null) loc = Location.nullLoc;
     String errMsg = loc.toString() + "\n\n" + str;
     int i;
     for (i = aborts.size()-1; i >= 0; i--) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Errors.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Errors.java
@@ -21,69 +21,40 @@
 ***************************************************************************/
 package tla2sany.semantic;
 
-import tla2sany.st.Location;
-import tla2sany.utilities.Vector;
+import java.util.ArrayList;
+import java.util.List;
 
+import tla2sany.st.Location;
 
 public class Errors {
 
-  private boolean succeed = true;
-
-  private int    numAborts   = 0;
-  private int    numErrors   = 0;
-  private int    numWarnings = 0;
-
-  private Vector warnings = new Vector();
-  private Vector errors   = new Vector();
-  private Vector aborts   = new Vector();
+  private List<String> warnings = new ArrayList<String>();
+  private List<String> errors   = new ArrayList<String>();
+  private List<String> aborts   = new ArrayList<String>();
 
   /*************************************************************************
   * The following methods to return the warnings, errors, and aborts in a  *
   * sane way were added by LL on 12 May 2008.                              *
   *************************************************************************/
-  public String[] getAborts()   { return StringVectortoStringArray(aborts) ; }
-  public String[] getErrors()   { return StringVectortoStringArray(errors) ; }
-  public String[] getWarnings() { return StringVectortoStringArray(warnings) ; }
+  public String[] getAborts()   { return this.aborts.toArray(String[]::new); }
+  public String[] getErrors()   { return this.errors.toArray(String[]::new); }
+  public String[] getWarnings() { return this.warnings.toArray(String[]::new); }
 
-  private String[] StringVectortoStringArray(Vector vec) {
-    String[] retVal = new String[vec.size()] ;
-    for (int i = 0 ; i < retVal.length; i++) {
-      retVal[i] = (String) vec.elementAt(i) ;
-     } ;
-    return retVal;
-   }
-
-  public final void addWarning( Location loc, String str ) { 
+  public final void addWarning( Location loc, String str ) {
     if (loc == null) loc = Location.nullLoc;
-
-    int i;
-    for (i = warnings.size()-1; i >= 0; i--) {
-      if ( (loc.toString() + "\n\n" + str).equals( warnings.elementAt(i) ) ) break;
-    }
-
-    if ( i < 0) {
-      warnings.addElement( loc.toString() + "\n\n"+ str );
-      numWarnings++;
+    final String message = loc.toString() + "\n\n" + str;
+    if (!this.warnings.contains(message)) {
+      this.warnings.add(message);
     }
   }
-
 
   public final void addError(Location loc, String str) {
     if (loc == null) loc = Location.nullLoc;
-
-    int i;
-    for (i = errors.size()-1; i >= 0; i--) {
-      if ( (loc.toString() + "\n\n" + str).equals( errors.elementAt(i) ) )  break;
+    final String message = loc.toString() + "\n\n" + str;
+    if (!this.errors.contains(message)) {
+      this.errors.add(message);
     }
-
-    if ( i < 0) {
-      errors.addElement( loc.toString() + "\n\n"+ str );
-      numErrors++;
-    }
-    succeed = false;
-
   }
-  
 
   /**
    * 
@@ -94,20 +65,13 @@ public class Errors {
    */
   public final void addAbort(Location loc, String str, boolean abort) throws AbortException {
     if (loc == null) loc = Location.nullLoc;
-    String errMsg = loc.toString() + "\n\n" + str;
-    int i;
-    for (i = aborts.size()-1; i >= 0; i--) {
-      if (errMsg.equals(aborts.elementAt(i))) break;
+    final String message = loc.toString() + "\n\n" + str;
+    if (!this.aborts.contains(message)) {
+      this.aborts.add(message);
     }
-    if (i < 0) {
-      aborts.addElement(errMsg);
-      numAborts++;
-    }
-    succeed = false;
 
     if (abort){
-      // System.out.println(this.toString());
-      throw new AbortException(); 
+      throw new AbortException();
     }
   }
 
@@ -125,35 +89,34 @@ public class Errors {
     addAbort(Location.nullLoc, str, true);
   }
 
-  public final boolean isSuccess()             { return succeed; }
+  public final boolean isSuccess()             { return this.aborts.isEmpty() && this.errors.isEmpty(); }
 
-  public final boolean isFailure()             { return !succeed; }
+  public final boolean isFailure()             { return !this.isSuccess(); }
 
-  public final int     getNumErrors()          { return numErrors; }
+  public final int     getNumErrors()          { return this.errors.size(); }
 
-  public final int     getNumAbortsAndErrors() { return numAborts + numErrors; }
+  public final int     getNumAbortsAndErrors() { return this.aborts.size() + this.errors.size(); }
 
-  public final int     getNumMessages()        { return numAborts + numErrors + numWarnings; }
+  public final int     getNumMessages()        { return this.aborts.size() + this.errors.size() + this.warnings.size(); }
 
-  public final String  toString()  { 
+  public final String  toString()  {
     StringBuffer ret = new StringBuffer("");
 
-    ret.append((numAborts > 0) ? "*** Abort messages: " + numAborts + "\n\n" : "");
-    for (int i = 0; i < aborts.size(); i++)   {
-      ret.append(aborts.elementAt(i) + "\n\n\n");
+    ret.append((this.aborts.size() > 0) ? "*** Abort messages: " + this.aborts.size() + "\n\n" : "");
+    for (final String message : this.aborts)   {
+      ret.append(message + "\n\n\n");
     }
 
-    ret.append((numErrors > 0) ? "*** Errors: " + numErrors + "\n\n" : "");
-    for (int i = 0; i < errors.size(); i++)   {
-      ret.append(errors.elementAt(i) + "\n\n\n");
+    ret.append((this.errors.size() > 0) ? "*** Errors: " + this.errors.size() + "\n\n" : "");
+    for (final String message : this.errors)   {
+      ret.append(message + "\n\n\n");
     }
 
-    ret.append((numWarnings > 0) ? "*** Warnings: " + numWarnings + "\n\n" : "");
-    for (int i = 0; i < warnings.size(); i++) {
-      ret.append(warnings.elementAt(i) + "\n\n\n");
+    ret.append((this.warnings.size() > 0) ? "*** Warnings: " + this.warnings.size() + "\n\n" : "");
+    for (final String message : this.warnings) {
+      ret.append(message + "\n\n\n");
     }
 
     return ret.toString();
   }
-	    
 }

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestErrors.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestErrors.java
@@ -22,9 +22,13 @@
  ******************************************************************************/
 package tla2sany.semantic;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import tla2sany.semantic.Errors.ErrorDetails;
 import tla2sany.st.Location;
 
 /**
@@ -45,21 +49,25 @@ public class TestErrors {
   @Test
   public void testWarningMessages() {
     final Errors log = new Errors();
+    final List<ErrorDetails> expectedDetails = new ArrayList<ErrorDetails>();
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test warning message";
     log.addWarning(loc1, message1);
     final String expected1 = loc1.toString() + "\n\n" + message1;
+    expectedDetails.add(new ErrorDetails(loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is another test warning message";
     log.addWarning(loc2, message2);
     final String expected2 = loc2.toString() + "\n\n" + message2;
+    expectedDetails.add(new ErrorDetails(loc2, message2));
 
     final Location loc3 = Location.nullLoc;
     final String message3 = "This is yet another test warning message";
     log.addWarning(null, message3);
     final String expected3 = loc3.toString() + "\n\n" + message3;
+    expectedDetails.add(new ErrorDetails(loc3, message3));
 
     final String[] expected = new String[] { expected1, expected2, expected3 };
     final String[] actual = log.getWarnings();
@@ -72,6 +80,11 @@ public class TestErrors {
     Assert.assertEquals(0, log.getErrors().length);
     Assert.assertEquals(0, log.getAborts().length);
 
+    final List<ErrorDetails> blank = new ArrayList<ErrorDetails>();
+    Assert.assertEquals(expectedDetails, log.getWarningDetails());
+    Assert.assertEquals(blank, log.getErrorDetails());
+    Assert.assertEquals(blank, log.getAbortDetails());
+
     final String actualSummary = log.toString();
     for (final String expectedMessage : expected) {
       Assert.assertTrue(actualSummary.contains(expectedMessage));
@@ -81,21 +94,25 @@ public class TestErrors {
   @Test
   public void testErrorMessages() {
     final Errors log = new Errors();
+    final List<ErrorDetails> expectedDetails = new ArrayList<ErrorDetails>();
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test error message";
     log.addError(loc1, message1);
     final String expected1 = loc1.toString() + "\n\n" + message1;
+    expectedDetails.add(new ErrorDetails(loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is another test error message";
     log.addError(loc2, message2);
     final String expected2 = loc2.toString() + "\n\n" + message2;
+    expectedDetails.add(new ErrorDetails(loc2, message2));
 
     final Location loc3 = Location.nullLoc;
     final String message3 = "This is yet another test error message";
     log.addError(null, message3);
     final String expected3 = loc3.toString() + "\n\n" + message3;
+    expectedDetails.add(new ErrorDetails(loc3, message3));
 
     final String[] expected = new String[] { expected1, expected2, expected3 };
     final String[] actual = log.getErrors();
@@ -108,6 +125,11 @@ public class TestErrors {
     Assert.assertEquals(0, log.getWarnings().length);
     Assert.assertEquals(0, log.getAborts().length);
 
+    final List<ErrorDetails> blank = new ArrayList<ErrorDetails>();
+    Assert.assertEquals(blank, log.getWarningDetails());
+    Assert.assertEquals(expectedDetails, log.getErrorDetails());
+    Assert.assertEquals(blank, log.getAbortDetails());
+
     final String actualSummary = log.toString();
     for (final String expectedMessage : expected) {
       Assert.assertTrue(actualSummary.contains(expectedMessage));
@@ -117,6 +139,7 @@ public class TestErrors {
   @Test
   public void testAbortMessages() {
     final Errors log = new Errors();
+    final List<ErrorDetails> expectedDetails = new ArrayList<ErrorDetails>();
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test abort message";
@@ -125,6 +148,7 @@ public class TestErrors {
       Assert.fail();
     } catch (AbortException e) { }
     final String expected1 = loc1.toString() + "\n\n" + message1;
+    expectedDetails.add(new ErrorDetails(loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is another test abort message";
@@ -133,6 +157,7 @@ public class TestErrors {
       Assert.fail();
     } catch (AbortException e) { }
     final String expected2 = loc2.toString() + "\n\n" + message2;
+    expectedDetails.add(new ErrorDetails(loc2, message2));
 
     final Location loc3 = Location.nullLoc;
     final String message3 = "This is yet another test abort message";
@@ -141,6 +166,7 @@ public class TestErrors {
       Assert.fail();
     } catch (AbortException e) { }
     final String expected3 = loc3.toString() + "\n\n" + message3;
+    expectedDetails.add(new ErrorDetails(loc3, message3));
 
     final String[] expected = new String[] { expected1, expected2, expected3 };
     final String[] actual = log.getAborts();
@@ -152,6 +178,11 @@ public class TestErrors {
     Assert.assertEquals(expected.length, log.getNumAbortsAndErrors());
     Assert.assertEquals(0, log.getWarnings().length);
     Assert.assertEquals(expected.length, log.getAborts().length);
+
+    final List<ErrorDetails> blank = new ArrayList<ErrorDetails>();
+    Assert.assertEquals(blank, log.getWarningDetails());
+    Assert.assertEquals(blank, log.getErrorDetails());
+    Assert.assertEquals(expectedDetails, log.getAbortDetails());
 
     final String actualSummary = log.toString();
     for (final String expectedMessage : expected) {
@@ -162,6 +193,7 @@ public class TestErrors {
   @Test
   public void testAlternativeAbortFunctions() {
     final Errors log = new Errors();
+    final List<ErrorDetails> expectedDetails = new ArrayList<ErrorDetails>();
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test abort message";
@@ -171,6 +203,7 @@ public class TestErrors {
       Assert.fail();
     }
     final String expected1 = loc1.toString() + "\n\n" + message1;
+    expectedDetails.add(new ErrorDetails(loc1, message1));
 
     final Location loc2 = Location.nullLoc;
     final String message2 = "This is another test abort message";
@@ -180,6 +213,7 @@ public class TestErrors {
       Assert.fail();
     }
     final String expected2 = loc2.toString() + "\n\n" + message2;
+    expectedDetails.add(new ErrorDetails(loc2, message2));
 
     final Location loc3 = Location.nullLoc;
     final String message3 = "This is yet another test abort message";
@@ -188,6 +222,7 @@ public class TestErrors {
       Assert.fail();
     } catch (AbortException e) { }
     final String expected3 = loc3.toString() + "\n\n" + message3;
+    expectedDetails.add(new ErrorDetails(loc3, message3));
 
     final String[] expected = new String[] { expected1, expected2, expected3 };
     final String[] actual = log.getAborts();
@@ -199,6 +234,11 @@ public class TestErrors {
     Assert.assertEquals(expected.length, log.getNumAbortsAndErrors());
     Assert.assertEquals(0, log.getWarnings().length);
     Assert.assertEquals(expected.length, log.getAborts().length);
+
+    final List<ErrorDetails> blank = new ArrayList<ErrorDetails>();
+    Assert.assertEquals(blank, log.getWarningDetails());
+    Assert.assertEquals(blank, log.getErrorDetails());
+    Assert.assertEquals(expectedDetails, log.getAbortDetails());
 
     final String actualSummary = log.toString();
     for (final String expectedMessage : expected) {
@@ -215,12 +255,16 @@ public class TestErrors {
     log.addWarning(loc1, message1);
     final String expectedWarning = loc1.toString() + "\n\n" + message1;
     final String[] expectedWarnings = new String[] { expectedWarning };
+    final List<ErrorDetails> expectedWarningDetails = new ArrayList<ErrorDetails>();
+    expectedWarningDetails.add(new ErrorDetails(loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is a test error message";
     log.addError(loc2, message2);
     final String expectedError = loc2.toString() + "\n\n" + message2;
     final String[] expectedErrors = new String[] { expectedError };
+    final List<ErrorDetails> expectedErrorDetails = new ArrayList<ErrorDetails>();
+    expectedErrorDetails.add(new ErrorDetails(loc2, message2));
 
     final Location loc3 = genLocation();
     final String message3 = "This is a test abort message";
@@ -230,6 +274,8 @@ public class TestErrors {
     } catch (AbortException e) { }
     final String expectedAbort = loc3.toString() + "\n\n" + message3;
     final String[] expectedAborts = new String[] { expectedAbort };
+    final List<ErrorDetails> expectedAbortDetails = new ArrayList<ErrorDetails>();
+    expectedAbortDetails.add(new ErrorDetails(loc3, message3));
 
     Assert.assertArrayEquals(expectedWarnings, log.getWarnings());
     Assert.assertArrayEquals(expectedErrors, log.getErrors());
@@ -239,6 +285,10 @@ public class TestErrors {
     Assert.assertEquals(expectedWarnings.length + expectedErrors.length + expectedAborts.length, log.getNumMessages());
     Assert.assertEquals(expectedErrors.length, log.getNumErrors());
     Assert.assertEquals(expectedErrors.length + expectedAborts.length, log.getNumAbortsAndErrors());
+
+    Assert.assertEquals(expectedWarningDetails, log.getWarningDetails());
+    Assert.assertEquals(expectedErrorDetails, log.getErrorDetails());
+    Assert.assertEquals(expectedAbortDetails, log.getAbortDetails());
 
     final String actualSummary = log.toString();
     Assert.assertTrue(actualSummary.contains(expectedWarning));
@@ -257,6 +307,8 @@ public class TestErrors {
     log.addWarning(loc1, message1);
     final String expectedWarning = loc1.toString() + "\n\n" + message1;
     final String[] expectedWarnings = new String[] { expectedWarning };
+    final List<ErrorDetails> expectedWarningDetails = new ArrayList<ErrorDetails>();
+    expectedWarningDetails.add(new ErrorDetails(loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is a test error message";
@@ -265,6 +317,8 @@ public class TestErrors {
     log.addError(loc2, message2);
     final String expectedError = loc2.toString() + "\n\n" + message2;
     final String[] expectedErrors = new String[] { expectedError };
+    final List<ErrorDetails> expectedErrorDetails = new ArrayList<ErrorDetails>();
+    expectedErrorDetails.add(new ErrorDetails(loc2, message2));
 
     final Location loc3 = genLocation();
     final String message3 = "This is a test abort message";
@@ -277,6 +331,8 @@ public class TestErrors {
     }
     final String expectedAbort = loc3.toString() + "\n\n" + message3;
     final String[] expectedAborts = new String[] { expectedAbort };
+    final List<ErrorDetails> expectedAbortDetails = new ArrayList<ErrorDetails>();
+    expectedAbortDetails.add(new ErrorDetails(loc3, message3));
 
     Assert.assertArrayEquals(expectedWarnings, log.getWarnings());
     Assert.assertArrayEquals(expectedErrors, log.getErrors());
@@ -286,6 +342,10 @@ public class TestErrors {
     Assert.assertEquals(expectedWarnings.length + expectedErrors.length + expectedAborts.length, log.getNumMessages());
     Assert.assertEquals(expectedErrors.length, log.getNumErrors());
     Assert.assertEquals(expectedErrors.length + expectedAborts.length, log.getNumAbortsAndErrors());
+
+    Assert.assertEquals(expectedWarningDetails, log.getWarningDetails());
+    Assert.assertEquals(expectedErrorDetails, log.getErrorDetails());
+    Assert.assertEquals(expectedAbortDetails, log.getAbortDetails());
 
     final String actualSummary = log.toString();
     Assert.assertTrue(actualSummary.contains(expectedWarning));

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestErrors.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestErrors.java
@@ -1,0 +1,295 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Linux Foundation. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+package tla2sany.semantic;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tla2sany.st.Location;
+
+/**
+ * Tests for the {@link Errors} class, to ensure its workings remain
+ * unchanged as it is refactored internally.
+ */
+public class TestErrors {
+
+  private static int seed = 0;
+
+  private static Location genLocation() {
+    final String filename = String.format("Test%d.tla", seed);
+    final Location loc = new Location(filename, seed*3, seed*5, seed*7, seed*11);
+    seed++;
+    return loc;
+  }
+
+  @Test
+  public void testWarningMessages() {
+    final Errors log = new Errors();
+
+    final Location loc1 = genLocation();
+    final String message1 = "This is a test warning message";
+    log.addWarning(loc1, message1);
+    final String expected1 = loc1.toString() + "\n\n" + message1;
+
+    final Location loc2 = genLocation();
+    final String message2 = "This is another test warning message";
+    log.addWarning(loc2, message2);
+    final String expected2 = loc2.toString() + "\n\n" + message2;
+
+    final Location loc3 = Location.nullLoc;
+    final String message3 = "This is yet another test warning message";
+    log.addWarning(null, message3);
+    final String expected3 = loc3.toString() + "\n\n" + message3;
+
+    final String[] expected = new String[] { expected1, expected2, expected3 };
+    final String[] actual = log.getWarnings();
+    Assert.assertArrayEquals(expected, actual);
+    Assert.assertFalse(log.isFailure());
+    Assert.assertTrue(log.isSuccess());
+    Assert.assertEquals(expected.length, log.getNumMessages());
+    Assert.assertEquals(0, log.getNumErrors());
+    Assert.assertEquals(0, log.getNumAbortsAndErrors());
+    Assert.assertEquals(0, log.getErrors().length);
+    Assert.assertEquals(0, log.getAborts().length);
+
+    final String actualSummary = log.toString();
+    for (final String expectedMessage : expected) {
+      Assert.assertTrue(actualSummary.contains(expectedMessage));
+    }
+  }
+
+  @Test
+  public void testErrorMessages() {
+    final Errors log = new Errors();
+
+    final Location loc1 = genLocation();
+    final String message1 = "This is a test error message";
+    log.addError(loc1, message1);
+    final String expected1 = loc1.toString() + "\n\n" + message1;
+
+    final Location loc2 = genLocation();
+    final String message2 = "This is another test error message";
+    log.addError(loc2, message2);
+    final String expected2 = loc2.toString() + "\n\n" + message2;
+
+    final Location loc3 = Location.nullLoc;
+    final String message3 = "This is yet another test error message";
+    log.addError(null, message3);
+    final String expected3 = loc3.toString() + "\n\n" + message3;
+
+    final String[] expected = new String[] { expected1, expected2, expected3 };
+    final String[] actual = log.getErrors();
+    Assert.assertArrayEquals(expected, actual);
+    Assert.assertTrue(log.isFailure());
+    Assert.assertFalse(log.isSuccess());
+    Assert.assertEquals(expected.length, log.getNumMessages());
+    Assert.assertEquals(expected.length, log.getNumErrors());
+    Assert.assertEquals(expected.length, log.getNumAbortsAndErrors());
+    Assert.assertEquals(0, log.getWarnings().length);
+    Assert.assertEquals(0, log.getAborts().length);
+
+    final String actualSummary = log.toString();
+    for (final String expectedMessage : expected) {
+      Assert.assertTrue(actualSummary.contains(expectedMessage));
+    }
+  }
+
+  @Test
+  public void testAbortMessages() {
+    final Errors log = new Errors();
+
+    final Location loc1 = genLocation();
+    final String message1 = "This is a test abort message";
+    try {
+      log.addAbort(loc1, message1);
+      Assert.fail();
+    } catch (AbortException e) { }
+    final String expected1 = loc1.toString() + "\n\n" + message1;
+
+    final Location loc2 = genLocation();
+    final String message2 = "This is another test abort message";
+    try {
+      log.addAbort(loc2, message2);
+      Assert.fail();
+    } catch (AbortException e) { }
+    final String expected2 = loc2.toString() + "\n\n" + message2;
+
+    final Location loc3 = Location.nullLoc;
+    final String message3 = "This is yet another test abort message";
+    try {
+      log.addAbort(null, message3);
+      Assert.fail();
+    } catch (AbortException e) { }
+    final String expected3 = loc3.toString() + "\n\n" + message3;
+
+    final String[] expected = new String[] { expected1, expected2, expected3 };
+    final String[] actual = log.getAborts();
+    Assert.assertArrayEquals(expected, actual);
+    Assert.assertTrue(log.isFailure());
+    Assert.assertFalse(log.isSuccess());
+    Assert.assertEquals(expected.length, log.getNumMessages());
+    Assert.assertEquals(0, log.getNumErrors());
+    Assert.assertEquals(expected.length, log.getNumAbortsAndErrors());
+    Assert.assertEquals(0, log.getWarnings().length);
+    Assert.assertEquals(expected.length, log.getAborts().length);
+
+    final String actualSummary = log.toString();
+    for (final String expectedMessage : expected) {
+      Assert.assertTrue(actualSummary.contains(expectedMessage));
+    }
+  }
+
+  @Test
+  public void testAlternativeAbortFunctions() {
+    final Errors log = new Errors();
+
+    final Location loc1 = genLocation();
+    final String message1 = "This is a test abort message";
+    try {
+      log.addAbort(loc1, message1, false);
+    } catch (AbortException e) {
+      Assert.fail();
+    }
+    final String expected1 = loc1.toString() + "\n\n" + message1;
+
+    final Location loc2 = Location.nullLoc;
+    final String message2 = "This is another test abort message";
+    try {
+      log.addAbort(message2, false);
+    } catch (AbortException e) {
+      Assert.fail();
+    }
+    final String expected2 = loc2.toString() + "\n\n" + message2;
+
+    final Location loc3 = Location.nullLoc;
+    final String message3 = "This is yet another test abort message";
+    try {
+      log.addAbort(message3);
+      Assert.fail();
+    } catch (AbortException e) { }
+    final String expected3 = loc3.toString() + "\n\n" + message3;
+
+    final String[] expected = new String[] { expected1, expected2, expected3 };
+    final String[] actual = log.getAborts();
+    Assert.assertArrayEquals(expected, actual);
+    Assert.assertTrue(log.isFailure());
+    Assert.assertFalse(log.isSuccess());
+    Assert.assertEquals(expected.length, log.getNumMessages());
+    Assert.assertEquals(0, log.getNumErrors());
+    Assert.assertEquals(expected.length, log.getNumAbortsAndErrors());
+    Assert.assertEquals(0, log.getWarnings().length);
+    Assert.assertEquals(expected.length, log.getAborts().length);
+
+    final String actualSummary = log.toString();
+    for (final String expectedMessage : expected) {
+      Assert.assertTrue(actualSummary.contains(expectedMessage));
+    }
+  }
+
+  @Test
+  public void testMixedMessageLevels() {
+    final Errors log = new Errors();
+
+    final Location loc1 = genLocation();
+    final String message1 = "This is a test warning message";
+    log.addWarning(loc1, message1);
+    final String expectedWarning = loc1.toString() + "\n\n" + message1;
+    final String[] expectedWarnings = new String[] { expectedWarning };
+
+    final Location loc2 = genLocation();
+    final String message2 = "This is a test error message";
+    log.addError(loc2, message2);
+    final String expectedError = loc2.toString() + "\n\n" + message2;
+    final String[] expectedErrors = new String[] { expectedError };
+
+    final Location loc3 = genLocation();
+    final String message3 = "This is a test abort message";
+    try {
+      log.addAbort(loc3, message3);
+      Assert.fail();
+    } catch (AbortException e) { }
+    final String expectedAbort = loc3.toString() + "\n\n" + message3;
+    final String[] expectedAborts = new String[] { expectedAbort };
+
+    Assert.assertArrayEquals(expectedWarnings, log.getWarnings());
+    Assert.assertArrayEquals(expectedErrors, log.getErrors());
+    Assert.assertArrayEquals(expectedAborts, log.getAborts());
+    Assert.assertTrue(log.isFailure());
+    Assert.assertFalse(log.isSuccess());
+    Assert.assertEquals(expectedWarnings.length + expectedErrors.length + expectedAborts.length, log.getNumMessages());
+    Assert.assertEquals(expectedErrors.length, log.getNumErrors());
+    Assert.assertEquals(expectedErrors.length + expectedAborts.length, log.getNumAbortsAndErrors());
+
+    final String actualSummary = log.toString();
+    Assert.assertTrue(actualSummary.contains(expectedWarning));
+    Assert.assertTrue(actualSummary.contains(expectedError));
+    Assert.assertTrue(actualSummary.contains(expectedAbort));
+  }
+
+  @Test
+  public void testDuplicateErrorsIgnored() {
+    final Errors log = new Errors();
+
+    final Location loc1 = genLocation();
+    final String message1 = "This is a test warning message";
+    log.addWarning(loc1, message1);
+    log.addWarning(loc1, message1);
+    log.addWarning(loc1, message1);
+    final String expectedWarning = loc1.toString() + "\n\n" + message1;
+    final String[] expectedWarnings = new String[] { expectedWarning };
+
+    final Location loc2 = genLocation();
+    final String message2 = "This is a test error message";
+    log.addError(loc2, message2);
+    log.addError(loc2, message2);
+    log.addError(loc2, message2);
+    final String expectedError = loc2.toString() + "\n\n" + message2;
+    final String[] expectedErrors = new String[] { expectedError };
+
+    final Location loc3 = genLocation();
+    final String message3 = "This is a test abort message";
+    try {
+      log.addAbort(loc3, message3, false);
+      log.addAbort(loc3, message3, false);
+      log.addAbort(loc3, message3, false);
+    } catch (AbortException e) {
+      Assert.fail();
+    }
+    final String expectedAbort = loc3.toString() + "\n\n" + message3;
+    final String[] expectedAborts = new String[] { expectedAbort };
+
+    Assert.assertArrayEquals(expectedWarnings, log.getWarnings());
+    Assert.assertArrayEquals(expectedErrors, log.getErrors());
+    Assert.assertArrayEquals(expectedAborts, log.getAborts());
+    Assert.assertTrue(log.isFailure());
+    Assert.assertFalse(log.isSuccess());
+    Assert.assertEquals(expectedWarnings.length + expectedErrors.length + expectedAborts.length, log.getNumMessages());
+    Assert.assertEquals(expectedErrors.length, log.getNumErrors());
+    Assert.assertEquals(expectedErrors.length + expectedAborts.length, log.getNumAbortsAndErrors());
+
+    final String actualSummary = log.toString();
+    Assert.assertTrue(actualSummary.contains(expectedWarning));
+    Assert.assertTrue(actualSummary.contains(expectedError));
+    Assert.assertTrue(actualSummary.contains(expectedAbort));
+  }
+}


### PR DESCRIPTION
The motivation for these changes are to facilitate development & testing of https://github.com/tlaplus/rfcs/issues/15. In general, it is also nice for users to have programmatic access to error messages (locations and such) instead of them being encoded in a string.

These changes do three things and are broken into a series of logical commits:
1. (Before any changes) Write regression tests against the `Error` class API to ensure these changes do not break anything
2. Refactor the class to use a standard Java `List<>` instead of our custom `Vector` class
3. Change the `Errors` class to store `ErrorDetails` objects instead of string-serialized messages; this class is serialized to a string (in the same format as before) upon request.

The intention here is that this makes it very easy to modify `ErrorDetails` by adding an enumerated error code parameter, so as to incrementally introduce standardized semantic- & level-checking error codes into the codebase.

There was one small bug found by the initial tests: while the `addWarning` and `addError` APIs handled the case of a null `Location` parameter being passed in, the `addAbort` API did not; this was fixed in place.