### PR TITLE
Raise a warning if a state-level formula is used as a PROPERTY.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -257,6 +257,7 @@ public interface EC
     public static final int TLC_LIVE_CANNOT_EVAL_FORMULA = 2251;
     public static final int TLC_LIVE_ENCOUNTERED_NONBOOL_PREDICATE = 2252;
     public static final int TLC_LIVE_FORMULA_TAUTOLOGY = 2253;
+    public static final int TLC_LIVE_FORMULA_STATE_LEVEL = 2255;
 
     
     public static final int TLC_EXPECTED_VALUE = 2215;

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -1790,14 +1790,8 @@ public class MP
             }
             placeHolder = "%" + (i + 1) + "%"; //$NON-NLS-1$ //$NON-NLS-2$
             placeHolderPosition = buffer.indexOf(placeHolder);
-            if (placeHolderPosition != -1)
-            {
+            while ((placeHolderPosition = buffer.indexOf(placeHolder)) != -1) {
                 buffer.replace(placeHolderPosition, placeHolderPosition + placeHolder.length(), parameters[i]);
-            } else
-            {
-                // the place holder is not found
-                // stop processing
-                break;
             }
         }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -899,6 +899,15 @@ public class MP
         case EC.TLC_LIVE_FORMULA_TAUTOLOGY:
             b.append("Temporal formula is a tautology (its negation is unsatisfiable).");
             break;
+		case EC.TLC_LIVE_FORMULA_STATE_LEVEL:
+			b.append(
+					"The formula %1% is a state-level formula, but it was used as a PROPERTY (or PROPERTIES), "
+					+ "where a temporal formula is typically expected. State-level formulas used as PROPERTY "
+					+ "or PROPERTIES are only checked in the initial state. To verify that the formula %1% "
+					+ "holds in all states of every behavior, use INVARIANT %1% instead. Alternatively, "
+					+ "applying the \"always\" temporal operator (□) to the state-level formula %1% changes it "
+					+ "into a temporal formula, asserting that %1% holds in all states of every behavior.");
+			break;
 
         case EC.TLC_EXPECTED_VALUE:
             b.append("TLC expected a %1% value, but did not find one. %2%");

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -53,6 +53,7 @@ import tla2sany.semantic.ExternalModuleTable;
 import tla2sany.semantic.LabelNode;
 import tla2sany.semantic.LetInNode;
 import tla2sany.semantic.LevelConstants;
+import tla2sany.semantic.LevelNode;
 import tla2sany.semantic.ModuleNode;
 import tla2sany.semantic.NumeralNode;
 import tla2sany.semantic.OpApplNode;
@@ -992,6 +993,9 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
                 {
                     Assert.fail(EC.TLC_CONFIG_ID_REQUIRES_NO_ARG, new String[] { propName });
                 }
+				if (opDef.getLevel() == LevelNode.VariableLevel) {
+					MP.printWarning(EC.TLC_LIVE_FORMULA_STATE_LEVEL, new String[] { propName });
+				}
                 this.processConfigProps(propName, opDef.getBody(), Context.Empty, List.Empty);
             } else if (prop == null)
             {


### PR DESCRIPTION
`Warning: The formula Inv is a state-level formula, but it was used as a PROPERTY (or PROPERTIES), where a temporal formula is typically expected. State-level formulas used as PROPERTY or PROPERTIES are only checked in the initial state. To verify that the formula Inv holds in all states of every behavior, use INVARIANT Inv instead. Alternatively, applying the "always" temporal operator (□) to the state-level formula Inv changes it into a temporal formula, asserting that Inv holds in all states of every behavior.`

[Feature][TLC]