### PR TITLE
Docs: git is a dependency of the toolbox build

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -57,6 +57,7 @@ Install the following dependencies to your path:
  * [Java Development Kit](https://adoptium.net/) version 11 (newer versions will [likely cause build failures](https://github.com/tlaplus/tlaplus/issues/1162#issuecomment-2737943830))
  * [Apache Ant](https://ant.apache.org/) version 1.9.8+
  * [Apache Maven](https://maven.apache.org/) version 3.9.7+
+ * [Git](https://git-scm.com/) version 2.0+
 
 Clone this repo & open a shell in its root, then run:
 ```bash


### PR DESCRIPTION
Supersedes #1206; while running `nix-shell --pure` it was discovered that toolbox maven builds will fail if git is not available on the path. Thus document that git is required to build the toolbox in DEVELOPING.md.