### PR TITLE
Support expressions as filters for unsatisfied breakpoints.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCSourceBreakpoint.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCSourceBreakpoint.java
@@ -137,4 +137,10 @@ public class TLCSourceBreakpoint extends SourceBreakpoint {
 		}
 		return fire;
 	}
+
+	public boolean matchesLocation(final Location loc) {
+		return getLine() == loc.beginLine()
+				//TODO why *smaller* than BEGINcolumn?
+				&& getColumnAsInt() <= loc.beginColumn();
+	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCSourceBreakpoint.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCSourceBreakpoint.java
@@ -48,6 +48,22 @@ public class TLCSourceBreakpoint extends SourceBreakpoint {
 	private final Location location;
 	private final OpDefNode condition;
 	
+	public TLCSourceBreakpoint(final SpecProcessor processor, final String s) {
+		this.location = Location.nullLoc;
+		this.setLine(this.location.beginLine());
+		this.hits = 0;
+		
+		setCondition(s);
+		final ModuleNode semanticRoot = processor.getRootModule();
+		final OpDefNode odn = semanticRoot.getOpDef(s);
+		if (odn != null) {
+			// Use existing definition.
+			condition = odn;
+		} else {
+			condition = TLCDebuggerExpression.process(processor, semanticRoot, location, s);
+		}
+	}
+	
 	public TLCSourceBreakpoint(final SpecProcessor processor, final String module, final SourceBreakpoint s,
 			final ModuleNode semanticRoot) {
 		setColumn(s.getColumn());
@@ -139,6 +155,9 @@ public class TLCSourceBreakpoint extends SourceBreakpoint {
 	}
 
 	public boolean matchesLocation(final Location loc) {
+		if (location == Location.nullLoc) {
+			return true;
+		}
 		return getLine() == loc.beginLine()
 				//TODO why *smaller* than BEGINcolumn?
 				&& getColumnAsInt() <= loc.beginColumn();

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
@@ -702,9 +702,7 @@ public class TLCStackFrame extends StackFrame {
 		// is, where do we keep the hit count. A user would select the meaning by
 		// passing e.g. TLCGet("level") > 3 as the hit condition for state-level and a
 		// simple integer for const-level.
-		return bp.getLine() == node.getLocation().beginLine()
-				//TODO why *smaller* than BEGINcolumn?
-				&& bp.getColumnAsInt() <= node.getLocation().beginColumn();
+		return bp.matchesLocation(node.getLocation());
 	}
 
     boolean matches(SemanticNode expr, RuntimeException e) {


### PR DESCRIPTION
Previously (see git commit https://github.com/tlaplus/tlaplus/commit/f849bf1b8f85960c0c0ca2cae1034a1feeb20b52), only hit count conditions were supported.  The hit count condition can now be expressed as `TLCGet("level") >= C`, where C is the desired hit count.  If the root module does not (transitively) extend the TLC module, the expression becomes `LET T == INSTANCE TLC IN T!TLCGet("level") >= C`.

Related: https://github.com/tlaplus/tlaplus/commit/afd53e936b41b88791a8dfe0b9ce59987dec203e

Enabled by Github PR https://github.com/tlaplus/tlaplus/pull/1099 "Debugger: Add support for on demand breakpoint expressions"
https://github.com/tlaplus/tlaplus/pull/1099