### PR TITLE
Include name of poolFile in error message when de-serialization fails.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -367,7 +367,11 @@ public class MP
             b.append("Out Of Memory. There are probably too many initial states.");
             break;
         case EC.SYSTEM_ERROR_READING_POOL:
-            b.append("when reading the disk (StatePoolReader.run):\n%1%");
+            if (parameters.length == 2) {
+                b.append("when reading pool file %2% (StatePoolReader.run):\n%1%");
+            } else {
+                b.append("when reading the disk (StatePoolReader.run):\n%1%");
+            }
             break;
 
         case EC.SYSTEM_CHECKPOINT_RECOVERY_CORRUPT:

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskByteArrayQueue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskByteArrayQueue.java
@@ -579,7 +579,9 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 		    catch (Exception e) 
 		    {
 		      // Assert.printStack(e);
-		      MP.printError(EC.SYSTEM_ERROR_READING_POOL, e.getMessage(), e);
+		      final String[] cause = this.poolFile == null ? new String[] { e.getMessage() }
+				: new String[] { e.getMessage(), this.poolFile.getName() };
+		      MP.printError(EC.SYSTEM_ERROR_READING_POOL, cause, e);
 		      System.exit(1);
 		    }
 		  }

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/ObjectPoolStack.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/ObjectPoolStack.java
@@ -129,7 +129,9 @@ public class ObjectPoolStack {
           }
           catch (Exception e) 
           {
-              MP.printError(EC.SYSTEM_ERROR_READING_POOL, e);
+              final String[] cause = ObjectPoolStack.this.poolFile == null ? new String[] { e.getMessage() }
+				: new String[] { e.getMessage(), ObjectPoolStack.this.poolFile.getName() };
+              MP.printError(EC.SYSTEM_ERROR_READING_POOL, cause, e);
               System.exit(1);
           }
       }

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/StatePoolReader.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/StatePoolReader.java
@@ -182,8 +182,10 @@ public class StatePoolReader extends Thread {
     }
     catch (Exception e) 
     {
+      final String[] cause = this.poolFile == null ? new String[] { e.getMessage() }
+		: new String[] { e.getMessage(), this.poolFile.getName() };
       // Assert.printStack(e);
-      MP.printError(EC.SYSTEM_ERROR_READING_POOL, e.getMessage(), e);
+      MP.printError(EC.SYSTEM_ERROR_READING_POOL, cause, e);
       System.exit(1);
     }
   }


### PR DESCRIPTION
Part of Github issue #1154
https://github.com/tlaplus/tlaplus/issues/1154

[Bug][TLC]