### PR TITLE
Fill mandatory reason field to comply with the protocol (fixes #1143)

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/AttachingDebugger.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/AttachingDebugger.java
@@ -40,7 +40,6 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
-import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
 
 import tlc2.tool.impl.Tool;
@@ -149,7 +148,10 @@ public class AttachingDebugger extends TLCDebugger {
 			
 			StoppedEventArguments eventArguments = new StoppedEventArguments();
 			eventArguments.setThreadId(0);
-			eventArguments.setReason(StoppedEventArgumentsReason.PAUSE);
+			// DAP mandates non-null reason in StoppedEvent by spec.
+			// Since StoppedEvent created here is to stop the execution voluntarily on launch which
+			// pre-defined reasons doesn't fit, we fill empty-string as default.
+			eventArguments.setReason("");
 			launcher.getRemoteProxy().stopped(eventArguments);
 		});
 		

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/AttachingDebugger.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/AttachingDebugger.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 
 import org.eclipse.lsp4j.debug.OutputEventArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
 import org.eclipse.lsp4j.debug.launch.DSPLauncher;
 
 import tlc2.tool.impl.Tool;
@@ -148,6 +149,7 @@ public class AttachingDebugger extends TLCDebugger {
 			
 			StoppedEventArguments eventArguments = new StoppedEventArguments();
 			eventArguments.setThreadId(0);
+			eventArguments.setReason(StoppedEventArgumentsReason.PAUSE);
 			launcher.getRemoteProxy().stopped(eventArguments);
 		});
 		

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebugger.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebugger.java
@@ -75,6 +75,7 @@ import org.eclipse.lsp4j.debug.StepBackArguments;
 import org.eclipse.lsp4j.debug.StepInArguments;
 import org.eclipse.lsp4j.debug.StepOutArguments;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.eclipse.lsp4j.debug.StoppedEventArgumentsReason;
 import org.eclipse.lsp4j.debug.TerminateArguments;
 import org.eclipse.lsp4j.debug.TerminatedEventArguments;
 import org.eclipse.lsp4j.debug.Thread;
@@ -633,7 +634,7 @@ public abstract class TLCDebugger extends AbstractDebugger implements IDebugTarg
 			LOGGER.finer("pause -> stopped");
 			StoppedEventArguments eventArguments = new StoppedEventArguments();
 			eventArguments.setThreadId(0);
-			eventArguments.setReason("pause");
+			eventArguments.setReason(StoppedEventArgumentsReason.PAUSE);
 			launcher.getRemoteProxy().stopped(eventArguments);
 		});
 		return CompletableFuture.completedFuture(null);

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
@@ -669,6 +669,8 @@ public class TLCStackFrame extends StackFrame {
 			// the term "exception" appears in the front-end.
 			eventArguments.setReason(StoppedEventArgumentsReason.EXCEPTION);
 			eventArguments.setText(this.exception.getMessage().replaceAll("(?m)^@!@!@.*", ""));
+		} else {
+			eventArguments.setReason(StoppedEventArgumentsReason.STEP);
 		}
 		return eventArguments;
 	}

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
@@ -670,7 +670,9 @@ public class TLCStackFrame extends StackFrame {
 			eventArguments.setReason(StoppedEventArgumentsReason.EXCEPTION);
 			eventArguments.setText(this.exception.getMessage().replaceAll("(?m)^@!@!@.*", ""));
 		} else {
-			eventArguments.setReason(StoppedEventArgumentsReason.STEP);
+			// DAP mandates non-null reason in StoppedEvent by spec.
+			// Since StoppedEventArguments returned here would be sent in various cases, we just fill empty string as default.
+			eventArguments.setReason("");
 		}
 		return eventArguments;
 	}


### PR DESCRIPTION
As described in #1143, `StoppedEvent`'s `reason` field is now missing while it is mandatory, which causes some clients to fail to work with TLC debugger.