### PR TITLE
When an invariant is violated, show the values of any \A-bound names

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -7,6 +7,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 
@@ -498,6 +499,9 @@ public class MP
             break;
         case EC.TLC_INVARIANT_VIOLATED_INITIAL:
             b.append("Invariant %1% is violated by the initial state:\n%2%");
+            if (parameters.length > 2) {
+                b.append("\n%3%");
+            }
             break;
         case EC.TLC_PROPERTY_VIOLATED_INITIAL:
             b.append("Property %1% is violated by the initial state:\n%2%");
@@ -519,6 +523,9 @@ public class MP
             break;
         case EC.TLC_INVARIANT_VIOLATED_BEHAVIOR:
             b.append("Invariant %1% is violated.");
+            if (parameters.length > 1) {
+                b.append("\n%2%");
+            }
             break;
         case EC.TLC_INVARIANT_VIOLATED_LEVEL:
         	b.append("The invariant %1% is not a state predicate (one with no primes or temporal operators).");

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/FalseExpressionWithDetails.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/FalseExpressionWithDetails.java
@@ -1,0 +1,55 @@
+// Copyright (c) 2025, Oracle and/or its affiliates.
+
+package tlc2.tool;
+
+import tla2sany.semantic.SemanticNode;
+import tlc2.util.Context;
+
+/**
+ * Information about an expression that evaluated to FALSE with details about why.  This class has no particular
+ * publicly-exposed structure, only a single {@link #prettyPrint()} method to display the information.
+ */
+public class FalseExpressionWithDetails {
+
+    /**
+     * Alias for {@code null}, used if an expression was actually true instead of false.  This constant provides
+     * a slightly more readable name than using {@code null} directly.
+     */
+    public static final FalseExpressionWithDetails NO_VIOLATION = null;
+
+    private final SemanticNode subexpression;
+    private final Context context;
+
+    public FalseExpressionWithDetails(SemanticNode subexpression, Context context) {
+        this.subexpression = subexpression;
+        this.context = context;
+    }
+
+    public String prettyPrint() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("The first false conjunct was: ").append(subexpression);
+
+        Context ptr = context;
+        if (ptr != Context.Empty) {
+            sb.append("\nValues of \\A-bound names: ");
+            while (ptr != Context.Empty) {
+                sb.append("\n    ")
+                        .append(ptr.getName().getName())
+                        .append(" = ")
+                        .append(ptr.getValue());
+                ptr = ptr.next();
+            }
+        }
+
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "FalseExpressionWithDetails{" +
+                "subexpression=" + subexpression +
+                ", context=" + context +
+                '}';
+    }
+
+}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ITool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ITool.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2019 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2025, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -126,6 +127,17 @@ public interface ITool extends TraceApp, OpDefEvaluator {
 	TLCState enabled(SemanticNode pred, Context c, TLCState s0, TLCState s1);
 	TLCState enabled(SemanticNode pred, IActionItemList acts, Context c, TLCState s0, TLCState s1);
 	TLCState enabled(SemanticNode pred, IActionItemList acts, Context c, TLCState s0, TLCState s1, CostModel cm);
+
+	/**
+	 * Evaluate the given action, and if it evaluates to FALSE, return information about why.
+	 *
+	 * @param act the action
+	 * @param s0 the current state
+	 * @param s1 the next state (or {@link TLCState#Empty})
+	 * @return information about why the action evaluates to FALSE, or {@code null} if the action evaluates to TRUE
+	 * @throws util.Assert.TLCRuntimeException if the action does not evaluate to a boolean value
+	 */
+	FalseExpressionWithDetails checkValidity(Action act, TLCState s0, TLCState s1);
 
 	boolean isValid(ExprNode expr, Context ctxt);
 	

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ModelChecker.java
@@ -559,15 +559,15 @@ public class ModelChecker extends AbstractChecker
         return false;
 	}
 
-	final boolean doNextSetErr(TLCState curState, TLCState succState, boolean keep, int ec, String param) throws IOException, WorkerException {
+	final boolean doNextSetErr(TLCState curState, TLCState succState, boolean keep, int ec, String... params) throws IOException, WorkerException {
 		synchronized (this)
 		{
 		    if (this.setErrState(curState, succState, keep, ec))
 		    {
-		    	if (param == null) {
+		    	if (params == null) {
 		    		MP.printError(ec);
 		    	} else {
-		    		MP.printError(ec, param);
+		    		MP.printError(ec, params);
 		    	}
 				this.trace.printTrace(curState, succState);
 				this.theStateQueue.finishAll();
@@ -1181,10 +1181,11 @@ public class ModelChecker extends AbstractChecker
 				// Check properties of the state:
 				if (!seen || forceChecks) {
 					for (int j = 0; j < tool.getInvariants().length; j++) {
-						if (!tool.isValid(tool.getInvariants()[j], curState)) {
+						FalseExpressionWithDetails falseExpr = this.tool.checkValidity(this.tool.getInvariants()[j], curState, TLCState.Empty);
+						if (falseExpr != null) {
 							// We get here because of invariant violation:
 							MP.printError(EC.TLC_INVARIANT_VIOLATED_INITIAL,
-									new String[] { tool.getInvNames()[j].toString(), tool.evalAlias(curState, curState).toString() });
+									new String[] { tool.getInvNames()[j].toString(), tool.evalAlias(curState, curState).toString(), falseExpr.prettyPrint() });
 							if (!TLCGlobals.continuation) {
 								this.errState = curState;
 								returnValue = EC.TLC_INVARIANT_VIOLATED_INITIAL;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/DebugTool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/DebugTool.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright (c) 2020 Microsoft Research. All rights reserved. 
+ * Copyright (c) 2025, Oracle and/or its affiliates.
  *
  * The MIT License (MIT)
  * 
@@ -48,6 +49,7 @@ import tlc2.tool.INextStateFunctor;
 import tlc2.tool.INextStateFunctor.InvariantViolatedException;
 import tlc2.tool.IStateFunctor;
 import tlc2.tool.ITool;
+import tlc2.tool.FalseExpressionWithDetails;
 import tlc2.tool.TLCState;
 import tlc2.tool.TLCStateFun;
 import tlc2.tool.TLCStateMutExt;
@@ -123,20 +125,28 @@ public class DebugTool extends Tool {
 	}
 
 	@Override
-	public boolean isValid(Action act, TLCState state) {
+	public FalseExpressionWithDetails checkValidity(Action act, TLCState s0, TLCState s1) {
+		// Need this override for breakpoints to work
+		return isValid(act, s0, s1)
+			? null
+			: new FalseExpressionWithDetails(act.pred, Context.Empty);
+	}
+
+	@Override
+	public boolean isValid(Action act, TLCState s0, TLCState s1) {
 		if (act.isInternal()) {
 			mode = EvalMode.Debugger;
 			try {
-				return this.isValid(act, state, TLCState.Empty);
+				return super.isValid(act, s0, s1);
 			} finally {
 				mode = EvalMode.State;
 			}
 		}
 		mode = EvalMode.State;
 		try {
-			return this.isValid(act, state, TLCState.Empty);
+			return super.isValid(act, s0, s1);
 		} catch (ResetEvalException ree) {
-			return this.isValid(act, state);
+			return super.isValid(act, s0, s1);
 		}
 	}
 	

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
-// Copyright (c) 2022, 2023, Oracle and/or its affiliates.
+// Copyright (c) 2022, 2025, Oracle and/or its affiliates.
 // Last modified on Wed 12 Jul 2017 at 16:10:00 PST by ian morris nieves
 //      modified on Thu  2 Aug 2007 at 10:25:48 PST by lamport
 //      modified on Fri Jan  4 22:46:57 PST 2002 by yuanyu
@@ -44,6 +44,7 @@ import tlc2.tool.IContextEnumerator;
 import tlc2.tool.INextStateFunctor;
 import tlc2.tool.IStateFunctor;
 import tlc2.tool.ITool;
+import tlc2.tool.FalseExpressionWithDetails;
 import tlc2.tool.StateVec;
 import tlc2.tool.TLCState;
 import tlc2.tool.TLCStateFun;
@@ -3486,9 +3487,112 @@ public abstract class Tool
         return this.enabled(acts, s0, s1, cm);
   }
 
+    @Override
+    public FalseExpressionWithDetails checkValidity(Action act, TLCState s0, TLCState s1) {
+      return checkValidity(
+              act.pred,
+              act.con,
+              s0,
+              s1,
+              act.cm,
+              act.con);
+    }
+
+    /**
+     * Helper for {@link ITool#checkValidity(Action, TLCState, TLCState)}.
+     */
+    private FalseExpressionWithDetails checkValidity(SemanticNode expr, Context c, TLCState s0, TLCState s1, CostModel cm, Context relevantAssignments) {
+        if (expr.getKind() == OpApplKind) {
+            OpApplNode appl = (OpApplNode) expr;
+            ExprOrOpArgNode[] args = appl.getArgs();
+            SymbolNode opNode = appl.getOperator();
+            int opcode = BuiltInOPs.getOpCode(opNode.getName());
+
+            switch (opcode) {
+                case 0: { // User-defined operator, maybe substituted
+                    if (args.length == 0) {
+                        Object val = this.lookup(opNode, c, s0, false);
+                        if (val instanceof LazyValue) {
+                            LazyValue lv = (LazyValue) val;
+                            if (coverage) {
+                                cm = cm.getAndIncrement(expr);
+                            }
+                            return checkValidity(lv.expr, lv.con, s0, s1, cm, relevantAssignments);
+                        } else if (val instanceof OpDefNode) {
+                            OpDefNode opDef = (OpDefNode) val;
+                            opcode = BuiltInOPs.getOpCode(opDef.getName());
+                            if (opcode == 0) {
+                                if (coverage) {
+                                    cm = cm.getAndIncrement(expr);
+                                }
+                                Context c1 = this.getOpContext(opDef, args, c, true, cm, toolId);
+                                return checkValidity(opDef.getBody(), c1, s0, s1, cm, relevantAssignments);
+                            }
+                        }
+                    }
+                    break;
+                }
+                case OPCODE_bf: { // BoundedForall
+                    if (coverage) {
+                        cm = cm.getAndIncrement(expr);
+                    }
+                    ContextEnumerator Enum = this.contexts(appl, c, s0, s1, EvalControl.Clear, cm);
+                    SemanticNode body = args[0];
+                    Context c1;
+                    while ((c1 = Enum.nextElement()) != null) {
+                        FalseExpressionWithDetails result = checkValidity(body, c1, s0, s1, cm, c1.withAlternateSuffix(c, relevantAssignments));
+                        if (result != null) {
+                            return result;
+                        }
+                    }
+                    return FalseExpressionWithDetails.NO_VIOLATION;
+                }
+                case OPCODE_cl: // ConjList
+                case OPCODE_land: {
+                    if (coverage) {
+                        cm = cm.getAndIncrement(expr);
+                    }
+                    for (ExprOrOpArgNode arg : args) {
+                        FalseExpressionWithDetails result = checkValidity(arg, c, s0, s1, cm, relevantAssignments);
+                        if (result != FalseExpressionWithDetails.NO_VIOLATION) {
+                            return result;
+                        }
+                    }
+                    return FalseExpressionWithDetails.NO_VIOLATION;
+                }
+                case OPCODE_implies: {
+                    if (coverage) {
+                        cm = cm.getAndIncrement(expr);
+                    }
+                    ExprOrOpArgNode arg0 = args[0];
+                    ExprOrOpArgNode arg1 = args[1];
+
+                    Value val = this.eval(arg0, c, s0, s1, EvalControl.Clear, cm);
+                    if (!(val instanceof BoolValue)) {
+                        Assert.fail(EC.TLC_EXPECTED_VALUE, new String[]{"boolean", arg0.toString()}, arg0, c);
+                    }
+
+                    return ((BoolValue) val).val
+                            ? checkValidity(arg1, c, s0, s1, cm, relevantAssignments)
+                            : FalseExpressionWithDetails.NO_VIOLATION;
+                }
+            }
+
+            // fall thru to default case
+        }
+
+        Value val = this.eval(expr, c, s0, s1, EvalControl.Clear, cm);
+        if (!(val instanceof BoolValue)) {
+            Assert.fail(EC.TLC_EXPECTED_VALUE, new String[]{"boolean", expr.toString()}, expr, c);
+        }
+        return ((BoolValue) val).val
+                ? FalseExpressionWithDetails.NO_VIOLATION
+                : new FalseExpressionWithDetails(expr, relevantAssignments);
+    }
+
   /* This method determines if the action predicate is valid in (s0, s1). */
   @Override
-  public final boolean isValid(Action act, TLCState s0, TLCState s1) {
+  public boolean isValid(Action act, TLCState s0, TLCState s1) {
     Value val = this.eval(act.pred, act.con, s0, s1, EvalControl.Clear, act.cm);
     if (!(val instanceof BoolValue)) {
       Assert.fail(EC.TLC_EXPECTED_VALUE, new String[]{"boolean", act.pred.toString()}, act.pred, act.con);

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/Context.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/Context.java
@@ -1,12 +1,15 @@
 // Copyright (c) 2003 Compaq Corporation.  All rights reserved.
 // Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+// Copyright (c) 2025, Oracle and/or its affiliates.
 // Last modified on Mon 30 Apr 2007 at 15:30:03 PST by lamport
 //      modified on Fri Feb 16 14:26:21 PST 2001 by yuanyu
 
 package tlc2.util;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -236,6 +239,41 @@ public final class Context implements Iterator<Context> {
 		}
 		return new Context(this.name, this.value, this.next.deepCopy());
 	}
+
+	/**
+	 * Create a new context by replacing a suffix of this one.  For example, given the context
+	 * <pre>
+	 *     a -> b -> c -> d -> e
+	 * </pre>
+	 * replacing suffix {@code c -> d -> e} with {@code x -> y} results in
+	 * <pre>
+	 *     a -> b -> x -> y
+	 * </pre>
+	 *
+	 * <p>Contexts are immutable; this method does not modify the receiver.
+	 *
+	 * <p>Note that suffixes are compared using reference equality.
+	 *
+	 * @param oldSuffix the suffix to replace
+	 * @param newSuffix the new suffix to add
+	 * @return a context with the old suffix replaced with the new suffix
+	 */
+	public Context withAlternateSuffix(Context oldSuffix, Context newSuffix) {
+		List<Context> prefix = new ArrayList<>(this.depth());
+		Context ptr = this;
+		while (ptr != oldSuffix && ptr != null) {
+			prefix.add(ptr);
+			ptr = ptr.next();
+		}
+
+		Context result = newSuffix;
+		for (int i = prefix.size() - 1; i >= 0; i--) {
+			Context entry = prefix.get(i);
+			result = result.cons(entry.getName(), entry.getValue());
+		}
+		return result;
+	}
+
 }
 /*
 ----------------------------- MODULE Scoping -----------------------------


### PR DESCRIPTION
This commit makes TLC output some additional helpful information for invariants of the form

    \A x \in S: P(x)

Specifically, TLC will now point to the souce location of P and give the value of x that makes P false.

For instance, given a simple spec like

    ---- MODULE InvariantViolationExplanation ----
    EXTENDS Naturals
    VARIABLE i
    Init == i = 1
    Next == i < 10 /\ i' = i + 1
    Safe == \A x \in 0..i: x+x /= i
    ====

TLC will now output

    Error: Invariant Safe is violated.
    More information: The expression at line 6, col 24 to line 6, col 31 of module InvariantViolationExplanation is FALSE (when x = 1)

(In addition to the behavior leading to the violation, which contains the value of `i`.)

Having the specific value of x can make the violation much easier to digest.