### PR TITLE
Improve error messages when TLC encounters an non-enumerable value.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Integers.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Integers.java
@@ -5,6 +5,7 @@
 
 package tlc2.module;
 
+import tla2sany.semantic.ExprNode;
 import tlc2.output.EC;
 import tlc2.tool.EvalException;
 import tlc2.tool.impl.TLARegistry;
@@ -251,4 +252,14 @@ public class Integers extends UserObj implements ValueConstants
     {
         return sb.append("Int");
     }
+
+	@Override
+	public String getNonEnumerableErrorMsg(final ExprNode exprNode) {
+		return String.format(
+				"TLC encountered the non-enumerable quantifier bound\n%1$s\n%2$s\n"
+				+ "The set Int contains infinitely many elements. As a result, TLC cannot evaluate expressions that\n"
+				+ "universally (\\A) or existentially (\\E) quantify over %1$s, because this would require checking an\n"
+				+ "infinite number of cases. Note that TLC handles set membership like T \\subseteq Int for any finite set T.",
+				Values.ppr(this.toString()), exprNode.toString());
+	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Naturals.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Naturals.java
@@ -5,6 +5,7 @@
 
 package tlc2.module;
 
+import tla2sany.semantic.ExprNode;
 import tlc2.output.EC;
 import tlc2.tool.EvalException;
 import tlc2.tool.impl.TLARegistry;
@@ -260,4 +261,14 @@ public class Naturals extends UserObj implements ValueConstants
     {
         return sb.append("Nat");
     }
+
+	@Override
+	public String getNonEnumerableErrorMsg(final ExprNode exprNode) {
+		return String.format(
+				"TLC encountered the non-enumerable quantifier bound\n%1$s\n%2$s\n"
+				+ "The set Nat contains infinitely many elements. As a result, TLC cannot evaluate expressions that\n"
+				+ "universally (\\A) or existentially (\\E) quantify over %1$s, because this would require checking an\n"
+				+ "infinite number of cases. Note that TLC handles set membership like T \\subseteq Nat for any finite set T.",
+				Values.ppr(this.toString()), exprNode.toString());
+	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
@@ -6,6 +6,7 @@
 
 package tlc2.module;
 
+import tla2sany.semantic.ExprNode;
 import tlc2.output.EC;
 import tlc2.tool.EvalControl;
 import tlc2.tool.EvalException;
@@ -13,8 +14,8 @@ import tlc2.tool.impl.TLARegistry;
 import tlc2.value.IBoolValue;
 import tlc2.value.ValueConstants;
 import tlc2.value.Values;
-import tlc2.value.impl.FunctionValue;
 import tlc2.value.impl.BoolValue;
+import tlc2.value.impl.FunctionValue;
 import tlc2.value.impl.IntValue;
 import tlc2.value.impl.ModelValue;
 import tlc2.value.impl.OpValue;
@@ -486,4 +487,15 @@ public class Sequences extends UserObj implements ValueConstants
         return new TupleValue(values);
     }
 
+	@Override
+	public String getNonEnumerableErrorMsg(final ExprNode exprNode) {
+		return String.format(
+				"TLC encountered the non-enumerable quantifier bound\n%1$s\n%2$s\n"
+				+ "In TLA+, Seq(S) represents the set of all finite sequences whose elements come from the set S. Even when S\n"
+				+ "is a finite set, the number of possible sequences in Seq(S) is unbounded because sequences can have any\n"
+				+ "finite length (e.g., length 0, 1, 2, and so on). As a result, TLC cannot evaluate expressions that\n"
+				+ "universally (\\A) or existentially (\\E) quantify over %1$s, because this would require checking an\n"
+				+ "infinite number of cases. Note that for a finite set of sequences s, TLC handles s \\subseteq Seq(S).",
+				Values.ppr(this.toString()), exprNode.toString());
+	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -3982,8 +3982,7 @@ public abstract class Tool
 	    for (int i = 0; i < flen; i++) {
 	      Value boundSet = this.eval(domains[i], c, s0, s1, control, cm);
 	      if (!(boundSet instanceof Enumerable)) {
-	        Assert.fail("TLC encountered a non-enumerable quantifier bound\n" +
-	                    Values.ppr(boundSet.toString()) + ".\n" + domains[i], domains[i], c);
+	        Assert.fail(boundSet.getNonEnumerableErrorMsg(domains[i]), domains[i], c);
 	      }
 	      FormalParamNode[] farg = formals[i];
 	      if (isTuples[i]) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserObj.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserObj.java
@@ -5,6 +5,8 @@
 
 package tlc2.value.impl;
 
+import tla2sany.semantic.ExprNode;
+
 public abstract class UserObj {
 
   /* Returns negative, 0, positive for less than, equal, greater than. */
@@ -23,5 +25,8 @@ public abstract class UserObj {
     sb = this.toString(sb, 0, true);
     return sb.toString();
   }
-  
+
+  public String getNonEnumerableErrorMsg(final ExprNode exprNode) {
+	return null;
+  } 
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserValue.java
@@ -6,6 +6,7 @@
 
 package tlc2.value.impl;
 
+import tla2sany.semantic.ExprNode;
 import tlc2.tool.FingerprintException;
 import tlc2.value.IValue;
 import tlc2.value.Values;
@@ -136,4 +137,11 @@ public class UserValue extends Value {
     }
   }
 
+	@Override
+	public String getNonEnumerableErrorMsg(final ExprNode exprNode) {
+		if (userObj.getNonEnumerableErrorMsg(exprNode) != null) {
+			return userObj.getNonEnumerableErrorMsg(exprNode);
+		}
+		return super.getNonEnumerableErrorMsg(exprNode);
+	}	
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import tla2sany.semantic.ExprNode;
 import tla2sany.semantic.SemanticNode;
 import tlc2.TLCGlobals;
 import tlc2.tool.FingerprintException;
@@ -397,5 +398,10 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
 					.collect(Collectors.toList());
 		}
 		return new ArrayList<>(0);
+	}
+
+	public String getNonEnumerableErrorMsg(final ExprNode exprNode) {
+		return "TLC encountered a non-enumerable quantifier bound\n" +
+                Values.ppr(this.toString()) + ".\n" + exprNode.toString();
 	}
 }


### PR DESCRIPTION
```
TLC encountered a non-enumerable quantifier bound
Seq({1, 2}).
line 49, col 17 to line 49, col 26 of module DieHard
```

```
TLC encountered the non-enumerable quantifier bound
Seq({1, 2})
line 49, col 17 to line 49, col 26 of module DieHard
In TLA+, Seq(S) represents the set of all finite sequences whose
elements come from the set S. Even when S is a finite set, the number of
possible sequences in Seq(S) is unbounded because sequences can have any
finite length (e.g., length 0, 1, 2, and so on). As a result, TLC cannot
evaluate expressions that universally (\A) or existentially (\E)
quantify over Seq({1, 2}), because this would require checking an
infinite number of cases. Note that for a finite set of sequences s, TLC
handles s \subseteq Seq(S).
```

```
TLC encountered the non-enumerable quantifier bound
Nat
line 48, col 17 to line 48, col 19 of module DieHard
```
```
TLC encountered the non-enumerable quantifier bound
Nat
line 48, col 17 to line 48, col 19 of module DieHard
The set Nat contains infinitely many elements. As a result, TLC cannot
evaluate expressions that
universally (\A) or existentially (\E) quantify over Nat, because this
would require checking an
infinite number of cases. Note that TLC handles set membership like T
\subseteq Nat for a finite set T.
```

```
TLC encountered the non-enumerable quantifier bound
Int
line 48, col 17 to line 48, col 19 of module DieHard
```

```
TLC encountered the non-enumerable quantifier bound
Int
line 48, col 17 to line 48, col 19 of module DieHard
The set Int contains infinitely many elements. As a result, TLC cannot
evaluate expressions that
universally (\A) or existentially (\E) quantify over Int, because this
would require checking an
infinite number of cases. Note that TLC handles set membership like T
\subseteq Int for any finite set T.
```

[Feature][TLC]

Related: https://github.com/tlaplus/rfcs/issues/15