### PR TITLE
Raise warning when symbol appears in Records.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java
@@ -164,7 +164,8 @@ public enum ErrorCode {
    * Standardized warnings. These should not cause a parse failure.
    */
   EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY (4800, ErrorLevel.WARNING),
-  INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY (4801, ErrorLevel.WARNING);
+  INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY (4801, ErrorLevel.WARNING),
+  RECORD_CONSTRUCTOR_FIELD_NAME_CLASH (4802, ErrorLevel.WARNING);
 
   /**
    * The error's level of seriousness.

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
@@ -4075,6 +4075,17 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 					);
 				}
 			}
+			
+			final SymbolNode s = symbolTable.resolveSymbol(labels[lvi]);
+			if (s != null) {
+				errors.addWarning(ErrorCode.RECORD_CONSTRUCTOR_FIELD_NAME_CLASH, syntaxTreeNode[0].getLocation(), String
+						.format("The field name \"%1$s\" in the record constructor is identical to the existing definition or declaration\n"
+								+ "named %1$s, located at %2$s.\n"
+								+ "The field in the record will not take the value of the %1$s definition or declaration.\n"
+								+ "In TLA+, field names in records are strings, regardless of any similarly named declarations or definitions.\n"
+								+ "Therefore, DOMAIN [%1$s |-> ...] = {\"%1$s\"} holds true.",
+								labels[lvi], s.getLocation()));
+			}
 
 			// The second one gets the expression indicating the field value (or set of
 			// values)

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/error_corpus/W4802_Pre_Test.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/error_corpus/W4802_Pre_Test.tla
@@ -1,0 +1,8 @@
+If a symbol is defined then a record is defined with a field name
+overlapping with the symbol, generate a warning since the value of
+the symbol will not be used as the record field name.
+---- MODULE W4802_Pre_Test ----
+Foo == TRUE
+SomeRecord == [Foo |-> 42]
+====
+


### PR DESCRIPTION
Addresses Github issue #1184
https://github.com/tlaplus/tlaplus/issues/1184

[Feature][TLC]

```
The field name "SomeField" in the record constructor is identical to the existing definition or declaration
named SomeField, located at line 5, col 1 to line 6, col 4 of module RiverCrossingFlashlight.
The field in the record will not take the value of the SomeField definition or declaration.
In TLA+, field names in records are strings, regardless of any similarly named declarations or definitions.
Therefore, DOMAIN [SomeField |-> ...] = {"SomeField"} holds true.
```