### PR TITLE
Add debugging aids to (i) print statistics about the complexity of liveness checking, and (ii) visualize the tableau graph with GraphViz.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -251,6 +251,7 @@ public interface EC
     public static final int TLC_FP_COMPLETED = 2211;
     
     public static final int TLC_LIVE_IMPLIED = 2212;
+    public static final int TLC_LIVE_IMPLIED_DEBUG = 2263;
     public static final int TLC_LIVE_CANNOT_HANDLE_FORMULA = 2213;
     public static final int TLC_LIVE_WRONG_FORMULA_FORMAT = 2214;
     public static final int TLC_LIVE_ENCOUNTERED_ACTIONS = 2249;

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -880,6 +880,10 @@ public class MP
         case EC.TLC_LIVE_IMPLIED:
             b.append("Implied-temporal checking--satisfiability problem has %1% branches.");
             break;
+        case EC.TLC_LIVE_IMPLIED_DEBUG:
+			b.append(
+					"Implied-temporal checking--branch of satisfiable problem has %1% possible error model(s), %2% promise(s), %3% state check(s), %4% action check(s), and a tableau with %5% node(s).");
+            break;
         case EC.TLC_LIVE_CANNOT_HANDLE_FORMULA:
         	if (parameters.length > 1) {
         		b.append("TLC cannot handle the temporal formula %1%:\n%2%");


### PR DESCRIPTION
Add debugging capabilities to TLC's liveness checking functionality by providing two Java system property-based debugging aids: statistics printing and tableau graph visualization.

Adds the system property `-Dtlc2.tool.liveness.Liveness.debug=true` to enable printing of liveness checking complexity statistics. Adds the system property `-Dtlc2.tool.liveness.Liveness.tableauExportPath=/out/put/path.dot` to export tableau graphs in GraphViz DOT format.

[Feature][TLC]