### PR TITLE
LazyValue no longer inherits from Value

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Thu  2 Aug 2007 at 10:25:48 PST by lamport
 //      modified on Fri Jan  4 22:46:57 PST 2002 by yuanyu
@@ -1776,8 +1776,7 @@ public abstract class Tool
 	for (int i = 0; i < letLen; i++) {
 	  OpDefNode opDef = letDefs[i];
 	  if (opDef.getArity() == 0) {
-	    Value rhs = new LazyValue(opDef.getBody(), c1, cm);
-	    c1 = c1.cons(opDef, rhs);
+	    c1 = c1.cons(opDef, new LazyValue(opDef.getBody(), c1, cm));
 	  }
 	}
 	return this.eval(expr1.getBody(), c1, s0, s1, control, cm);
@@ -2913,8 +2912,7 @@ public abstract class Tool
             for (int i = 0; i < letDefs.length; i++) {
               OpDefNode opDef = letDefs[i];
               if (opDef.getArity() == 0) {
-                Value rhs = new LazyValue(opDef.getBody(), c1, cm);
-                c1 = c1.cons(opDef, rhs);
+                c1 = c1.cons(opDef, new LazyValue(opDef.getBody(), c1, cm));
               }
             }
             return this.enabled(pred1.getBody(), acts, c1, s0, s1, cm);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/IValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/IValue.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2019 Microsoft Research. All rights reserved. 
- * Copyright (c) 2023, Oracle and/or its affiliates.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -44,8 +44,8 @@ import tlc2.value.impl.TLCVariable;
  *     <li>Atomic values like {@link BoolValue}, {@link IntValue}, and {@link ModelValue}</li>
  *     <li>Composite values like {@link tlc2.value.impl.SetEnumValue} and {@link tlc2.value.impl.FcnRcdValue} that
  *         build larger structures out of other values</li>
- *     <li>Lazy values like {@link tlc2.value.impl.LazyValue}, {@link tlc2.value.impl.SubsetValue}, and
- *         {@link tlc2.value.impl.FcnLambdaValue} that delay full simplification until the last possible moment</li>
+ *     <li>Lazy values like {@link tlc2.value.impl.SubsetValue} and {@link tlc2.value.impl.FcnLambdaValue} that delay
+ *         full simplification until the last possible moment</li>
  *     <li>Special values like {@link tlc2.value.impl.OpRcdValue} and {@link tlc2.value.impl.UserValue} whose
  *         purposes are highly varied</li>
  * </ul>
@@ -93,10 +93,9 @@ import tlc2.value.impl.TLCVariable;
  * {@link tlc2.value.impl.OpValue#eval} method applies an operator to arguments.
  *
  * <h2>Expression Levels</h2>
- * Some value types like {@link tlc2.value.impl.LazyValue} and {@link tlc2.value.impl.OpLambdaValue} wrap TLA+
- * expressions.  They may even wrap expressions with non-constant level (see {@link tla2sany.semantic.LevelConstants}).
- * As such, the meaning of a value is not necessarily fixed and may depend on the current behavior or whether the value
- * is used inside <code>ENABLED</code>.
+ * Some value types like {@link tlc2.value.impl.OpLambdaValue} wrap TLA+ expressions.  They may even wrap expressions
+ * with non-constant level (see {@link tla2sany.semantic.LevelConstants}).  As such, the meaning of a value is not
+ * necessarily fixed and may depend on the current behavior or whether the value is used inside <code>ENABLED</code>.
  */
 public interface IValue extends Comparable<Object> {
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/ValueConstants.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/ValueConstants.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2025, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:21:10 PST by lamport
 //      modified on Tue Aug 15 16:45:14 PDT 2000 by yuanyu
 
@@ -33,7 +34,7 @@ public interface ValueConstants {
   byte USERVALUE        = MODELVALUE + 1;
   byte INTERVALVALUE    = USERVALUE + 1;
   byte UNDEFVALUE       = INTERVALVALUE + 1;
-  byte LAZYVALUE        = UNDEFVALUE + 1;
+  byte LAZYVALUE        = UNDEFVALUE + 1; // no longer used as of 2025/2/19
   byte DUMMYVALUE       = LAZYVALUE + 1;
 
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:13 PST by lamport
 //      modified on Wed Dec  5 23:18:07 PST 2001 by yuanyu
@@ -56,7 +56,7 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
 	    "a special set constant",                     // "UserValue",
 	    "a set of the form i..j",                     // "IntervalValue",
 	    "an undefined value",                         // "UndefValue",
-	    "a value represented in lazy form",           // "LazyValue",
+	    "a value represented in lazy form",           // "LazyValue", // no longer used as of 2025/2/19
 	    "a dummy for not-a-value",                    // "DummyValue",    
 	  };
 	  


### PR DESCRIPTION
LazyValue supports none of the functionality of Value:
 - it can't be compared for equality
 - it can't be tested for membership
 - it can't be serialized
 - it can't be converted to other Value types
 - it can't be passed to Java operator overrides

It seems tempting to treat LazyValue as a not-yet-evaluated value, but that doesn't work out in practice.  The meaning of a LazyValue depends on the current behavior and whether it is being used under a prime operator or inside `ENABLED`.  TLC does not (and has never) allowed LazyValue inside another LazyValue or inside other composite values like SetEnumValue.

This change should make us a little more confident in TLC's existing (and future) code: there is greatly reduced risk of LazyValue "leaking" into places it doesn't belong.