### PR TITLE
Raise warning when symbol appears in Records.

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticCorpusTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticCorpusTests.java
@@ -194,6 +194,7 @@ public class SemanticCorpusTests {
     }
     Assert.assertTrue(out.toString(), spec.parseErrors.isSuccess());
     Assert.assertTrue(out.toString(), spec.semanticErrors.isSuccess());
+    Assert.assertTrue(out.toString(), spec.semanticErrors.getWarnings().length == 0);
     return spec.getExternalModuleTable();
   }
 

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/corpus/ProofsTest.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/corpus/ProofsTest.tla
@@ -26,10 +26,10 @@ PROOF BY
     OmittedProof,
     ProofByDef
 
-(* ID: ProofByQED *)
-THEOREM ProofByQED == RefersTo(c, "c")
+(* ID: ProofByQEDA *)
+THEOREM ProofByQEDA == RefersTo(c, "c")
 PROOF
-  (* ID: ProofByQED!<1>a *)
+  (* ID: ProofByQEDA!<1>a *)
   <1>a QED
 
 (* ID: ProofByQED *)
@@ -56,7 +56,7 @@ COROLLARY NestedProof == []RefersTo(v, "v")
   (* ID: NestedProof!<2>b *) <2>b IsLevel(RefersTo(<1>b, "NestedProof!<1>b"), VariableLevel)
   (* ID: NestedProof!<2>c *) <2>c IsLevel(RefersTo(<1>c, "NestedProof!<1>c"), ActionLevel)
   (* ID: NestedProof!<2>d *) <2>d IsLevel(RefersTo(<1>d, "NestedProof!<1>d"), TemporalLevel)
-  <2>d QED
+  <2>e QED
     (* ID: NestedProof!<3>a *) <3>a IsLevel(RefersTo(<2>a, "NestedProof!<2>a"), ConstantLevel)
     (* ID: NestedProof!<3>b *) <3>b IsLevel(RefersTo(<2>b, "NestedProof!<2>b"), VariableLevel)
     (* ID: NestedProof!<3>c *) <3>c IsLevel(RefersTo(<2>c, "NestedProof!<2>c"), ActionLevel)
@@ -66,7 +66,7 @@ COROLLARY NestedProof == []RefersTo(v, "v")
       RefersTo(<3>b, "NestedProof!<3>b"),
       RefersTo(<3>c, "NestedProof!<3>c"),
       RefersTo(<3>d, "NestedProof!<3>d")
-<1>d QED BY
+<1>e QED BY
   RefersTo(<1>a, "NestedProof!<1>a"),
   RefersTo(<1>b, "NestedProof!<1>b"),
   RefersTo(<1>c, "NestedProof!<1>c"),

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/corpus/RecordsTest.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/corpus/RecordsTest.tla
@@ -52,4 +52,6 @@ THEOREM TemporalRecord == IsLevel([
   TemporalLevel
 )
 
+
+THEOREM SomeRecord == [c |-> c] = [ x \in {"c"} |-> c]  
 =============================================================================


### PR DESCRIPTION
Do NOT raise a warning in cases like the following, which imply that the user understands the semantics correctly (context: https://github.com/tlaplus/tlaplus/issues/1184):

```tla
bar == 23
R == [bar |-> bar]
```

This scenario frequently comes up in a TLC ALIAS
(https://github.com/tlaplus/tlaplus/issues/485).

Related to Git commit e61495931507f5ad5ec232be9e65fe8f2a1bf379

Follow-up of Github issue #1184
https://github.com/tlaplus/tlaplus/issues/1184

[Feature][TLC]