### PR TITLE
Using `-dumptrace` option to produce state dumps in machine readable format.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
@@ -4,12 +4,14 @@ LOCAL INSTANCE TLCExt
 LOCAL INSTANCE Json
 LOCAL INSTANCE Sequences
 
+LOCAL _DumpTraceFilePrefix == ""
+
 LOCAL _JsonTraceFile ==
     "CounterExample.json"
 
 LOCAL _JsonTrace ==
     IF CounterExample.state = {} THEN TRUE ELSE
-        /\ JsonSerialize(_JsonTraceFile, CounterExample)
-        /\ PrintT("CounterExample written: " \o _JsonTraceFile)
+        /\ JsonSerialize(_DumpTraceFilePrefix \o _JsonTraceFile, CounterExample)
+        /\ PrintT("CounterExample written: " \o _DumpTraceFilePrefix \o _JsonTraceFile)
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -10,6 +10,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import pcal.Validator;
@@ -1054,7 +1055,7 @@ public class SpecObj
 		return this.parseUnitContext.get(this.getName());
 	}
 
-	public List<ExprNode> getPostConditionSpecs() {
+	public List<ExprNode> getPostConditionSpecs(final Map<String, String> params) {
 		// overridden by sub-classes.
 		return new ArrayList<>();
 	}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ITool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ITool.java
@@ -27,6 +27,7 @@ package tlc2.tool;
 
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 import tla2sany.semantic.ExprNode;
@@ -187,6 +188,8 @@ public interface ITool extends TraceApp, OpDefEvaluator {
 	int checkPostCondition();
 	
 	int checkPostConditionWithCounterExample(IValue value);
+	
+	int checkPostConditionWithCounterExample(IValue value, Map<String, String> params);
 
 	String[] getInvNames();
 
@@ -261,7 +264,7 @@ public interface ITool extends TraceApp, OpDefEvaluator {
 
 	SemanticNode getViewSpec();
 
-	ExprNode[] getPostConditionSpecs();
+	ExprNode[] getPostConditionSpecs(final Map<String, String> params);
 
 	OpDefNode getCounterExampleDef();
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -322,15 +322,7 @@ public class Simulator {
 		//
 		this.aril = rng.getAril();
 		
-		final SimulationWorkerResult result = simulate(initStates);
-		int errorCode = result.isError() ? result.error().errorCode : EC.NO_ERROR;
-		
-		// see tlc2.tool.Worker.doPostCheckAssumption()
-		if (result.isError() && result.error().hasTrace()) {
-			errorCode = Math.max(this.tool.checkPostConditionWithCounterExample(result.error().getCounterExample()), errorCode);
-		} else {
-			errorCode = Math.max(this.tool.checkPostCondition(), errorCode);
-		}
+		int errorCode = simulate(initStates);
 
 		// Do a final progress report.
 		report.isRunning = false;
@@ -348,7 +340,7 @@ public class Simulator {
 		return errorCode;
 	}
 
-	protected SimulationWorkerResult simulate(final StateVec initStates) throws InterruptedException {
+	protected int simulate(final StateVec initStates) throws InterruptedException {
 		// Start up multiple simulation worker threads, each with their own unique seed.
 		final Set<Integer> runningWorkers = new HashSet<>();
 		for (int i = 0; i < this.workers.size(); i++) {
@@ -358,6 +350,7 @@ public class Simulator {
 		}
 
 		SimulationWorkerResult result;
+		int errorCode = EC.NO_ERROR;
 		
 		// Continuously consume results from all worker threads.
 		while (true) {
@@ -388,6 +381,7 @@ public class Simulator {
 								error.stateTrace);
 						error.errorCode = EC.GENERAL;
 					}
+					errorCode = error.errorCode;
 					break;
 				}
 				
@@ -398,7 +392,15 @@ public class Simulator {
 				// regardless of the "continue" parameter, since these errors likely indicate a bug in the spec.
 				if (isNonContinuableError(error.errorCode)) {
 					error.errorCode = error.errorCode;
+					errorCode = error.errorCode;
 					break;
+				}
+				
+				// see tlc2.tool.Worker.doPostCheckAssumption()
+				if (result.error().hasTrace()) {
+					error.errorCode = Math.max(this.tool.checkPostConditionWithCounterExample(result.error().getCounterExample()), error.errorCode);
+				} else {
+					error.errorCode = Math.max(this.tool.checkPostCondition(), error.errorCode);
 				}
 				
 				// If the 'continue' option is false, then we always terminate on the
@@ -406,6 +408,7 @@ public class Simulator {
 				// results from the worker threads.
 				if (!TLCGlobals.continuation) {
 					error.errorCode = error.errorCode;
+					errorCode = error.errorCode;
 					break;
 				}
 
@@ -413,11 +416,13 @@ public class Simulator {
 				{
 					error.errorCode = EC.GENERAL;
 				}
+				errorCode = error.errorCode;
 			}
 			// If the result is OK, this indicates that the worker has terminated, so we
 			// make note of this. If all of the workers have terminated, there is no need to
 			// continue waiting for results, so we should terminate.
 			else {
+				errorCode = this.tool.checkPostCondition();
 				runningWorkers.remove(result.workerId());
 				if(runningWorkers.isEmpty()) {
 					break;
@@ -427,7 +432,7 @@ public class Simulator {
 		
 		// Shut down all workers.
 		this.shutdownAndJoinWorkers(workers);
-		return result;
+		return errorCode;
 	}
 
 	protected final void printBehavior(final TLCRuntimeException exception, final StateVec stateTrace) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -398,7 +398,10 @@ public class Simulator {
 				
 				// see tlc2.tool.Worker.doPostCheckAssumption()
 				if (result.error().hasTrace()) {
-					error.errorCode = Math.max(this.tool.checkPostConditionWithCounterExample(result.error().getCounterExample()), error.errorCode);
+					error.errorCode = Math
+							//TODO numOfGenTraces is not ideal because it is not monotonically increasing.
+							.max(this.tool.checkPostConditionWithCounterExample(result.error().getCounterExample(),
+									Map.of("_DumpTraceFilePrefix", String.format("%s_", numOfGenTraces.get()))), error.errorCode);
 				} else {
 					error.errorCode = Math.max(this.tool.checkPostCondition(), error.errorCode);
 				}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SingleThreadedSimulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SingleThreadedSimulator.java
@@ -61,7 +61,7 @@ public class SingleThreadedSimulator extends Simulator {
 	}
 
 	@Override
-	protected SimulationWorkerResult simulate(final StateVec initialStates) throws InterruptedException {
+	protected int simulate(final StateVec initialStates) throws InterruptedException {
 		// Unless REV#reset is issued below, running simulation under the debugger will
 		// result in different error traces even under identical seeds. This would not
 		// necessarily be a bug but producing the same trace with and without the
@@ -109,21 +109,22 @@ public class SingleThreadedSimulator extends Simulator {
 								error.stateTrace);
 						error.errorCode = EC.GENERAL;
 					}
-					return result;
+					errorCode = error.errorCode;
+					return errorCode;
 				}
 
 				// Print the trace for all other errors.
 				printBehavior(error);
 
 				if (isNonContinuableError(error.errorCode)) {
-					return result;
+					return errorCode;
 				}
 
 				// If the 'continue' option is false, then we always terminate on the
 				// first error, shutting down all workers. Otherwise, we continue receiving
 				// results from the worker threads.
 				if (!TLCGlobals.continuation) {
-					return result;
+					return errorCode;
 				}
 
 				if (errorCode == EC.NO_ERROR) {
@@ -134,7 +135,7 @@ public class SingleThreadedSimulator extends Simulator {
 			// terminate. For example, the worker has generated the requested number of traces.
 			else {
 				this.printSummary();
-				return result;
+				return errorCode;
 			}
 		}
 	}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ParameterizedSpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ParameterizedSpecObj.java
@@ -87,7 +87,7 @@ public class ParameterizedSpecObj extends SpecObj {
 	}
 
 	@Override
-	public List<ExprNode> getPostConditionSpecs() {
+	public List<ExprNode> getPostConditionSpecs(final Map<String, String> overrides) {
 		final List<ExprNode> res = new ArrayList<>();
 
 		@SuppressWarnings("unchecked")
@@ -101,6 +101,13 @@ public class ParameterizedSpecObj extends SpecObj {
 			for (Map.Entry<String, String> entry : pc.redefinitions.entrySet()) {
 				final OpDefNode redefined = moduleNode.getOpDef(entry.getKey());
 				redefined.setToolObject(spec.getId(), new StringValue(entry.getValue()));
+			}
+			for (Map.Entry<String, String> entry : overrides.entrySet()) {
+				final OpDefNode redefined = moduleNode.getOpDef(entry.getKey());
+				if (redefined != null) {
+					// The PostCondition may not declare or define the redefined OpDefNode.
+					redefined.setToolObject(spec.getId(), new StringValue(entry.getValue()));
+				}
 			}
 
 			res.add(opDef.getBody());

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
@@ -256,9 +256,9 @@ abstract class Spec
         return def.getBody();
     }
 
-    public final ExprNode[] getPostConditionSpecs()
+    public final ExprNode[] getPostConditionSpecs(final Map<String, String> params)
     {
-    	final List<ExprNode> res = this.specProcessor.getPostConditionSpecs();
+    	final List<ExprNode> res = this.specProcessor.getPostConditionSpecs(params);
     	
         String name = this.config.getPostCondition();
         if (name.length() != 0)

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -2186,7 +2186,7 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
 		return defns;
 	}
 
-	public java.util.List<ExprNode> getPostConditionSpecs() {
-		return this.specObj.getPostConditionSpecs();
+	public java.util.List<ExprNode> getPostConditionSpecs(final Map<String, String> params) {
+		return this.specObj.getPostConditionSpecs(params);
 	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -3551,23 +3551,27 @@ public abstract class Tool
 
 	@Override
 	public final int checkPostCondition() {
-		return checkPostConditionWithContext(Context.Empty);
+		return checkPostConditionWithContext(Context.Empty, Map.of());
 	}
 
 	@Override
 	public final int checkPostConditionWithCounterExample(final IValue value) {
+		return checkPostConditionWithCounterExample(value, Map.of());
+	}
+
+	@Override
+	public final int checkPostConditionWithCounterExample(final IValue value, final Map<String, String> params) {
 		final SymbolNode def = getCounterExampleDef();
 		if (def == null) {
 			// TLCExt!CounterExample does not appear anywhere in the spec.
 			return checkPostCondition();
 		}
-		final Context ctxt = Context.Empty.cons(def, value);
-		return checkPostConditionWithContext(ctxt);
+		return checkPostConditionWithContext(Context.Empty.cons(def, value), params);
 	}
 
-	private final int checkPostConditionWithContext(final Context ctxt) {
+	private final int checkPostConditionWithContext(final Context ctxt, final Map<String, String> params) {
 		// User request: http://discuss.tlapl.us/msg03658.html
-		final ExprNode[] postConditions = getPostConditionSpecs();
+		final ExprNode[] postConditions = getPostConditionSpecs(params);
 		for (int i = 0; i < postConditions.length; i++) {
 			final ExprNode en = postConditions[i];
 			try {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/SimulationTest2PostCondition.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/simulation/SimulationTest2PostCondition.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import tlc2.TLC;
 import tlc2.output.EC;
 
 public class SimulationTest2PostCondition extends SuccessfulSimulationTestCase {


### PR DESCRIPTION
Part of Github issue #1216
https://github.com/tlaplus/tlaplus/issues/1216

[Feature][TLC]