### PR TITLE
Move `Value.isEmpty()` to `Enumerable`

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Enumerable.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Enumerable.java
@@ -1,10 +1,12 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2025, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 13:20:54 PST by lamport
 //      modified on Thu Mar 11 21:25:20 PST 1999 by yuanyu
 
 package tlc2.value.impl;
 
+import tlc2.tool.FingerprintException;
 import tlc2.value.IValue;
 
 public interface Enumerable extends IValue {
@@ -24,7 +26,26 @@ public interface Enumerable extends IValue {
 		 */
 		RANDOMIZED
     }
-	
+
+  /**
+   * Determine if this set is empty.  This method is roughly equivalent to testing <code>{@link #size()} == 0</code>
+   * but superior in two ways:
+   * <ul>
+   *     <li>More efficient (it is expensive to compute the size of some sets)</li>
+   *     <li>More reliable (works even if {@link #size()} would throw an exception because the set is too large)</li>
+   * </ul>
+   *
+   * @return true if this set is empty, or false if it contains at least one element
+   */
+  default boolean isEmpty() {
+    try {
+      return elements().nextElement() == null;
+    } catch (RuntimeException | OutOfMemoryError e) {
+      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
+      else { throw e; }
+    }
+  }
+
   @Override
   int size();
   boolean member(Value elem);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/IntervalValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/IntervalValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Sat 23 February 2008 at 10:12:59 PST by lamport
 //      modified on Fri Aug 10 15:07:36 PDT 2001 by yuanyu
@@ -40,7 +41,7 @@ implements Enumerable, Reducible {
 		        if (cmp != 0) {
 					return cmp;
 				}
-				if (this.size() == 0) {
+				if (this.isEmpty()) {
 					// empty intervals are equal, regardless of the low value
 					return 0;
 				}
@@ -59,7 +60,7 @@ implements Enumerable, Reducible {
     try {
       if (obj instanceof IntervalValue) {
         IntervalValue intv = (IntervalValue)obj;
-        if (this.size() == 0) return intv.size() == 0;
+        if (this.isEmpty()) return intv.isEmpty();
         return (this.low == intv.low) && (this.high == intv.high);
       }
       // Well, we have to convert them to sets and compare.
@@ -111,6 +112,11 @@ implements Enumerable, Reducible {
 
   @Override
   public final boolean isFinite() { return true; }
+
+  @Override
+  public boolean isEmpty() {
+    return this.high < this.low;
+  }
 
   @Override
   public final int size() {
@@ -183,7 +189,7 @@ implements Enumerable, Reducible {
   @Override
   public final Value cup(Value set) {
     try {
-      if (this.size() == 0) return set;
+      if (this.isEmpty()) return set;
 
       if (set instanceof Reducible) {
         ValueVec cupElems = new ValueVec();

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetEnumValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetEnumValue.java
@@ -1,5 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Sat 23 February 2008 at 10:16:24 PST by lamport
 //      modified on Mon Aug 20 10:54:08 PDT 2001 by yuanyu
@@ -247,6 +248,11 @@ public static final SetEnumValue DummyEnum = new SetEnumValue((ValueVec)null, tr
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
       else { throw e; }
     }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return elems.isEmpty();
   }
 
   @Override

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SubsetValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SubsetValue.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2021, Oracle and/or its affiliates.
+// Copyright (c) 2021, 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 13:46:07 PST by lamport
 //      modified on Fri Aug 10 15:10:16 PDT 2001 by yuanyu
@@ -156,6 +156,12 @@ public class SubsetValue extends EnumerableValue implements Enumerable {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
       else { throw e; }
     }
+  }
+
+  @Override
+  public boolean isEmpty() {
+    // SUBSET S is never empty.  (It always contains {}.)
+    return false;
   }
 
   @Override

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2023, Oracle and/or its affiliates.
+// Copyright (c) 2023, 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Mon 30 Apr 2007 at 15:30:13 PST by lamport
 //      modified on Wed Dec  5 23:18:07 PST 2001 by yuanyu
@@ -144,77 +144,6 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
   public Object setData(final Object obj) {
 		throw new WrongInvocationException("Value: Can not set data\n" +
 			    Values.ppr(toString()));
-  }
-
-  public final boolean isEmpty() {
-    try {
-
-      switch (this.getKind()) {
-        case SETENUMVALUE:
-          {
-            SetEnumValue set = (SetEnumValue)this;
-            return set.elems.size() == 0;
-          }
-        case INTERVALVALUE:
-          {
-            IntervalValue intv = (IntervalValue)this;
-            return intv.size() == 0;
-          }
-        case SETCAPVALUE:
-          {
-            SetCapValue cap = (SetCapValue)this;
-            return cap.elements().nextElement() == null;
-          }
-        case SETCUPVALUE:
-          {
-            SetCupValue cup = (SetCupValue)this;
-            return cup.elements().nextElement() == null;
-          }
-        case SETDIFFVALUE:
-          {
-            SetDiffValue diff = (SetDiffValue)this;
-            return diff.elements().nextElement() == null;
-          }
-        case SETOFFCNSVALUE:
-          {
-            SetOfFcnsValue fcns = (SetOfFcnsValue)this;
-            return fcns.elements().nextElement() == null;
-          }
-        case SETOFRCDSVALUE:
-          {
-            SetOfRcdsValue srv = (SetOfRcdsValue)this;
-            return srv.elements().nextElement() == null;
-          }
-        case SETOFTUPLESVALUE:
-          {
-            SetOfTuplesValue stv = (SetOfTuplesValue)this;
-            return stv.elements().nextElement() == null;
-          }
-        case SUBSETVALUE:
-          {
-            // SUBSET S is never empty.  (It always contains {}.)
-            return false;
-          }
-        case UNIONVALUE:
-          {
-            UnionValue uv = (UnionValue)this;
-            return uv.elements().nextElement() == null;
-          }
-        case SETPREDVALUE:
-          {
-            SetPredValue spv = (SetPredValue)this;
-            return spv.elements().nextElement() == null;
-          }
-        default:
-          Assert.fail("Shouldn't call isEmpty() on value " + Values.ppr(this.toString()), getSource());
-          return false;
-      }
-
-    }
-    catch (RuntimeException | OutOfMemoryError e) {
-      if (hasSource()) { throw FingerprintException.getNewHead(this, e); }
-      else { throw e; }
-    }
   }
 
   /* Fully normalize this (composite) value. */


### PR DESCRIPTION
See #996.

The `isEmpty()` method is only applicable to enumerable sets, so it makes sense to move it to the `Enumerable` interface.

This commit also makes the following changes:
 - Add a docstring to the method
 - Make the method non-final so it can be overridden by subclasses
 - Remove the switch-based implementation in favor of a sensible default plus individual overrides for specific subclasses
 - Replace a few ocurrences of `size() == 0` with `isEmpty()` in `IntervalValue`