### PR TITLE
Added Nix dependencies shell file

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -15,6 +15,7 @@ There are other files and directories beyond these, but these are the most impor
 ├── CONTRIBUTING.md             # Info on contributing to the project
 ├── DEVELOPING.md               # This document
 ├── pom.xml                     # The Maven build system definition file
+├── shell.nix                   # Nix development dependencies shell file
 ├── toolbox/                    # All files related to the TLA⁺ Toolbox IDE
 ├── tlatools/
 │   └── org.lamport.tlatools/   # All files related to the TLA⁺ Tools
@@ -57,6 +58,7 @@ Install the following dependencies to your path:
  * [Java Development Kit](https://adoptium.net/) version 11 (newer versions will [likely cause build failures](https://github.com/tlaplus/tlaplus/issues/1162#issuecomment-2737943830))
  * [Apache Ant](https://ant.apache.org/) version 1.9.8+
  * [Apache Maven](https://maven.apache.org/) version 3.9.7+
+ * [Git](https://git-scm.com/) version 2.0+
 
 Clone this repo & open a shell in its root, then run:
 ```bash

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let pkgs = import <nixpkgs> {};
+in pkgs.mkShell {
+  packages = with pkgs; [
+    jdk11
+    ant
+    maven
+    git
+  ];
+}
+


### PR DESCRIPTION
Updated DEVELOPING.md with Git requirement

Added a shell.nix file which, when users run nix-shell in the root directory of this repo, will drop the user into a shell with all required dependencies to build both the tools and toolbox. As part of the process of creating this shell.nix file, it was discovered that the toolbox build process has a dependency on Git. Thus the DEVELOPING.md instructions were updated to list Git as a dependency to build the toolbox.

Since both myself and @Calvin-L are nix users this seems like a good addition, especially since by default my system uses a Java version higher than 11. Nix users will look for & recognize the `shell.nix` file and know how to use it.