### PR TITLE
SANY: created unified errors.addMessage() error reporting method

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 4270 Linux Foundation. All rights reserved.
+ * Copyright (c) 2025 Linux Foundation. All rights reserved.
  *
  * The MIT License (MIT)
  *
@@ -63,7 +63,7 @@ public enum ErrorCode {
    * never be reached since the semantic checking process will have failed
    * before those points.
    */
-  SUSPECTED_UNREACHABLE_CHECK (4004, ErrorLevel.UNDEFINED),
+  SUSPECTED_UNREACHABLE_CHECK (4004, ErrorLevel.ERROR),
 
   /**
    * SANY contains some code handling language features that are either not
@@ -79,7 +79,7 @@ public enum ErrorCode {
    * Subexpressions are one prominent category of language feature tagged
    * with this error code.
    */
-  UNSUPPORTED_LANGUAGE_FEATURE (4005, ErrorLevel.UNDEFINED),
+  UNSUPPORTED_LANGUAGE_FEATURE (4005, ErrorLevel.ERROR),
 
   /**
    * Standardized errors. These should cause a parse failure. They are
@@ -171,7 +171,6 @@ public enum ErrorCode {
    * The error's level of seriousness.
    */
   public static enum ErrorLevel {
-    UNDEFINED,
     WARNING,
     ERROR
   }

--- a/tlatools/org.lamport.tlatools/test/tla2sany/api/SANYFrontend.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/api/SANYFrontend.java
@@ -120,7 +120,7 @@ public class SANYFrontend implements Frontend {
     for (final String dependencyName : dependencies) {
       if (incompleteModules.contains(dependencyName)) {
         // TODO: reconstruct dependency chain for error message
-        throw log.addError(
+        throw log.addMessage(
           ErrorCode.MODULE_DEPENDENCIES_ARE_CIRCULAR,
           Location.nullLoc,
           "Circular dependency detected"

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticCorpusTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticCorpusTests.java
@@ -194,7 +194,7 @@ public class SemanticCorpusTests {
     }
     Assert.assertTrue(out.toString(), spec.parseErrors.isSuccess());
     Assert.assertTrue(out.toString(), spec.semanticErrors.isSuccess());
-    Assert.assertTrue(out.toString(), spec.semanticErrors.getWarnings().length == 0);
+    Assert.assertTrue(out.toString(), spec.semanticErrors.getWarningDetails().isEmpty());
     return spec.getExternalModuleTable();
   }
 

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestErrors.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/TestErrors.java
@@ -53,21 +53,21 @@ public class TestErrors {
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test warning message";
-    log.addWarning(ErrorCode.INTERNAL_ERROR, loc1, message1);
+    log.addMessage(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1);
     final String expected1 = loc1.toString() + "\n\n" + message1;
-    expectedDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc1, message1));
+    expectedDetails.add(new ErrorDetails(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is another test warning message";
-    log.addWarning(ErrorCode.INTERNAL_ERROR, loc2, message2);
+    log.addMessage(ErrorCode.INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc2, message2);
     final String expected2 = loc2.toString() + "\n\n" + message2;
-    expectedDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc2, message2));
+    expectedDetails.add(new ErrorDetails(ErrorCode.INSTANCED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc2, message2));
 
     final Location loc3 = Location.nullLoc;
     final String message3 = "This is yet another test warning message";
-    log.addWarning(ErrorCode.INTERNAL_ERROR, null, message3);
+    log.addMessage(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, null, message3);
     final String expected3 = loc3.toString() + "\n\n" + message3;
-    expectedDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc3, message3));
+    expectedDetails.add(new ErrorDetails(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc3, message3));
 
     final String[] expected = new String[] { expected1, expected2, expected3 };
     final String[] actual = log.getWarnings();
@@ -79,6 +79,7 @@ public class TestErrors {
     Assert.assertEquals(0, log.getErrors().length);
 
     final List<ErrorDetails> blank = new ArrayList<ErrorDetails>();
+    Assert.assertEquals(expectedDetails, log.getMessages());
     Assert.assertEquals(expectedDetails, log.getWarningDetails());
     Assert.assertEquals(blank, log.getErrorDetails());
 
@@ -95,19 +96,19 @@ public class TestErrors {
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test error message";
-    log.addError(ErrorCode.INTERNAL_ERROR, loc1, message1);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, loc1, message1);
     final String expected1 = loc1.toString() + "\n\n" + message1;
     expectedDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is another test error message";
-    log.addError(ErrorCode.INTERNAL_ERROR, loc2, message2);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, loc2, message2);
     final String expected2 = loc2.toString() + "\n\n" + message2;
     expectedDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc2, message2));
 
     final Location loc3 = Location.nullLoc;
     final String message3 = "This is yet another test error message";
-    log.addError(ErrorCode.INTERNAL_ERROR, null, message3);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, null, message3);
     final String expected3 = loc3.toString() + "\n\n" + message3;
     expectedDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc3, message3));
 
@@ -122,6 +123,7 @@ public class TestErrors {
 
     final List<ErrorDetails> blank = new ArrayList<ErrorDetails>();
     Assert.assertEquals(blank, log.getWarningDetails());
+    Assert.assertEquals(expectedDetails, log.getMessages());
     Assert.assertEquals(expectedDetails, log.getErrorDetails());
 
     final String actualSummary = log.toString();
@@ -136,15 +138,15 @@ public class TestErrors {
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test warning message";
-    log.addWarning(ErrorCode.INTERNAL_ERROR, loc1, message1);
+    log.addMessage(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1);
     final String expectedWarning = loc1.toString() + "\n\n" + message1;
     final String[] expectedWarnings = new String[] { expectedWarning };
     final List<ErrorDetails> expectedWarningDetails = new ArrayList<ErrorDetails>();
-    expectedWarningDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc1, message1));
+    expectedWarningDetails.add(new ErrorDetails(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is a test error message";
-    log.addError(ErrorCode.INTERNAL_ERROR, loc2, message2);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, loc2, message2);
     final String expectedError = loc2.toString() + "\n\n" + message2;
     final String[] expectedErrors = new String[] { expectedError };
     final List<ErrorDetails> expectedErrorDetails = new ArrayList<ErrorDetails>();
@@ -171,19 +173,19 @@ public class TestErrors {
 
     final Location loc1 = genLocation();
     final String message1 = "This is a test warning message";
-    log.addWarning(ErrorCode.INTERNAL_ERROR, loc1, message1);
-    log.addWarning(ErrorCode.INTERNAL_ERROR, loc1, message1);
-    log.addWarning(ErrorCode.INTERNAL_ERROR, loc1, message1);
+    log.addMessage(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1);
+    log.addMessage(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1);
+    log.addMessage(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1);
     final String expectedWarning = loc1.toString() + "\n\n" + message1;
     final String[] expectedWarnings = new String[] { expectedWarning };
     final List<ErrorDetails> expectedWarningDetails = new ArrayList<ErrorDetails>();
-    expectedWarningDetails.add(new ErrorDetails(ErrorCode.INTERNAL_ERROR, loc1, message1));
+    expectedWarningDetails.add(new ErrorDetails(ErrorCode.EXTENDED_MODULES_SYMBOL_UNIFICATION_AMBIGUITY, loc1, message1));
 
     final Location loc2 = genLocation();
     final String message2 = "This is a test error message";
-    log.addError(ErrorCode.INTERNAL_ERROR, loc2, message2);
-    log.addError(ErrorCode.INTERNAL_ERROR, loc2, message2);
-    log.addError(ErrorCode.INTERNAL_ERROR, loc2, message2);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, loc2, message2);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, loc2, message2);
+    log.addMessage(ErrorCode.INTERNAL_ERROR, loc2, message2);
     final String expectedError = loc2.toString() + "\n\n" + message2;
     final String[] expectedErrors = new String[] { expectedError };
     final List<ErrorDetails> expectedErrorDetails = new ArrayList<ErrorDetails>();


### PR DESCRIPTION
Also unified error reporting to single method

In commit be86598, error messages were tagged with a standardized error code. This code also contains an associated error level. Thus, in these changes the error reporting methods addError() and addWarning() are merged into a single method addMessage(), since the error level is already encoded in the standardized error code. The existing methods were tagged as deprecated. Some test code was updated to use the new method.

[SANY][Refactor]