### PR TITLE
Add ant target for building SANY as a Graal native image

### DIFF
--- a/tlatools/org.lamport.tlatools/customBuild.xml
+++ b/tlatools/org.lamport.tlatools/customBuild.xml
@@ -405,6 +405,21 @@
 		</jar>
 	</target>
 
+	<!-- Tested with GraalVM CE 24.0.1: https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-24.0.1 -->
+	<target name="dist-sany-graal-native" depends="dist">
+		<echo>WARNING: This feature is experimental and subject to change.</echo>
+		<exec executable="native-image">
+			<arg value="-cp" />
+			<arg value="${dist.file}" />
+			<arg value="-H:+UnlockExperimentalVMOptions" /> <!-- Required for -H:IncludeResources (as of Graal 24.0.1) -->
+			<arg value="-H:IncludeResources=tla2sany/.*" /> <!-- Make sure to include resource files (i.e. standard library modules) -->
+			<arg value="-H:-CheckToolchain" /> <!-- Make Graal a little more permissive in exotic environments -->
+			<arg value="-Os" />
+			<arg value="tla2sany.SANY" />
+			<arg value="sany" />
+		</exec>
+	</target>
+
 	<!-- Compiles the TLA+ tools *test* code -->
 	<target name="compile-test">
 		<!-- compile unit tests -->


### PR DESCRIPTION
With #1176 merged, it is now possible to build a native version of SANY that starts up much faster.

If you have installed GraalVM, you should have the executable `native-image` on your $PATH and you can run

    ant -f customBuild.xml dist-sany-graal-native

to build a native `./sany` executable.

The new build command is currently undocumented and subject to change. In particular, I am not certain I have included all the neccessary resource files for everything SANY can do.  I have only tested that `./sany` correctly loads one large well-formed TLA+ spec.