### PR TITLE
Do not ignore silently but raise warning if an invariant is a *constant-level* formula.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -76,6 +76,7 @@ public interface EC
     public static final int TLC_INVARIANT_VIOLATED_BEHAVIOR = 2110;
     public static final int TLC_INVARIANT_EVALUATION_FAILED = 2111;
     public static final int TLC_INVARIANT_VIOLATED_LEVEL = 2146;
+    public static final int TLC_INVARIANT_CONSTANT_LEVEL = 2149;
     public static final int TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR = 2112;
     public static final int TLC_ACTION_PROPERTY_EVALUATION_FAILED = 2113;
     public static final int TLC_DEADLOCK_REACHED = 2114;

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -528,6 +528,11 @@ public class MP
         				+ "please check if this bug described in LevelNode.java starting at line 590ff affects you.");
         	}
             break;
+        case EC.TLC_INVARIANT_CONSTANT_LEVEL:
+			b.append(
+					"The invariant %1% is a constant-level formula (i.e., it contains no variables, primes, or temporal operators) and evaluates to %2%. "
+					+ "To assert constant-level formulas in your spec, use ASSUME ConstInv, or to give the assumption a name such as YourAssumption, use ASSUME YourAssumption == ConstInv.");
+            break;
 
         case EC.TLC_INVARIANT_EVALUATION_FAILED:
             if (parameters.length == 1) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -1210,7 +1210,10 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
             } else if (!(inv instanceof IBoolValue) || !(((BoolValue) inv).val))
             {
                 Assert.fail(EC.TLC_CONFIG_ID_HAS_VALUE, new String[] { "invariant", name, inv.toString() });
-            }
+            } else if (inv instanceof IBoolValue)
+			{
+            	MP.printWarning(EC.TLC_INVARIANT_CONSTANT_LEVEL, new String[] { name, ((BoolValue) inv).toString() });
+			}
         }
     }
 

--- a/tlatools/org.lamport.tlatools/test-model/ConstLevelInvariant.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ConstLevelInvariant.tla
@@ -1,0 +1,25 @@
+---- MODULE ConstLevelInvariant ----
+EXTENDS Naturals
+
+CONSTANT C
+
+VARIABLE b
+
+Init ==
+    b = FALSE
+
+Next ==
+    b' = TRUE
+
+Spec ==
+	Init /\ [][Next]_b
+
+ConstLevelInvariant ==
+    C \subseteq Nat
+
+=============================================================================
+---- CONFIG ConstLevelInvariant ----
+SPECIFICATION Spec
+CONSTANT C = {1, 2, 3}
+INVARIANT ConstLevelInvariant
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstLevelInvariantTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstLevelInvariantTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ConstLevelInvariantTest extends ModelCheckerTestCase {
+
+	public ConstLevelInvariantTest() {
+		super("ConstLevelInvariant", new String[] { "-config", "ConstLevelInvariant.tla" }, ExitStatus.SUCCESS);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "2"));
+
+		assertTrue(recorder.recorded(EC.TLC_INVARIANT_CONSTANT_LEVEL));
+
+		assertZeroUncovered();
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}


### PR DESCRIPTION

```
Warning: The invariant ConstLevelInvariant is a constant-level formula (i.e., it contains no variables, primes, or temporal operators) and evaluates to TRUE. To assert constant-level formulas in your spec, use ASSUME ConstInv, or to give the assumption a name such as YourAssumption, use ASSUME YourAssumption == ConstInv.
```

[Feature][TLC]

- [ ] Add new error code `2149` to to VSCode extension similar to https://github.com/tlaplus/vscode-tlaplus/commit/73058ac5aed4c04375b28b699aa746c75f2bf603