### PR TITLE
Refactor `NamedInputStream` to facilitate reading TLA+ modules from non-file sources

### DIFF
--- a/tlatools/org.lamport.tlatools/META-INF/MANIFEST.MF
+++ b/tlatools/org.lamport.tlatools/META-INF/MANIFEST.MF
@@ -6,6 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Export-Package: pcal,
  pcal.exception,
  tla2sany,
+ tla2sany.api,
  tla2sany.StandardModules,
  tla2sany.drivers,
  tla2sany.explorer,

--- a/tlatools/org.lamport.tlatools/src/tla2sany/api/ModuleSourceCode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/api/ModuleSourceCode.java
@@ -22,6 +22,7 @@
  ******************************************************************************/
 package tla2sany.api;
 
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 
@@ -64,18 +65,18 @@ public class ModuleSourceCode {
    * desired (for advanced error reporting, for example) then the function
    * {@link ModuleSourceCode#getTextAsString} can be used.
    */
-  public final byte[] text;
+  private final byte[] text;
 
   /**
    * The origin of this module.
    */
-  public final ModuleOrigin origin;
+  private final ModuleOrigin origin;
 
   /**
    * The path at which this module was found, if sourced from
    * {@link ModuleOrigin#FILESYSTEM}. Null otherwise.
    */
-  public final Path path;
+  private final Path path;
 
   /**
    * Constructs a new instance of the {@link ModuleSourceCode} class.
@@ -91,11 +92,51 @@ public class ModuleSourceCode {
   }
 
   /**
+   * The text of this module's source code, as a UTF-8 encoded byte array.
+   *
+   * @return The module source code.
+   */
+  public byte[] getText() {
+    return this.text;
+  }
+
+  /**
+   * The origin of this module.
+   *
+   * @return The origin of this module.
+   */
+  public ModuleOrigin getOrigin() {
+    return this.origin;
+  }
+  
+  /**
+   * The path associated with this module, if it was sourced from the file
+   * system; otherwise null.
+   *
+   * @return The path associated with this module, if it has one.
+   */
+  public Path getPath() {
+    return this.path;
+  }
+
+  /**
    * Interpret the module text as a UTF-8 encoded string.
    *
    * @return The module text as a UTF-8 encoded string.
    */
   public String getTextAsString() {
     return new String(this.text, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Makes the module text available as a {@link ByteArrayInputStream}. This
+   * stream can either be closed or not, it does not matter; the underlying
+   * data is a byte array, not a file handle or anything else that needs to
+   * be explicitly released.
+   *
+   * @return The module text, as a {@link ByteArrayInputStream}.
+   */
+  public ByteArrayInputStream getTextAsInputStream() {
+    return new ByteArrayInputStream(this.text);
   }
 }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
@@ -303,33 +303,14 @@ public class ParseUnit {
             out.log(LogLevel.INFO, "Parsing module %s in file %s", nis.getModuleName(), absoluteResolvedPath);
         }
 
-        boolean parseSuccess; 
-        try 
-        {
-            // create parser object
-            parseTree = new tla2sany.parser.TLAplusParser(out, nis);
+        parseTree = new tla2sany.parser.TLAplusParser(out, nis.getSource().getText());
 
-            // Here is the one true REAL call to the parseTree.parse() for a file;
-            // The root node of the parse tree is left in parseTree.
-            parseSuccess = parseTree.parse();
+        // Here is the one true REAL call to the parseTree.parse() for a file;
+        // The root node of the parse tree is left in parseTree.
+        boolean parseSuccess = parseTree.parse();
 
-            // set the parse time stamp
-            parseStamp = System.currentTimeMillis();
-        } finally 
-        {
-            try
-            {
-                // SZ Aug 6, 2009: close the stream and release the OS resources
-                // this is Ok, since the repeated call of the parse method will
-                // return due to the fact, that the parse time stamp is newer 
-                // then the file time stamp
-                nis.close();
-            } catch (IOException e)
-            {
-                // eventually it is a good place to inform the user that the resources are
-                // not released 
-            }
-        }
+        // set the parse time stamp
+        parseStamp = System.currentTimeMillis();
         
         if (!parseSuccess)
         { // if parsing the contents of "nis" failed...

--- a/tlatools/org.lamport.tlatools/src/util/FileUtil.java
+++ b/tlatools/org.lamport.tlatools/src/util/FileUtil.java
@@ -386,7 +386,7 @@ public class FileUtil
             {
                 NamedInputStream nis = new NamedInputStream(sourceFileName, sourceModuleName, sourceFile);
                 return nis;
-            } catch (FileNotFoundException e)
+            } catch (IOException e)
             {
                 ToolIO.out.println("***Internal error: Unable to create NamedInputStream in toIStream method");
             }

--- a/tlatools/org.lamport.tlatools/src/util/NamedInputStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/NamedInputStream.java
@@ -1,107 +1,246 @@
-// Copyright (c) 2003 Compaq Corporation.  All rights reserved.
-// Portions Copyright (c) 2003 Microsoft Corporation.  All rights reserved.
+/*******************************************************************************
+ * Copyright (c) 2003 Compaq Corporation. All rights reserved.
+ * Copyright (c) 2003 Microsoft Corporation. All rights reserved.
+ * Copyright (c) 2025 The Linux Foundation. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
 package util;
 
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 
-// SZ Feb 20, 2009: moved to util and reformatted
+import tla2sany.api.ModuleSourceCode;
+import tla2sany.api.ModuleSourceCode.ModuleOrigin;
 
 /**
- * A NamedInputStream is an InputStream together with a name.  The most
- * common such object o will be one that is the InputStream obtained by
- * reading a file named o.getName().
+ * Fundamental class used to read TLA+ module source code. Despite the name,
+ * it is not itself an {@link InputStream}. In the past it used to inherit
+ * from {@link FileInputStream}, then was changed to simply read the file
+ * while being constructed and keep it around as a {@link ModuleSourceCode}
+ * instance wrapped by this class. This was motivated by a desire to decouple
+ * the TLA+ tools from reliance on files instead of other methods of reading
+ * in TLA+ modules, such as strings or files embedded inside jars. It was
+ * also nice to avoid lifetime management issues and be able to read a module
+ * multiple times.
  *
- * It extends FileInputStream, rather than input stream, since it's not 
- * possible to change the default hierarchy. This implies that it isn't 
- * possible to use the same class for a buffer derived from an input string.
- * 
- * @author Leslie Lamport
- * @version $Id$
+ * This class is currently in an intermediate phase where not all methods are
+ * safe to call under all circumstances. Several methods exist under the
+ * assumption that this class always refers to an underlying file with a
+ * valid path, which in the future is hoped not to be the case. These methods
+ * were written to function normally in the case that there *is* an actual
+ * underlying file, which will be the case until the rest of the codebase is
+ * changed to avoid using these methods and their implicit assumption of file
+ * existence. The unsafe methods have all been marked as deprecated.
  */
-public class NamedInputStream extends FileInputStream
+public class NamedInputStream implements Closeable
 {
-    private static int numberOfReferences = 0;  
-    
-    private String fileName;
-    private String moduleName;
-    private File inputFile;
+    /**
+     * A static field tracking the number of {@link NamedInputStream}
+     * instances that have been created, minus the number that have had
+     * {@link NamedInputStream#close()} called on them.
+     */
+    private static int numberOfReferences = 0;
 
-    public NamedInputStream(String file, String module, File input) throws FileNotFoundException
+    /**
+     * The expected name of the module. This is not based on any analysis of
+     * the module contents but comes from elsewhere, like if a module is
+     * imported from another.
+     */
+    private final String moduleName;
+
+    /**
+     * Information about the contents and source of the TLA+ module. This
+     * class is largely a legacy wrapper for it.
+     */
+    private final ModuleSourceCode source;
+
+    /**
+     * Initializes a new instance of the {@link NamedInputStream} class.
+     * This constructor immediately reads in the given file and stores it in
+     * a {@link ModuleSourceCode} instance for repeated later retrieval. It
+     * also increments the static reference counter for this class.
+     *
+     * @param fileName The name of the TLA+ file to be read. Ignored.
+     * @param moduleName The expected name of the module in the file.
+     * @param inputFile The actual TLA+ file to read in and store.
+     * @throws FileNotFoundException If the TLA+ file does not exist.
+     * @throws IOException If there was an error reading the TLA+ file.
+     */
+    public NamedInputStream(String fileName, String moduleName, File inputFile) throws FileNotFoundException, IOException
     {
-        super(input);
-        fileName = file;
-        moduleName = module;
-        inputFile = input;
-        synchronized (NamedInputStream.class) 
-        {
-            if (numberOfReferences < 0) 
-            {
-                numberOfReferences = 0;
-            }
-            numberOfReferences++;
+        this.moduleName = moduleName;
+        try (InputStream input = new FileInputStream(inputFile)) {
+          this.source = new ModuleSourceCode(
+              input.readAllBytes(),
+              ModuleOrigin.FILESYSTEM,
+              inputFile.toPath());
         }
 
+        synchronized (NamedInputStream.class)
+        {
+            if (NamedInputStream.numberOfReferences < 0)
+            {
+                NamedInputStream.numberOfReferences = 0;
+            }
+
+            NamedInputStream.numberOfReferences++;
+        }
     }
 
+    /**
+     * Alias of {@link NamedInputStream#getFileName()}.
+     *
+     * @return The name of the file.
+     */
     public final String getName()
     {
-        return fileName;
+        return this.getFileName();
     }
 
+    /**
+     * Gets the name of the file read in by this class, if it was sourced
+     * from the filesystem. Otherwise, synthesize the expected filename by
+     * appending .tla onto the module name.
+     *
+     * @return The name of the file read in by this class.
+     * @deprecated Avoid assuming TLA+ modules come from the filesystem.
+     */
+    @Deprecated(since = "1.8.0")
     public final String getFileName()
     {
-        return fileName;
+        return
+            this.source.getOrigin() == ModuleOrigin.FILESYSTEM
+            ? this.source.getPath().getFileName().toString()
+            : this.getModuleName() + TLAConstants.Files.TLA_EXTENSION;
     }
 
+    /**
+     * Gets the module name which was provided upon constructing the class.
+     * This name was not derived from the module contents and could be wrong.
+     *
+     * @return The expected name of the module read in by this class.
+     */
     public final String getModuleName()
     {
-        return moduleName;
+        return this.moduleName;
     }
 
+    /**
+     * If this module was sourced from the filesystem, return the path to
+     * that file. Otherwise, return null.
+     *
+     * @return Path if applicable, null otherwise.
+     * @deprecated Avoid assuming TLA+ modules come from the filesystem.
+     */
+    @Deprecated(since = "1.8.0")
     public final File sourceFile()
     {
-        return inputFile;
-    }
-    
-    /**
-	 * @return The absolute, resolved path. In case a file is symlinked, resolve the
-	 *         final target (doesn't work for cygwin symlinks but for mklink)
-     * @throws IOException 
-	 */
-    public final Path getAbsoluteResolvedPath() throws IOException {
-		return inputFile.toPath().toRealPath();
+        return
+            this.source.getOrigin() == ModuleOrigin.FILESYSTEM
+            ? this.source.getPath().toFile()
+            : null;
     }
 
+    /**
+     * If this module was sourced from the filesystem, return the path to
+     * that file in absolute resolved form. If the file was symlinked, this
+     * resolves the final target. On Windows, works for mklink but not cygwin
+     * symlinks. If the module was not sourced from the filesystem then
+     * return null.
+     *
+     * @throws IOException If file does not exist or other I/O error occurs.
+     * @deprecated Avoid assuming TLA+ modules come from the filesystem.
+     */
+    @Deprecated(since = "1.8.0")
+    public final Path getAbsoluteResolvedPath() throws IOException {
+        return
+            this.source.getOrigin() == ModuleOrigin.FILESYSTEM
+            ? this.source.getPath().toRealPath()
+            : null;
+    }
+
+    @Override
     public final String toString()
     {
-        return "[ fileName: " + fileName + ", moduleName: " + moduleName + " ]";
+        return "[ fileName: " + this.getFileName() + ", moduleName: " + this.getModuleName() + " ]";
     }
 
-    
     /**
-     * Sanity method
+     * Gets the {@link ByteArrayInputStream} instance containing the content
+     * held by this class. Caller can close the input stream or not; for a
+     * {@link ByteArrayInputStream}, closing it is a no-op.
+     *
+     * @return An {@link ByteArrayInputStream} with the module contents.
      */
+    public ByteArrayInputStream getInputStream() {
+      return this.source.getTextAsInputStream();
+    }
+
+    /**
+     * Gets the {@link ModuleSourceCode} instance wrapped by this class.
+     *
+     * @return The source code wrapped by this class.
+     */
+    public ModuleSourceCode getSource() {
+      return this.source;
+    }
+
+    /**
+     * This method does not actually close any underlying input stream but
+     * instead decrements a static reference counter for this class. Since
+     * transitioning the class to wrap {@link ModuleSourceCode} there is no
+     * {@link InputStream} instance that needs closing. Should be removed
+     * once {@link NamedInputStream#getNumberOfreferences()} is deleted.
+     */
+    @Override
     public void close() throws IOException
     {
-        synchronized (NamedInputStream.class) 
+        synchronized (NamedInputStream.class)
         {
-            numberOfReferences--;
+            NamedInputStream.numberOfReferences--;
         }
-        super.close();
     }
-    
 
     /**
-     * Sanity check method
-     * @return
+     * Gets the recorded number of {@link NamedInputStream} instances that
+     * have been constructed, minus the number that have been closed. It is
+     * unclear what the purpose of this is; it does not seem to be in use and
+     * was possibly used to debug lifetime management issues for file input
+     * streams at some point. Good candidate for future removal, along with
+     * the rest of the reference counting logic.
+     *
+     * @return The number of non-closed class instances constructed.
+     * @deprecated Unused, also lifetime tracking is now much less important
+     *             since no underlying {@link InputStream} actually needs to
+     *             be closed.
      */
+    @Deprecated(since = "1.8.0")
     public synchronized static int getNumberOfreferences()
     {
-        return numberOfReferences;
+        return NamedInputStream.numberOfReferences;
     }
-
 }

--- a/tlatools/org.lamport.tlatools/test/tla2sany/api/SANYFrontend.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/api/SANYFrontend.java
@@ -73,7 +73,7 @@ public class SANYFrontend implements Frontend {
     Resolver resolver
   ) throws TokenMgrError, ParseException {
     final ModuleSourceCode source = resolver.resolve(moduleName);
-    final TLAplusParser parser = new TLAplusParser(new SilentSanyOutput(), source.text);
+    final TLAplusParser parser = new TLAplusParser(new SilentSanyOutput(), source.getText());
     return new ModuleSyntaxTree(source, parser.CompilationUnit());
   }
 

--- a/tlatools/org.lamport.tlatools/test/util/NamedInputStreamTest.java
+++ b/tlatools/org.lamport.tlatools/test/util/NamedInputStreamTest.java
@@ -54,7 +54,7 @@ public class NamedInputStreamTest {
     assertEquals(inputFile.toRealPath(), nis.getAbsoluteResolvedPath());
     assertEquals(String.format("[ fileName: %s, moduleName: %s ]", fileName, moduleName), nis.toString());
     assertEquals(1, NamedInputStream.getNumberOfreferences());
-    assertArrayEquals(contents, nis.readAllBytes());
+    assertArrayEquals(contents, nis.getInputStream().readAllBytes());
     nis.close();
     assertEquals(0, NamedInputStream.getNumberOfreferences());
   }


### PR DESCRIPTION
In furtherance of #719. It took a while to find a decent entry point for refactoring SANY to not rely on files, but `NamedInputStream` is one part of the puzzle. This PR does not remove SANY's dependency on files but is scoped in a way that sets up further changes elsewhere.

The `NamedInputStream` class, before these changes, was the main method used inside SANY to access the contents of module files. That is unchanged, but the class is now a thin wrapper around the `ModuleSourceCode` class which is one small part of the new SANY API that has been cooking in the test directory. Since lifetime management is not Java's strong suit, input streams are de-emphasized in favor of keeping a byte array of file contents around in memory. `ByteArrayInputStream` instances can be created over that byte array on demand, and it doesn't matter whether they're closed or not.

The `ModuleSourceCode` class is written for a world where modules can come from many possible places, not necessarily files. The broad strategy here is for `ModuleSourceCode` to wear `NamedInputStream`'s skin for a bit until the rest of SANY stops using `NamedInputStream`'s deprecated file-specific methods. Then the rest of SANY can slowly migrate to using `ModuleSourceCode` directly, and `NamedInputStream` can eventually be deleted. 

There are two commits in this PR. The first writes unit tests for `NamedInputStream`. The second changes `NamedInputStream` into a wrapper for `ModuleSourceCode` in a way where all the existing tests pass unchanged. `NamedInputStream` is also extensively documented during this process and various methods are marked deprecated.