### PR TITLE
Relax recommendation for tabs over spaces

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -216,7 +216,7 @@ That said, it is worth following a few guiding principles:
 For new Java code we recommend (but do not require):
 
  - Each `public` class and method should have a javadoc description of its purpose and behavior.
- - Use 4 spaces for indentation.  If you choose to use tabs instead, do not mix tabs and spaces.
+ - Do not mix tabs and spaces.
  - Put opening curly braces (`{`) on the same line as the corresponding declaration or statement.
  - Include braces for single-statement bodies of statements like `if` and `while`, even though they are optional.
  - Avoid lines longer than 120 characters.


### PR DESCRIPTION
Addresses #1198.

It was not my intention to be prescriptive here.  The default Eclipse settings use tabs.

Until we reach consensus on what style (if any) to standardize on, I don't think there's a reason to have a fine-grained rule in this slot. The number one rule above still stands:

 > 1. Modifications should copy the style of nearby code rather than change it.