### PR TITLE
SANY bugfix: syntax parser errors were incorrectly silenced

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
@@ -308,7 +308,7 @@ public class ParseUnit {
         try 
         {
             // create parser object
-            parseTree = new tla2sany.parser.TLAplusParser(nis, StandardCharsets.UTF_8.name());
+            parseTree = new tla2sany.parser.TLAplusParser(nis, StandardCharsets.UTF_8.name(), out);
 
             // Here is the one true REAL call to the parseTree.parse() for a file;
             // The root node of the parse tree is left in parseTree.

--- a/tlatools/org.lamport.tlatools/test/tla2sany/output/RecordedSanyOutput.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/output/RecordedSanyOutput.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2025 The Linux Foundation. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+package tla2sany.output;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class recorded all SANY output as individual messages. Useful for
+ * testing SANY's output behavior.
+ */
+public class RecordedSanyOutput implements SanyOutput {
+
+  /**
+   * A SANY output message. Can either be a single log message or the
+   * contents of a {@link ByteArrayOutputStream} owned by some hopefully
+   * short-lived section of code in SANY itself that writes to the stream.
+   */
+  public static class Message {
+    private final LogLevel level;
+    private final String format;
+    private final Object[] args;
+    private final ByteArrayOutputStream stream;
+
+    public Message(LogLevel level, String format, Object... args) {
+      this.level = level;
+      this.format = format;
+      this.args = args;
+      this.stream = null;
+    }
+
+    public Message(LogLevel level, ByteArrayOutputStream stream) {
+      this.level = level;
+      this.format = null;
+      this.args = null;
+      this.stream = stream;
+    }
+
+    public LogLevel getLevel() {
+      return this.level;
+    }
+
+    public String getText() {
+      return
+          (null == this.stream
+          ? String.format(this.format, this.args)
+          : this.stream.toString()) + '\n';
+    }
+
+    @Override
+    public String toString() {
+      return this.getText();
+    }
+  }
+
+  private final List<Message> messages = new ArrayList<>();
+  
+  private final LogLevel logLevel;
+  
+  public RecordedSanyOutput(LogLevel logLevel) {
+    this.logLevel = logLevel;
+  }
+
+  @Override
+  public void log(LogLevel level, String format, Object... args) {
+    if (level.ordinal() >= this.logLevel.ordinal()) {
+      this.messages.add(new Message(level, format, args));
+    }
+  }
+
+  @Override
+  public PrintStream getStream(LogLevel level) {
+    if (level.ordinal() >= this.logLevel.ordinal()) {
+      ByteArrayOutputStream stream = new ByteArrayOutputStream();
+      this.messages.add(new Message(level, stream));
+      return new PrintStream(stream);
+    } else {
+      return SilentSanyOutput.NullOutputStream;
+    }
+  }
+
+  public List<Message> getMessages() {
+    return this.messages;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    for (Message msg : this.messages) {
+      sb.append(msg.toString());
+    }
+
+    return sb.toString();
+  }
+}

--- a/tlatools/org.lamport.tlatools/test/tla2sany/parser/ParseErrorTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/parser/ParseErrorTests.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Linux Foundation. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+package tla2sany.parser;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import tla2sany.drivers.SANY;
+import tla2sany.modanalyzer.SpecObj;
+import tla2sany.output.LogLevel;
+import tla2sany.output.RecordedSanyOutput;
+import util.FilenameToStream;
+import util.SimpleFilenameToStream;
+
+
+/**
+ * Currently, SANY's syntax parser level has its own error reporting
+ * machinery distinct from the {@link tla2sany.semantic.Errors} class. Until
+ * these are unified and syntax parser errors are tagged with an appropriate
+ * error code, these tests ensure syntax error text is output appropriately.
+ */
+@RunWith(Parameterized.class)
+public class ParseErrorTests {
+
+  public static class ParseErrorTest {
+    public final String moduleBody;
+    public final String error;
+    public ParseErrorTest(String moduleBody, String error) {
+      this.moduleBody = moduleBody;
+      this.error = error;
+    }
+    @Override
+    public String toString() {
+      return this.moduleBody;
+    }
+  }
+
+	@Parameters(name = "{index}: {0}")
+	public static ParseErrorTest[] getTestCases() {
+	  return new ParseErrorTest[] {
+	      new ParseErrorTest("x = 0", "Was expecting \"==== or more Module body\"\nEncountered \"x\" at line")
+	  };
+	}
+
+  @Parameter
+  public ParseErrorTest testCase;
+
+  @Test
+  public void testAll() throws IOException {
+    Path inputFile = Files.createTempFile("SanyTest", ".tla");
+    String fileName = inputFile.getFileName().toString();
+    String moduleName = fileName.substring(0, fileName.length() - 4);
+    String input = String.format("---- MODULE %s ----\n%s\n====", moduleName, this.testCase.moduleBody);
+    Files.writeString(inputFile, input);
+
+    final FilenameToStream fts = new SimpleFilenameToStream(inputFile.getParent().toString());
+    final SpecObj spec = new SpecObj(inputFile.toString(), fts);
+    final RecordedSanyOutput out = new RecordedSanyOutput(LogLevel.INFO);
+    SANY.frontEndInitialize();
+    try {
+      SANY.frontEndParse(spec, out, false);
+      Assert.fail("Expected parse failure.");
+    } catch (ParseException e) {
+      Assert.assertTrue(out.toString(), out.toString().contains(this.testCase.error));
+    }
+  }
+}

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticCorpusTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticCorpusTests.java
@@ -22,9 +22,7 @@
  ******************************************************************************/
 package tla2sany.semantic;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,8 +49,7 @@ import tla2sany.explorer.ExploreNode;
 import tla2sany.explorer.ExplorerVisitor;
 import tla2sany.modanalyzer.SpecObj;
 import tla2sany.output.LogLevel;
-import tla2sany.output.SanyOutput;
-import tla2sany.output.SimpleSanyOutput;
+import tla2sany.output.RecordedSanyOutput;
 import tla2sany.parser.ParseException;
 import tlc2.tool.CommonTestCase;
 import util.FilenameToStream;
@@ -183,23 +180,21 @@ public class SemanticCorpusTests {
   private static ExternalModuleTable parse(Path rootModulePath) {
     final FilenameToStream fts = new SimpleFilenameToStream(rootModulePath.getParent().toString());
     final SpecObj spec = new SpecObj(rootModulePath.toString(), fts);
-    final ByteArrayOutputStream output = new ByteArrayOutputStream();
-    final PrintStream outStream = new PrintStream(output);
-    final SanyOutput out = new SimpleSanyOutput(outStream, LogLevel.INFO);
+    final RecordedSanyOutput out = new RecordedSanyOutput(LogLevel.INFO);
     SANY.frontEndInitialize();
     try {
       SANY.frontEndParse(spec, out);
     } catch (ParseException e) {
-      Assert.fail(e.toString() + output.toString());
+      Assert.fail(e.toString() + out.toString());
     }
     try {
       SANY.frontEndSemanticAnalysis(spec, out, true);
     } catch (SemanticException e) {
-      Assert.fail(e.toString() + output.toString());
+      Assert.fail(e.toString() + out.toString());
     }
-    Assert.assertTrue(output.toString(), spec.parseErrors.isSuccess());
-    Assert.assertTrue(output.toString(), spec.semanticErrors.isSuccess());
-    Assert.assertTrue(output.toString(), spec.semanticErrors.getWarnings().length == 0);
+    Assert.assertTrue(out.toString(), spec.parseErrors.isSuccess());
+    Assert.assertTrue(out.toString(), spec.semanticErrors.isSuccess());
+    Assert.assertTrue(out.toString(), spec.semanticErrors.getWarnings().length == 0);
     return spec.getExternalModuleTable();
   }
 

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticErrorCorpusTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/SemanticErrorCorpusTests.java
@@ -22,9 +22,7 @@
  ******************************************************************************/
 package tla2sany.semantic;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,8 +46,7 @@ import tla2sany.drivers.SemanticException;
 import tla2sany.modanalyzer.SpecObj;
 import tla2sany.parser.ParseException;
 import tla2sany.output.LogLevel;
-import tla2sany.output.SanyOutput;
-import tla2sany.output.SimpleSanyOutput;
+import tla2sany.output.RecordedSanyOutput;
 import tla2sany.semantic.Errors.ErrorDetails;
 import tlc2.tool.CommonTestCase;
 import util.FilenameToStream;
@@ -159,14 +156,12 @@ public class SemanticErrorCorpusTests {
   private static Errors parse(Path rootModulePath) {
     final FilenameToStream fts = new SimpleFilenameToStream(rootModulePath.getParent().toString());
     final SpecObj spec = new SpecObj(rootModulePath.toString(), fts);
-    final ByteArrayOutputStream output = new ByteArrayOutputStream();
-    final PrintStream outStream = new PrintStream(output);
-    final SanyOutput out = new SimpleSanyOutput(outStream, LogLevel.INFO);
+    final RecordedSanyOutput out = new RecordedSanyOutput(LogLevel.INFO);
     SANY.frontEndInitialize();
     try {
       SANY.frontEndParse(spec, out);
     } catch (ParseException e) {
-      Assert.assertNotEquals(e.toString() + output.toString(), 0, spec.parseErrors.getNumMessages());
+      Assert.assertNotEquals(e.toString() + out.toString(), 0, spec.parseErrors.getNumMessages());
       return spec.parseErrors;
     } try {
       SANY.frontEndSemanticAnalysis(spec, out, true);

--- a/tlatools/org.lamport.tlatools/test/tlc2/output/SpecTraceExpressionWriterTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/output/SpecTraceExpressionWriterTest.java
@@ -13,14 +13,11 @@ import org.junit.Test;
 import tla2sany.drivers.FrontEndException;
 import tla2sany.drivers.SANY;
 import tla2sany.modanalyzer.SpecObj;
-import tla2sany.output.LogLevel;
-import tla2sany.output.SanyOutput;
-import tla2sany.output.SimpleSanyOutput;
+import tla2sany.output.SilentSanyOutput;
 import tlc2.model.Formula;
 import tlc2.model.MCState;
 import tlc2.model.TraceExpressionInformationHolder;
 import util.TLAConstants;
-import util.TestPrintStream;
 
 /**
  * The genesis for these tests is regressions that were introduced by beautification changes made as part of #393.
@@ -79,10 +76,8 @@ public class SpecTraceExpressionWriterTest {
 		writer.writeFiles(tlaFile, cfgFile);
 		
 		final SpecObj so = new SpecObj(tlaFile.getAbsolutePath(), null);
-		final TestPrintStream printStream = new TestPrintStream();
 		
-		final SanyOutput out = new SimpleSanyOutput(printStream, LogLevel.INFO);
-		final int result = SANY.frontEndMain(so, tlaFile.getAbsolutePath(), out);
+		final int result = SANY.frontEndMain(so, tlaFile.getAbsolutePath(), new SilentSanyOutput());
 		if (result != 0) {
 			throw new FrontEndException("Parsing returned a non-zero success code (" + result + ")");
 		}


### PR DESCRIPTION
As part of PR #1209, SANY output was centralized into a single logging class. These changes extended to the TLAplusParser class, which was given an additional constructor accepting a SanyOutput parameter. Unfortunately the existing constructors were auto-generated by JavaCC so could not be removed, and the code constructing TLAplusParser in ParseUnit.java was neglected to be updated to use the new constructor accepting the SanyOutput parameter. By default the calls to SanyOutput in TLAplusParser were sent to a SilentSanyOutput instance, and so this had the effect that all detailed parse error messages occuring at the syntax level and below were silenced. The parse failure itself was recorded, but the specific reason for the failure was not output.

These changes update ParseUnit to use the new TLAplusParser constructor which accepts a SanyOutput parameter, thus ensuring all logging in that class flows through the same SanyOutput instance used by the rest of the parse run. A regression test system is also added to ensure syntax parser errors are not inadvertently silenced in the future. A full fix would involve onboarding SANY's syntax parser level to the standardized error code system, ensuring that all parse error messages are triggered & output appropriately.

This bug was reported by Olav Bunte in #1221. This PR closes #1221.

[SANY][Bugfix]