### PR TITLE
Make TLCCache work in a constant context

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/TLCExt.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/TLCExt.tla
@@ -168,8 +168,7 @@ TLCCache(expression, closure) ==
   (* Equals the value that an earlier evaluation of the expression evaluated to *)
   (* iff the closure of the earlier evaluation and this evaluation are equal.   *)
   (*                                                                            *)
-  (* Currently only implemented for state-level formulas.  See TLC!TLCEval for  *)
-  (* constant-level formulas.                                                   *)
+  (* Works in constant and variable-level contexts.                             *)
   (******************************************************************************)
   expression
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TLCExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TLCExt.java
@@ -57,7 +57,6 @@ import tlc2.tool.impl.Tool;
 import tlc2.util.Context;
 import tlc2.util.FP64;
 import tlc2.util.IdThread;
-import tlc2.value.IValue;
 import tlc2.value.Values;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.CounterExample;
@@ -336,7 +335,9 @@ public class TLCExt {
 
 		if (expr.getLevel() == LevelConstants.ConstantLevel) {
 			final Value key = tool.eval(closure, c, s0, s1, control, cm).normalize();
-			return tool.getOrSetCached(key, (final Value _ignored) -> tool.eval(expr, c, s0, s1, control, cm).normalize());
+			return tool.getOrSetCached(key, () -> {
+				return tool.eval(expr, c, s0, s1, control, cm).normalize();
+			});
 		} else if ( expr.getLevel() == LevelConstants.VariableLevel) {
 			final int key = expr.hashCode() ^ closure.hashCode() ^ tool.eval(closure, c, s0).hashCode();
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TLCExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TLCExt.java
@@ -57,6 +57,7 @@ import tlc2.tool.impl.Tool;
 import tlc2.util.Context;
 import tlc2.util.FP64;
 import tlc2.util.IdThread;
+import tlc2.value.IValue;
 import tlc2.value.Values;
 import tlc2.value.impl.BoolValue;
 import tlc2.value.impl.CounterExample;
@@ -333,8 +334,10 @@ public class TLCExt {
 		final ExprOrOpArgNode expr = args[0];
 		final ExprOrOpArgNode closure = args[1];
 
-		if (expr.getLevel() == LevelConstants.VariableLevel) {
-
+		if (expr.getLevel() == LevelConstants.ConstantLevel) {
+			final Value key = tool.eval(closure, c, s0, s1, control, cm);
+			return tool.getOrSetCached(key, (final Value _ignored) -> tool.eval(expr, c, s0, s1, control, cm));
+		} else if ( expr.getLevel() == LevelConstants.VariableLevel) {
 			final int key = expr.hashCode() ^ closure.hashCode() ^ tool.eval(closure, c, s0).hashCode();
 
 			final Value value = s0.getCached(key);
@@ -345,7 +348,7 @@ public class TLCExt {
 			return s0.setCached(key, tool.eval(expr, c, s0, s1, control, cm));
 		}
 
-		// For constant, action or temporal formulas, all we do is to evaluate the TLA+
+		// For action or temporal formulas, all we do is to evaluate the TLA+
 		// expression--nothing is cached!
 		return null; // Returning null here causes Tool.java to evaluate the original expression.
 	}

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/TLCExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/TLCExt.java
@@ -335,8 +335,8 @@ public class TLCExt {
 		final ExprOrOpArgNode closure = args[1];
 
 		if (expr.getLevel() == LevelConstants.ConstantLevel) {
-			final Value key = tool.eval(closure, c, s0, s1, control, cm);
-			return tool.getOrSetCached(key, (final Value _ignored) -> tool.eval(expr, c, s0, s1, control, cm));
+			final Value key = tool.eval(closure, c, s0, s1, control, cm).normalize();
+			return tool.getOrSetCached(key, (final Value _ignored) -> tool.eval(expr, c, s0, s1, control, cm).normalize());
 		} else if ( expr.getLevel() == LevelConstants.VariableLevel) {
 			final int key = expr.hashCode() ^ closure.hashCode() ^ tool.eval(closure, c, s0).hashCode();
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -13,8 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 import tla2sany.parser.SyntaxTreeNode;
@@ -4025,9 +4023,9 @@ public abstract class Tool
 		return PROBABILISTIC;
 	}
 	
-	private final ConcurrentMap<Value, Value> constantsCache = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<Value, Value> constantsCache = new ConcurrentHashMap<>();
 	
-	public Value getOrSetCached(Value key, Function<Value, Value> valueSrc) {
-		return constantsCache.computeIfAbsent(key, valueSrc);
+	public Value getOrSetCached(Value key, Supplier<Value> valueSrc) {
+		return constantsCache.computeIfAbsent(key, (Value _ignored) -> valueSrc.get());
 	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -12,6 +12,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import tla2sany.parser.SyntaxTreeNode;
@@ -4020,5 +4023,11 @@ public abstract class Tool
 
 	public static boolean isProbabilistic() {
 		return PROBABILISTIC;
+	}
+	
+	private final ConcurrentMap<Value, Value> constantsCache = new ConcurrentHashMap<>();
+	
+	public Value getOrSetCached(Value key, Function<Value, Value> valueSrc) {
+		return constantsCache.computeIfAbsent(key, valueSrc);
 	}
 }

--- a/tlatools/org.lamport.tlatools/test-model/ConstantContextTLCCache.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ConstantContextTLCCache.cfg
@@ -1,0 +1,2 @@
+INIT Init
+NEXT Next

--- a/tlatools/org.lamport.tlatools/test-model/ConstantContextTLCCache.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ConstantContextTLCCache.tla
@@ -1,0 +1,29 @@
+---- MODULE ConstantContextTLCCache ----
+EXTENDS Integers, TLC, TLCExt
+
+COUNT_ID == 1
+
+ASSUME TLCSet(COUNT_ID, 0)
+
+inc(v) ==
+    CASE TLCSet(COUNT_ID, TLCGet(COUNT_ID) + 1) -> v
+
+defn == TLCCache(inc({ x : x \in 1 .. 5 }), {1})
+derivedDefn == TLCCache(inc({ i \in 1 .. 5 : i + 1 \in defn }), {2})
+
+VARIABLE x, y
+
+ASSUME 5 \in defn
+ASSUME 5 \notin derivedDefn
+
+Init ==
+    /\ y = defn
+    /\ x = derivedDefn
+
+Next ==
+    /\ 1 \in defn
+    /\ 1 \in derivedDefn
+    /\ Assert(TLCGet(COUNT_ID) = 2, <<"count was", TLCGet(COUNT_ID)>>)
+    /\ UNCHANGED <<x, y>>
+
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/module/ConstantContextTLCCacheTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/module/ConstantContextTLCCacheTest.java
@@ -1,0 +1,23 @@
+package tlc2.module;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ConstantContextTLCCacheTest extends ModelCheckerTestCase {
+	public ConstantContextTLCCacheTest() {
+		super("ConstantContextTLCCache");
+	}
+	
+	@Test
+	public void test() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValue(EC.TLC_SEARCH_DEPTH, "1"));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "1", "0"));
+		assertFalse(recorder.recorded(EC.GENERAL));
+	}
+}


### PR DESCRIPTION
It's not a fundamental fix for `TLCEval`, but this addresses #1212 for me. As described in the issue, I was unable to make TLC consistently cache a value. `TLCCache` only worked for variable-level formulas, and `TLCEval` silently fails depending on how the definition is referenced (e.g., it stops working if you refer to your constant from inside a set comprehension). Given that `TLCEval` is very hard to fix, I followed Markus's advice to pivot.

Instead of working on `TLCEval`, I extended `TLCCache` to work in constant contexts. This means, as long as you can make a sufficiently unique "closure" object that identifies your value, you can cache anything you want at the constant or variable levels (no applications for other levels come to mind yet).

The intended application is in combination with IOUtils, to ensure your datafile is not silently reloaded in a loop.

Inventory of changes:
- `TLCCache` has a 2nd code path, where values are cached in the provided `Tool`. I do this by adding a concurrent hash map, so that multiple workers can safely use this code path, and I don't have to worry about optimizing read and write concurrency management.
- A test that uses `TLCGet`/`TLCSet` to confirm a cached value is computed only once, from assumptions, to init, to next-state.

One thing I'm assuming: it's sufficient to call `.normalize()` on a value you're going to cache across workers, so that you can safely reference it across said workers without accidentally doing thread unsafe lazy evaluation. I think that's probably reasonable, from how I understand `.normalize()`, but do correct me if I'm wrong.