### PR TITLE
Raise a warning if checking temporal properties without a behavior spec.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -258,6 +258,7 @@ public interface EC
     public static final int TLC_LIVE_ENCOUNTERED_NONBOOL_PREDICATE = 2252;
     public static final int TLC_LIVE_FORMULA_TAUTOLOGY = 2253;
     public static final int TLC_LIVE_FORMULA_STATE_LEVEL = 2255;
+    public static final int TLC_CONFIG_NO_SPEC_BUT_PROPERTY = 2257;
 
     
     public static final int TLC_EXPECTED_VALUE = 2215;

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -908,6 +908,14 @@ public class MP
 					+ "applying the \"always\" temporal operator (□) to the state-level formula %1% changes it "
 					+ "into a temporal formula, asserting that %1% holds in all states of every behavior.");
 			break;
+		case EC.TLC_CONFIG_NO_SPEC_BUT_PROPERTY:
+			b.append(
+					"Temporal properties (PROPERTY or PROPERTIES) are being verified without a behavior specification "
+					+ "(SPECIFICATION). Only INIT and NEXT have been provided. This is likely to result in (trivial) "
+					+ "counterexamples showing infinite stuttering following the initial state. It is recommended to use "
+					+ "SPECIFICATION Spec, with Spec asserting a suitable fairness constraint (compare Chapter "
+					+ "8, page 87ff of Specifying Systems at https://lamport.azurewebsites.net/tla/book.html).");
+			break;
 
         case EC.TLC_EXPECTED_VALUE:
             b.append("TLC expected a %1% value, but did not find one. %2%");

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -1067,6 +1067,15 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
             Assert.fail(EC.TLC_CONFIG_MISSING_NEXT);
         }
         
+		if (this.config.getSpec().length() == 0 && !this.config.getProperties().isEmpty()
+				&& this.impliedTemporals.length > 0) {
+			// Raise a warning if the specification verifies one or more PROPERTIES but
+			// lacks a behavior spec (SPECIFICATION), having only INIT and NEXT. However, if
+			// the verified PROPERTY is a refinement check against another spec that doesn't
+			// assert fairness (i.e., this.impliedTemporals is empty), then it's acceptable
+			// to have PROPERTY without a corresponding SPECIFICATION.
+			MP.printWarning(EC.TLC_CONFIG_NO_SPEC_BUT_PROPERTY, new String[] { "" });
+		}
         
 		// Process overrides given by ParameterizedSpecObj *after* the ordinary config
 		// has been processed. A check above expects this.invariants to be empty if


### PR DESCRIPTION
`Warning: Temporal properties (PROPERTY or PROPERTIES) are being verified without a behavior specification (SPECIFICATION). Only INIT and NEXT have been provided. This is likely to result in (trivial) counterexamples showing infinite stuttering following the initial state. It is recommended to use SPECIFICATION Spec, with Spec asserting a suitable fairness constraint (compare Chapter 8, page 87ff of Specifying Systems at https://lamport.azurewebsites.net/tla/book.html).`

[Feature][TLC]