### PR TITLE
SANY: Add type parameters to Vector usage

### DIFF
--- a/tlatools/org.lamport.tlatools/javacc/tla+.jj
+++ b/tlatools/org.lamport.tlatools/javacc/tla+.jj
@@ -119,7 +119,7 @@ public class TLAplusParser implements tla2sany.st.SyntaxTreeConstants, ParseTree
     ***********************************************************************/
     String[]deps = new String[ dependencyList.size() ];
     for (int lvi =0; lvi < deps.length; lvi++)
-      deps[lvi] = ((UniqueString)dependencyList.elementAt(lvi)).toString();
+      deps[lvi] = dependencyList.elementAt(lvi).toString();
     return deps;
   }
   public TreeNode rootNode() { return ParseTree; }
@@ -132,7 +132,7 @@ public class TLAplusParser implements tla2sany.st.SyntaxTreeConstants, ParseTree
     * The root node.                                                       *
     ***********************************************************************/
 
-  public Vector dependencyList = new Vector( 20 );
+  public final Vector<UniqueString> dependencyList = new Vector<UniqueString>(20);
 
   private UniqueString mn = null;
      /**********************************************************************

--- a/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/explorer/Explorer.java
@@ -111,7 +111,7 @@ public class Explorer {
 
 	private void lookUpAndPrintSyntaxTree(String symbName) {
 
-		Vector<SymbolNode> symbolVect = new Vector<>(8); // Initial room for 8 symbols with same name
+		final Vector<SymbolNode> symbolVect = new Vector<>(8); // Initial room for 8 symbols with same name
 
 		// Collect in Vector symbols all SymbolNodes in the semNodesTable whose name ==
 		// symbName
@@ -130,8 +130,8 @@ public class Explorer {
 
 		// Print them all
 		for (int i = 0; i < symbolVect.size(); i++) {
-			SymbolNode sym = (SymbolNode) (symbolVect.elementAt(i));
-			((SemanticNode) (sym)).getTreeNode().printST(0);
+			SymbolNode sym = symbolVect.elementAt(i);
+			sym.getTreeNode().printST(0);
 			System.out.println();
 		}
 
@@ -139,7 +139,7 @@ public class Explorer {
 
 	private void lookUpAndPrintDef(String symbName) {
 
-		Vector<SymbolNode> symbolVect = new Vector<>(8); // Initial room for 8 symbols with same name
+		final Vector<SymbolNode> symbolVect = new Vector<>(8); // Initial room for 8 symbols with same name
 
 		// Collect in Vector symbols all SymbolNodes in the semNodesTable whose name ==
 		// symbName
@@ -158,7 +158,7 @@ public class Explorer {
 
 		// Print them all
 		for (int i = 0; i < symbolVect.size(); i++) {
-			SymbolNode sym = (SymbolNode) (symbolVect.elementAt(i));
+			SymbolNode sym = symbolVect.elementAt(i);
 			if (sym instanceof OpDefOrDeclNode) {
 				if (((OpDefOrDeclNode) sym).getOriginallyDefinedInModuleNode() != null) {
 					System.out.print(
@@ -169,14 +169,14 @@ public class Explorer {
 			} else if (sym instanceof FormalParamNode) {
 				System.out.print("Module: " + ((FormalParamNode) sym).getModuleNode().getName());
 			}
-			System.out.println(((ExploreNode) (symbolVect.elementAt(i))).toString(100, errors) + "\n");
+			System.out.println(symbolVect.elementAt(i).toString(100, errors) + "\n");
 		}
 
 	}
 
 	private void levelDataPrint(String symbName) {
 
-		Vector<SymbolNode> symbolVect = new Vector<>(8); // Initial room for 8 symbols with same name
+		final Vector<SymbolNode> symbolVect = new Vector<>(8); // Initial room for 8 symbols with same name
 
 		// Collect in Vector symbols all SymbolNodes in the semNodesTable whose name ==
 		// symbName
@@ -195,7 +195,7 @@ public class Explorer {
 
 		// Print them all
 		for (int i = 0; i < symbolVect.size(); i++) {
-			SymbolNode sym = (SymbolNode) (symbolVect.elementAt(i));
+			SymbolNode sym = symbolVect.elementAt(i);
 			if (sym instanceof OpDefOrDeclNode) {
 				if (((OpDefOrDeclNode) sym).getOriginallyDefinedInModuleNode() != null) {
 					System.out.print(

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ModulePointer.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ModulePointer.java
@@ -57,19 +57,19 @@ public class ModulePointer {
 
 
   // Returns Vector of names of modules extended
-  Vector getNamesOfModulesExtended() {
+  Vector<String> getNamesOfModulesExtended() {
     return moduleRelatives.directlyExtendedModuleNames; 
   }
   
 
   // Returns Vector of names of modules instanced
-  Vector getNamesOfModulesInstantiated() { 
+  Vector<String> getNamesOfModulesInstantiated() { 
     return moduleRelatives.directlyInstantiatedModuleNames; 
   }
 
 
   // Returns Vector of names of Module pointers for immediate inner modules
-  Vector getDirectInnerModules() { 
+  Vector<ModulePointer> getDirectInnerModules() { 
     return moduleRelatives.directInnerModules; 
   }
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ModuleRelatives.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ModuleRelatives.java
@@ -19,18 +19,24 @@ public class ModuleRelatives {
   ModulePointer outerModule                     = null; // TreeNode of the immediate outer (parent) module; 
                                                         //   null currentModule is the outermost in parseUnit
 
-  Vector        directInnerModules              = new Vector(); 
-                                                        // Vector of ModulePointers for immediate inner modules 
+  /**
+   * Vector of ModulePointers for immediate inner modules
+   */
+  final Vector<ModulePointer> directInnerModules = new Vector<>();
 
-  Vector        directlyExtendedModuleNames     = new Vector(); 
-                                                        // Vector of String names for modules mentioned in EXTENDS decls by 
-                                                        //   currentModule, whether or not they are resolved within the 
-                                                        //   current ParseUnit
+  /**
+   * Vector of String names for modules mentioned in EXTENDS decls by
+   * currentModule, whether or not they are resolved within the
+   * current ParseUnit
+   */
+  final Vector<String> directlyExtendedModuleNames = new Vector<>();
 
-  Vector        directlyInstantiatedModuleNames = new Vector(); 
-                                                        // Vector of String names for modules directly instantiated 
-                                                        //   by currentModule, whether or not they are resolved within the
-                                                        //   current ParseUnit
+  /**
+   * Vector of String names for modules directly instantiated
+   * by currentModule, whether or not they are resolved within the
+   * current ParseUnit
+   */
+  final Vector<String> directlyInstantiatedModuleNames = new Vector<>();
 
   ModuleContext context = new ModuleContext();          // The context that maps module String names known in this module 
                                                         //   (whether or not they are referenced in it) to ModulePointers
@@ -51,17 +57,17 @@ public class ModuleRelatives {
 
     ret += "\ndirectInnerModules: ";
     for (int i = 0; i < directInnerModules.size(); i++) {
-      ret += ((ModulePointer)(directInnerModules.elementAt(i))).getName() + " ";
+      ret += directInnerModules.elementAt(i).getName() + " ";
     }
 
     ret += "\ndirectlyExtendedModuleNames: ";
     for (int i = 0; i < directlyExtendedModuleNames.size(); i++) {
-      ret += (String)(directlyExtendedModuleNames.elementAt(i)) + " ";
+      ret += directlyExtendedModuleNames.elementAt(i) + " ";
     }
 
     ret += "\ndirectlyInstantiatedModuleNames: ";
     for (int i = 0; i < directlyInstantiatedModuleNames.size(); i++) {
-      ret += (String)(directlyInstantiatedModuleNames.elementAt(i)) + " ";
+      ret += directlyInstantiatedModuleNames.elementAt(i) + " ";
     }
 
     ret += "\n" + context.toString();

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnit.java
@@ -115,13 +115,13 @@ public class ParseUnit {
 
   public final ModulePointer getRootModule()  { return rootModule; }
 
-  final        Vector        getExtendees()   { return parseUnitRelatives.extendees; }
+  final        Vector<ParseUnit> getExtendees()   { return parseUnitRelatives.extendees; }
 
-  final        Vector        getExtendedBy()  { return parseUnitRelatives.extendedBy; }
+  final        Vector<ParseUnit> getExtendedBy()  { return parseUnitRelatives.extendedBy; }
 
-  final        Vector        getInstancees()  { return parseUnitRelatives.instancees; }
+  final        Vector<ParseUnit> getInstancees()  { return parseUnitRelatives.instancees; }
              
-  final        Vector        getInstancedBy() { return parseUnitRelatives.instancedBy; }
+  final        Vector<ParseUnit> getInstancedBy() { return parseUnitRelatives.instancedBy; }
 
   // Add-methods
   final        void          addExtendee(ParseUnit pu)    { parseUnitRelatives.extendees.addElement(pu); }
@@ -150,7 +150,7 @@ public class ParseUnit {
     return module.getRelatives().outerModule;
   }
 
-  final Vector getPeers(ModulePointer module) {
+  final Vector<ModulePointer> getPeers(ModulePointer module) {
     if ( module.getRelatives().outerModule != null ) {
       return module.getRelatives().outerModule.getRelatives().directInnerModules;
     }
@@ -387,11 +387,11 @@ public class ParseUnit {
     }
 
     ModuleContext currentContext = getContext(currentModule);
-    Vector        extendeeNames  = otherModule.getNamesOfModulesExtended();
+    final Vector<String> extendeeNames  = otherModule.getNamesOfModulesExtended();
 
     // For all modules extended by otherModule
     for (int i = 0; i < extendeeNames.size(); i++) {
-      String        extendeeName = (String)extendeeNames.elementAt(i);
+      String        extendeeName = extendeeNames.elementAt(i);
       ModulePointer extendeeResolvant = currentContext.resolve(extendeeName);
 
       // if extendeeName is resolved in currentContext, then
@@ -399,9 +399,9 @@ public class ParseUnit {
       // recursively add to currentContext all of the inner modules in
       // modules extended by resolvant
       if ( extendeeResolvant != null ) {
-        Vector directInnerModules = extendeeResolvant.getDirectInnerModules();
+        Vector<ModulePointer> directInnerModules = extendeeResolvant.getDirectInnerModules();
         for (int j = 0; j < directInnerModules.size(); j++) {
-          ModulePointer upperInnerMod = (ModulePointer)directInnerModules.elementAt(j);
+          ModulePointer upperInnerMod = directInnerModules.elementAt(j);
           currentContext.bindIfNotBound(upperInnerMod.getName(), upperInnerMod);
           handleExtensions(currentModule,extendeeResolvant); // recursive call
 	}
@@ -449,10 +449,10 @@ public class ParseUnit {
       // etc. at point where it is defined
       currentContext.union(getParent(ancestorModule).getContext());
 
-      Vector peers = getPeers(ancestorModule);
+      final Vector<ModulePointer> peers = getPeers(ancestorModule);
       // All peers defined so far are in the currentContext
       for (int i = 0; i < peers.size() - 1; i++) {
-        ModulePointer nextPeer = (ModulePointer)peers.elementAt(i);
+        ModulePointer nextPeer = peers.elementAt(i);
         currentContext.bindIfNotBound(nextPeer.getName(), nextPeer);
       }
       ancestorModule = getParent(ancestorModule);

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnitRelatives.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/ParseUnitRelatives.java
@@ -6,13 +6,13 @@ import tla2sany.utilities.Vector;
 
 class ParseUnitRelatives {
 
-  Vector extendees  = new Vector();  // vector of ParseUnit objects
+  final Vector<ParseUnit> extendees  = new Vector<>();
 
-  Vector extendedBy = new Vector();  // vector of ParseUnit objects
+  final Vector<ParseUnit> extendedBy = new Vector<>();
 
-  Vector instancees = new Vector();  // vector of ParseUnit objects  
+  final Vector<ParseUnit> instancees = new Vector<>();
 
-  Vector instancedBy = new Vector();  // vector of ParseUnit objects
+  final Vector<ParseUnit> instancedBy = new Vector<>();
 
   public final String toString() {
     return "[ extendees = "   + extendees.toString() +

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/OperatorStack.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/OperatorStack.java
@@ -10,7 +10,7 @@ import util.UniqueString;
 
 public class OperatorStack implements tla2sany.st.SyntaxTreeConstants {
 
-  private Vector StackOfStack = new Vector (10);
+  private final Vector<Vector<OSelement>> StackOfStack = new Vector<>(10);
     /***********************************************************************
     * The actual OperatorStack object.  It appears to be a vector of       *
     * vectors of OSElement objects.  A stack appears to be represented by  *
@@ -18,9 +18,7 @@ public class OperatorStack implements tla2sany.st.SyntaxTreeConstants {
     * stack.                                                               *
     ***********************************************************************/
 
-  private SyntaxTreeNode VoidSTNode = new SyntaxTreeNode( );
-
-  private Vector CurrentTop = null;
+  private Vector<OSelement> CurrentTop = null;
     /***********************************************************************
     * Appears to be the stack of OSelement objects at the top of the       *
     * OperatorStack.  It equals null if OperatorStack is empty.  Does it   *
@@ -45,7 +43,7 @@ public class OperatorStack implements tla2sany.st.SyntaxTreeConstants {
     /***********************************************************************
     * Adds an empty stack to the top of the OperatorStack.                 *
     ***********************************************************************/
-    CurrentTop = new Vector( 20 );
+    CurrentTop = new Vector<OSelement>( 20 );
     StackOfStack.addElement( CurrentTop );
   }
 
@@ -56,7 +54,7 @@ public class OperatorStack implements tla2sany.st.SyntaxTreeConstants {
     ***********************************************************************/
     StackOfStack.removeElementAt( StackOfStack.size()-1 );
     if (StackOfStack.size() > 0 )
-      CurrentTop = (Vector) StackOfStack.elementAt( StackOfStack.size() - 1 );
+      CurrentTop = StackOfStack.elementAt( StackOfStack.size() - 1 );
     else
       CurrentTop = null;
   }
@@ -93,7 +91,7 @@ What do left and right mean?????? What does shift mean????????
     if (CurrentTop.size() == 0)
       return true;
     else {
-      Operator op  = ((OSelement) CurrentTop.elementAt( CurrentTop.size()-1 )).getOperator();
+      Operator op  = CurrentTop.elementAt(CurrentTop.size() - 1).getOperator();
       if (op != null)
         return op.isPrefix() || op.isInfix();
       else
@@ -123,9 +121,9 @@ What do left and right mean?????? What does shift mean????????
     int n = CurrentTop.size()-1;
 //    SyntaxTreeNode localTN = new InfixExprNode();
     if (n>=3) {
-      SyntaxTreeNode opNode  = ((OSelement) CurrentTop.elementAt( n-2)).getNode();
-      SyntaxTreeNode leftOp  = ((OSelement) CurrentTop.elementAt( n-3)).getNode();
-      SyntaxTreeNode rightOp = ((OSelement) CurrentTop.elementAt( n-1)).getNode();
+      SyntaxTreeNode opNode  = CurrentTop.elementAt(n-2).getNode();
+      SyntaxTreeNode leftOp  = CurrentTop.elementAt(n-3).getNode();
+      SyntaxTreeNode rightOp = CurrentTop.elementAt(n-1).getNode();
       CurrentTop.removeElementAt(n-1);
       CurrentTop.removeElementAt(n-2);
       SyntaxTreeNode lSTN;
@@ -161,21 +159,16 @@ What do left and right mean?????? What does shift mean????????
     int n = CurrentTop.size()-1;
 //    SyntaxTreeNode localTN = new PrefixExprNode();
     if (n>=2) {
-      Operator op = ((OSelement) CurrentTop.elementAt( n-2)).getOperator();
-        /*******************************************************************
-        * It appears that op is no longer used.                            *
-        *******************************************************************/
-      SyntaxTreeNode opNode = ((OSelement) CurrentTop.elementAt( n-2)).getNode();
 // System.out.println( op.getIdentifier() );
 //      if ( op.isInfix() )
 //        ((GenOpNode)opNode).register( op.getIdentifier() + ".", STable);
 //      else
 //        ((GenOpNode)opNode).register( op.getIdentifier(), STable);
         SyntaxTreeNode lSTN = new SyntaxTreeNode(N_PrefixExpr,
-          ((OSelement) CurrentTop.elementAt( n-2)).getNode(),
-          ((OSelement) CurrentTop.elementAt( n-1)).getNode());
-//      localTN.addChild( ((OSelement) CurrentTop.elementAt( n-2)).getNode() ) ;
-//      localTN.addChild( ((OSelement) CurrentTop.elementAt( n-1)).getNode() ) ;
+          CurrentTop.elementAt(n-2).getNode(),
+          CurrentTop.elementAt(n-1).getNode());
+//      localTN.addChild( (CurrentTop.elementAt( n-2)).getNode() ) ;
+//      localTN.addChild( (CurrentTop.elementAt( n-1)).getNode() ) ;
       CurrentTop.removeElementAt(n-1);
       CurrentTop.setElementAt(new OSelement(lSTN) , n-2);
     }
@@ -201,18 +194,18 @@ What do left and right mean?????? What does shift mean????????
     SyntaxTreeNode lSTN;
 //    SyntaxTreeNode localTN = new PostfixExprNode();
     if (n>=2) {
-      Operator op = ((OSelement) CurrentTop.elementAt( n-1)).getOperator();
-      SyntaxTreeNode opNode = ((OSelement) CurrentTop.elementAt( n-1)).getNode();
+      Operator op = CurrentTop.elementAt(n-1).getOperator();
+      SyntaxTreeNode opNode = CurrentTop.elementAt(n-1).getNode();
       if (op != fcnOp ) {
 //      ((GenOpNode)opNode).register( op.getIdentifier(), STable);
         lSTN = new SyntaxTreeNode(N_PostfixExpr,
-          ((OSelement) CurrentTop.elementAt( n-2)).getNode(),
+          CurrentTop.elementAt(n-2).getNode(),
           opNode);
-//      localTN.addChild( ((OSelement) CurrentTop.elementAt( n-2)).getNode() ) ;
+//      localTN.addChild( (CurrentTop.elementAt( n-2)).getNode() ) ;
 //      localTN.addChild( opNode ) ;
       } else {
 // System.out.println("postfix reduction : FcnOp");
-        SyntaxTreeNode eSTN = ((OSelement) CurrentTop.elementAt( n-2)).getNode();
+        SyntaxTreeNode eSTN = CurrentTop.elementAt(n-2).getNode();
         lSTN = new SyntaxTreeNode( eSTN.getFN(), N_FcnAppl, eSTN, (SyntaxTreeNode[]) (opNode.heirs()) );
       }
       CurrentTop.removeElementAt(n-1);
@@ -236,7 +229,7 @@ What do left and right mean?????? What does shift mean????????
     do { // until (n != CurrentTop.size()-1);
       n = CurrentTop.size()-1; 
          // note !!! n is used as index, not size. XXX lousy identifier.
-      tm0 = (OSelement)CurrentTop.elementAt( n );
+      tm0 = CurrentTop.elementAt( n );
 
       if ( ! tm0.isOperator() ) break; /* break = return here */
       oR = tm0.getOperator();
@@ -248,7 +241,7 @@ What do left and right mean?????? What does shift mean????????
                                    tm0.getNode().getLocation().toString() + 
                                    " on empty stack");
         } else {
-          tm1 = (OSelement)CurrentTop.elementAt( n-1 );
+          tm1 = CurrentTop.elementAt( n-1 );
           if ( tm1.isOperator()) {
             oL = tm1.getOperator();
 // System.out.println("tm1 est " + oL.toString() );
@@ -263,7 +256,7 @@ What do left and right mean?????? What does shift mean????????
             }
           } else { // tm1 is Expression - what's below ?
             if ( n > 1 ) {
-              tm2 = (OSelement)CurrentTop.elementAt( n-2 );
+              tm2 = CurrentTop.elementAt( n-2 );
               if ( tm2.isOperator() ) { 
                 oL = tm2.getOperator();
                 if ( Operator.succ( oL, oR ) ) { // prefix or infix ?
@@ -291,7 +284,7 @@ What do left and right mean?????? What does shift mean????????
       } else if ( oR.isPrefix() ) {
         if ( n == 0 ) break; // can't do anything yet
         else {
-          tm1 = (OSelement)CurrentTop.elementAt( n-1 );
+          tm1 = CurrentTop.elementAt( n-1 );
           if ( tm1.isOperator()) { // prefix, or infix
             oL = tm1.getOperator();
             if ( oL.isPostfix() ) {
@@ -322,7 +315,7 @@ What do left and right mean?????? What does shift mean????????
               break;
         } else {
 // System.out.println("infix case: " + oR.getIdentifier());
-          tm1 = (OSelement)CurrentTop.elementAt( n-1 );
+          tm1 = CurrentTop.elementAt( n-1 );
           if ( tm1.isOperator()) {
             oL = tm1.getOperator();
             if ( oL.isInfix() || oL.isPrefix() ) { 
@@ -357,14 +350,14 @@ What do left and right mean?????? What does shift mean????????
 // System.out.println("tm1 is expression");
             if ( n > 1 ) {
 // System.out.println("deep stack");
-              tm2 = (OSelement)CurrentTop.elementAt( n-2 );
+              tm2 = CurrentTop.elementAt( n-2 );
               if ( tm2.isOperator() ) {
                 oL = tm2.getOperator();
 // System.out.println("tm2 is operator: " + oL.getIdentifier());
                 Operator mixL = Operators.getMixfix( oL );
                 if (  mixL != null && ((n==2) 
                     || 
-                     ((OSelement)CurrentTop.elementAt( n-3 )).isOperator())) {
+                     CurrentTop.elementAt(n-3).isOperator())) {
 // System.out.println("identified prefix");
                   oL = mixL;
                 } 
@@ -440,14 +433,14 @@ What do left and right mean?????? What does shift mean????????
     pushOnStack( null, Operator.VoidOperator() );
     reduceStack();
     if ( isWellReduced() )
-      return ((OSelement) CurrentTop.elementAt(0)).getNode();
+      return CurrentTop.elementAt(0).getNode();
     else {
       StringBuffer msg = new StringBuffer("Couldn't properly parse expression");
       int l[];
       do {
-//((OSelement)CurrentTop.elementAt(n)).getNode().printTree(new java.io.PrintWriter(System.out));  n++;
+//(CurrentTop.elementAt(n)).getNode().printTree(new java.io.PrintWriter(System.out));  n++;
         msg.append("-- incomplete expression at ");
-        msg.append( ((OSelement)CurrentTop.elementAt(n)).getNode().getLocation().toString() ) ;
+        msg.append(CurrentTop.elementAt(n).getNode().getLocation().toString() ) ;
         msg.append(".\n");
         n++;
       } while (n < CurrentTop.size()-1);
@@ -477,7 +470,7 @@ What do left and right mean?????? What does shift mean????????
   }
 
   public SyntaxTreeNode bottomOfStack() {
-    return ((OSelement) CurrentTop.elementAt(0)).getNode();
+    return CurrentTop.elementAt(0).getNode();
   }
 
   public final void reduceRecord( SyntaxTreeNode middle, SyntaxTreeNode right ) throws ParseException {
@@ -488,21 +481,21 @@ What do left and right mean?????? What does shift mean????????
     index = CurrentTop.size()-1;
     if (index < 0)
       throw new ParseException("\n    ``.'' has no left hand side at " + middle.getLocation().toString() + "." );
-    oselt = (OSelement)CurrentTop.elementAt( index );
+    oselt = CurrentTop.elementAt( index );
 
     if ( oselt.isOperator() ) {
-      OSelement ospelt = (OSelement)CurrentTop.elementAt( index - 1 );
+      OSelement ospelt = CurrentTop.elementAt( index - 1 );
       if ( oselt.getOperator().isPostfix() && !ospelt.isOperator() ) {
         CurrentTop.addElement( null ); // humour reducePostfix
         reducePostfix();
         index = CurrentTop.size()-1;             // fix humoring
         CurrentTop.removeElementAt(index);
         index--;
-        oselt = (OSelement)CurrentTop.elementAt( index );
+        oselt = CurrentTop.elementAt( index );
       } else
         throw new ParseException("\n    ``.'' follows operator " + oselt.getNode().getLocation().toString() + "." );
     } 
-    SyntaxTreeNode left = ((OSelement) CurrentTop.elementAt(index )).getNode();
+    SyntaxTreeNode left = CurrentTop.elementAt(index).getNode();
     SyntaxTreeNode rcd = new SyntaxTreeNode(N_RecordComponent, left, middle, right);
     CurrentTop.setElementAt(new OSelement(rcd) , index);
 }
@@ -512,7 +505,7 @@ What do left and right mean?????? What does shift mean????????
   final private String printStack() {
     String str = new String( "stack dump, " + StackOfStack.size() + " levels, " + CurrentTop.size() + " in top one: ");
      for (int i = 0; i< CurrentTop.size(); i++ ) {
-       SyntaxTreeNode tn = ((OSelement)CurrentTop.elementAt( i )).getNode();
+       SyntaxTreeNode tn = CurrentTop.elementAt(i).getNode();
        if (tn != null)
          str = str.concat(tn.getImage() + " " );
      }
@@ -527,7 +520,7 @@ What do left and right mean?????? What does shift mean????????
     if (CurrentTop == null) {return null;} ;
     int n = CurrentTop.size() ;
     if (n == 0) {return null;} ;
-    return (OSelement) CurrentTop.elementAt(n-1) ;
+    return CurrentTop.elementAt(n-1) ;
    }
 
   final public void popCurrentTop() {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/TLAplusParser.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/TLAplusParser.java
@@ -30,7 +30,7 @@ public class TLAplusParser implements tla2sany.st.SyntaxTreeConstants, ParseTree
     ***********************************************************************/
     String[]deps = new String[ dependencyList.size() ];
     for (int lvi =0; lvi < deps.length; lvi++)
-      deps[lvi] = ((UniqueString)dependencyList.elementAt(lvi)).toString();
+      deps[lvi] = dependencyList.elementAt(lvi).toString();
     return deps;
   }
   public TreeNode rootNode() { return ParseTree; }
@@ -43,7 +43,7 @@ public class TLAplusParser implements tla2sany.st.SyntaxTreeConstants, ParseTree
     * The root node.                                                       *
     ***********************************************************************/
 
-  public Vector dependencyList = new Vector( 20 );
+  public final Vector<UniqueString> dependencyList = new Vector<UniqueString>(20);
 
   private UniqueString mn = null;
      /**********************************************************************

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/APSubstInNode.java
@@ -86,7 +86,7 @@ public class APSubstInNode extends LevelNode {
    * substitutions is to be produced.
    */
   public APSubstInNode(TreeNode treeNode, SymbolTable instancerST,
-		     Vector instanceeDecls, ModuleNode ingmn, ModuleNode edmn, Errors errors)
+		     final Vector<OpDeclNode> instanceeDecls, ModuleNode ingmn, ModuleNode edmn, Errors errors)
   throws AbortException {
     super(APSubstInKind, treeNode);
     this.instantiatingModule = ingmn;
@@ -136,17 +136,17 @@ public class APSubstInNode extends LevelNode {
    * OpApplNode or an OpArgNode substituted for each CONSTANT of
    * VARIABLE OpDeclNode in vector v.
    */
-  final void constructSubst(Vector instanceeDecls, SymbolTable instancerST,
+  final void constructSubst(final Vector<OpDeclNode> instanceeDecls, SymbolTable instancerST,
 			    TreeNode treeNode, Errors errors)
   throws AbortException {
-    Vector vtemp = new Vector();
+    final Vector<Subst> vtemp = new Vector<>();
 
     // for each CONSTANT or VARIABLE declared in module being
     // instantiated (the instancee)
     for ( int i = 0; i < instanceeDecls.size(); i++ ) {
       // Get the OpDeclNode for the CONSTANT or VARIABLE being
       // substituted for, i.e. "c" in" c <- e"
-      OpDeclNode decl = (OpDeclNode)instanceeDecls.elementAt(i);
+      OpDeclNode decl = instanceeDecls.elementAt(i);
 
       // Try to resolve the name in the instancer module so we can see
       // if it is recognized as an operator, and if so, what kind of
@@ -191,7 +191,7 @@ public class APSubstInNode extends LevelNode {
     // that are legally possible. Make an array out of them
     this.substs = new Subst[ vtemp.size() ];
     for (int i = 0; i < vtemp.size(); i++) {
-      this.substs[i] = (Subst)vtemp.elementAt(i);
+      this.substs[i] = vtemp.elementAt(i);
     }
   } // end constructSubst()
 
@@ -270,10 +270,10 @@ public class APSubstInNode extends LevelNode {
    * possible, because X is not defined in the instantiating module,
    * then we have an error.
    */
-  final void matchAll(Vector decls, Errors errors) {
+  final void matchAll(final Vector<OpDeclNode> decls, Errors errors) {
     for (int i = 0; i < decls.size(); i++) {
       // Get the name of the i'th operator that must be substituted for
-      UniqueString opName = ((OpDeclNode)decls.elementAt(i)).getName();
+      UniqueString opName = decls.elementAt(i).getName();
 
       // See if it is represented in the substitutions array
       int j;
@@ -286,7 +286,7 @@ public class APSubstInNode extends LevelNode {
         errors.addError(ErrorCode.SUSPECTED_UNREACHABLE_CHECK,
 			stn.getLocation(),
 			"Substitution missing for symbol " + opName + " declared at " +
-			((OpDeclNode)(decls.elementAt(i))).getTreeNode().getLocation() +
+			decls.elementAt(i).getTreeNode().getLocation() +
 			" \nand instantiated in module " + instantiatingModule.getName() + "." );
       }
     }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Context.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Context.java
@@ -246,13 +246,13 @@ public class Context implements ExploreNode {
    * Returns a Vector of those SymbolNodes in this Context that are
    * instances of class "template" (or one of its subclasses)
    */
-  public Vector<SymbolNode> getByClass( Class<?> template ) {
-    Vector<SymbolNode> result = new Vector<>();
+  public <T> Vector<T> getByClass(Class<T> template) {
+    final Vector<T> result = new Vector<>();
     Enumeration<Pair> list = table.elements();
     while (list.hasMoreElements()) {
       Pair elt = list.nextElement();
       if (template.isInstance(elt.info)) {
-        result.addElement( elt.info );
+        result.addElement(template.cast(elt.info));
       }
     }
     return result;
@@ -268,7 +268,7 @@ public class Context implements ExploreNode {
       // Class template = OpDefNode.class;
     Pair nextPair = lastPair;
 
-    Vector<OpDefNode> result = new Vector<>();
+    final Vector<OpDefNode> result = new Vector<>();
     while (nextPair != null) {
       if ( nextPair.info instanceof OpDefNode &&     // true for superclasses too.
            ((OpDefNode)nextPair.info).getKind() != ASTConstants.ModuleInstanceKind &&
@@ -289,7 +289,7 @@ public class Context implements ExploreNode {
       // Class template = ThmOrAssumpDefNode.class;
     Pair nextPair = lastPair;
 
-    Vector<ThmOrAssumpDefNode> result = new Vector<>();
+    final Vector<ThmOrAssumpDefNode> result = new Vector<>();
     while (nextPair != null) {
       if ( nextPair.info instanceof ThmOrAssumpDefNode)
         { result.addElement( (ThmOrAssumpDefNode)(nextPair.info) );} ;
@@ -301,49 +301,48 @@ public class Context implements ExploreNode {
   /**
    * Returns vector of OpDeclNodes that represent CONSTANT declarations
    */
-  public Vector<SemanticNode> getConstantDecls() {
+  public Vector<OpDeclNode> getConstantDecls() {
     Class<? extends SemanticNode> templateClass = OpDeclNode.class;
     Enumeration<Pair> list = table.elements();
 
-    Vector<SemanticNode> result = new Vector<>();
+    final Vector<OpDeclNode> result = new Vector<>();
     while (list.hasMoreElements()) {
       Pair elt = list.nextElement();
       if (templateClass.isInstance(elt.info) &&     // true for superclasses too.
          ((OpDeclNode)elt.info).getKind() == ASTConstants.ConstantDeclKind  )
-        result.addElement( (SemanticNode)(elt.info) );
+        result.addElement( (OpDeclNode)(elt.info) );
 
     }
     return result;
   }
 
-  /* Returns vector of OpDeclNodes that represent CONSTANT declarations  */
-  public Vector<SemanticNode> getVariableDecls() {
+  /* Returns vector of OpDeclNodes that represent VARIABLE declarations  */
+  public Vector<OpDeclNode> getVariableDecls() {
     Class<? extends SemanticNode> templateClass = OpDeclNode.class;
     Enumeration<Pair> list = table.elements();
 
-    Vector<SemanticNode> result = new Vector<>();
+    final Vector<OpDeclNode> result = new Vector<>();
     while (list.hasMoreElements()) {
       Pair elt = list.nextElement();
       if (templateClass.isInstance(elt.info) &&     // true for superclasses too.
            ((OpDeclNode)elt.info).getKind() == ASTConstants.VariableDeclKind  )
-        result.addElement( (SemanticNode)(elt.info) );
+        result.addElement( (OpDeclNode)(elt.info) );
     }
     return result;
   }
 
   /**
-   * Returns a Vector of those SymbolNodes in this Context that are
-   * instances of class ModuleNode
+   * Returns a Vector {@link ModuleNode} instances in this context.
    */
-  public Vector<SemanticNode> getModDefs() {
+  public Vector<ModuleNode> getModDefs() {
     Class<? extends SemanticNode> template = ModuleNode.class;
     Enumeration<Pair> list = table.elements();
 
-    Vector<SemanticNode> result = new Vector<>();
+    final Vector<ModuleNode> result = new Vector<>();
     while (list.hasMoreElements()) {
       Pair elt = list.nextElement();
       if (template.isInstance(elt.info))    // true for superclasses too.
-        result.addElement( (SemanticNode)(elt.info) );
+        result.addElement( (ModuleNode)(elt.info) );
     }
     return result;
   }
@@ -490,7 +489,7 @@ public class Context implements ExploreNode {
   * information.                                                           
   *************************************************************************/
   public Vector<String> getContextEntryStringVector(int depth, boolean b, Errors errors) {
-    Vector<String> ctxtEntries = new Vector<>(100);  // vector of Strings
+    final Vector<String> ctxtEntries = new Vector<>(100);
     Context naturalsContext =
                exMT.getContext(UniqueString.uniqueStringOf("Naturals"));
 

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ExternalModuleTable.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ExternalModuleTable.java
@@ -81,22 +81,16 @@ public class ExternalModuleTable implements ExploreNode {
   * moduleHashTable, and that each of its entries has a moduleName as the  *
   * key and a value that's an ExternalModuleTableEntry object.             *
   *************************************************************************/
-  public Hashtable<UniqueString, ExternalModuleTableEntry> moduleHashTable;
+  public final Hashtable<UniqueString, ExternalModuleTableEntry> moduleHashTable = new Hashtable<>();
 
   // Vector moduleVector contains ModuleNodes (the same ones as
   // moduleHashTable), but preserves the order in which they were
   // inserted.  If module A depends on module B, then A has a HIGHER
   // index than B.
-  public Vector<ModuleNode>    moduleNodeVector;
+  public final Vector<ModuleNode> moduleNodeVector = new Vector<>();
 
   // The nodule node of the root module
   public ModuleNode rootModule;
-
-  // Constructor
-  public ExternalModuleTable() {
-    moduleHashTable  = new Hashtable<>();
-    moduleNodeVector = new Vector<>();
-  }
 
   // Set and get the rootModule field
   public ModuleNode getRootModule()              { return rootModule; }
@@ -123,7 +117,7 @@ public class ExternalModuleTable implements ExploreNode {
   public ModuleNode[] getModuleNodes() {
     ModuleNode [] mods = new ModuleNode[moduleNodeVector.size()];
     for (int i = 0; i < mods.length; i++) {
-      mods[i] = (ModuleNode)moduleNodeVector.elementAt(i);
+      mods[i] = moduleNodeVector.elementAt(i);
     }
     return mods;
   }
@@ -185,7 +179,7 @@ public class ExternalModuleTable implements ExploreNode {
 
     String ret = "";
     for (int i = 0; i < moduleNodeVector.size(); i++) {
-      ModuleNode mn = (ModuleNode)moduleNodeVector.elementAt(i);
+      ModuleNode mn = moduleNodeVector.elementAt(i);
       if (mn != null) {
         ret += Strings.indent(2, "\nModule: " + Strings.indent(2, mn.toString(depth, errors)) );
       } else {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/Generator.java
@@ -202,9 +202,12 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		// The syntax tree node holding this GenID
 		private StringBuffer compoundID;
 		// The string name of the compound op, with "!"'s, if any
-		private Vector argsVector = new Vector();
-		// Vector of arguments (ExprNodes and OpArgNodes)
-		// that are embedded in the generalized identifier
+
+		/**
+		 * Vector of arguments (ExprNodes and OpArgNodes)
+		 * that are embedded in the generalized identifier
+		 */
+		private final Vector<ExprOrOpArgNode> argsVector = new Vector<>();
 
 		// The next three fields are null until the finalAppend
 		// method has been called
@@ -236,7 +239,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			return args;
 		}
 
-		public final Vector getArgsVector() {
+		public final Vector<ExprOrOpArgNode> getArgsVector() {
 			return argsVector;
 		}
 
@@ -284,7 +287,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			args = new ExprOrOpArgNode[argsVector.size()];
 
 			for (int i = 0; i < args.length; i++) {
-				args[i] = (ExprOrOpArgNode) argsVector.elementAt(i);
+				args[i] = argsVector.elementAt(i);
 			}
 		}
 
@@ -353,8 +356,8 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		/**********************************************************************
 		 * The fields modified by addSelector: *
 		 **********************************************************************/
-		private Vector opVec = new Vector(); // of SyntaxTreeNode ;
-		private Vector argVec = new Vector(); // of SyntaxTreeNode ;
+		private final Vector<SyntaxTreeNode> opVec = new Vector<>();
+		private final Vector<SyntaxTreeNode> argVec = new Vector<>();
 
 		/**********************************************************************
 		 * The fields set from opVec and argVec by finalize. *
@@ -397,8 +400,8 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			opsSTN = new SyntaxTreeNode[arrayLen];
 			args = new SyntaxTreeNode[arrayLen];
 			for (int i = 0; i < arrayLen; i++) {
-				args[i] = (SyntaxTreeNode) argVec.elementAt(i);
-				SyntaxTreeNode stn = (SyntaxTreeNode) opVec.elementAt(i);
+				args[i] = argVec.elementAt(i);
+				SyntaxTreeNode stn = opVec.elementAt(i);
 				opsSTN[i] = stn;
 				opNames[i] = stn.getUS();
 				switch (stn.getKind()) {
@@ -638,9 +641,9 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 * figuring out whether * this is actually a bug in selectorToNode. Instead, I
 		 * just kludged * something to handle that case. *
 		 ***********************************************************************/
-		Vector substInPrefix = new Vector(); // of SubstInNode
-		Vector params = new Vector(); // of FormalParamNode
-		Vector allArgs = new Vector(); // of ExprOrOpArgNode
+		final Vector<SemanticNode> substInPrefix = new Vector<>();
+		final Vector<FormalParamNode> params = new Vector<>();
+		final Vector<ExprOrOpArgNode> allArgs = new Vector<>();
 
 		/***********************************************************************
 		 * Local algorithm variables. *
@@ -674,7 +677,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 * algorithm's curContext * variable. *
 		 *********************************************************************/
 		int opDefArityFound = 0;
-		Vector opDefArgs = new Vector(); // of ExprOrOpArgNode objects
+		Vector<ExprOrOpArgNode> opDefArgs = new Vector<>();
 		boolean firstFindingOpName = true;
 		SymbolNode subExprOf = null;
 
@@ -716,7 +719,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 				// Following code changed on 23 Sep 2009 to fix bug, and corrected
 				// on 9 Nov 2009. See description in Subexpression.tla.
 				SymbolNode newSymbolNode = null;
-				Vector tempArgs = new Vector();
+				final Vector<TreeNode> tempArgs = new Vector<>();
 				// a vector of SyntaxTreeNode objects, one for each argument
 				// found for an undefined operator name in the following loop
 
@@ -895,7 +898,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 							 * curSymbolNode. *
 							 **********************************************************/
 							opDefArgs.addElement(generateExprOrOpArg(curSymbolNode, sel.opsSTN[idx],
-									i + opDefArityFound, (TreeNode) tempArgs.elementAt(i), cm));
+									i + opDefArityFound, tempArgs.elementAt(i), cm));
 						}
 						; // end for
 
@@ -979,7 +982,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 							}
 							; // for
 							opDefArityFound = 0;
-							opDefArgs = new Vector();
+							opDefArgs = new Vector<>();
 
 							/************************************************************
 							 * If newNode = null, then I think there's an error. It * should be caught
@@ -1672,7 +1675,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 ***********************************************************************/
 		ExprOrOpArgNode[] opDefArgArray = new ExprOrOpArgNode[opDefArgs.size()];
 		for (int i = 0; i < opDefArgs.size(); i++) {
-			opDefArgArray[i] = (ExprOrOpArgNode) opDefArgs.elementAt(i);
+			opDefArgArray[i] = opDefArgs.elementAt(i);
 		}
 		; // for
 
@@ -1954,7 +1957,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 ***********************************************************************/
 		FormalParamNode[] paramsArray = new FormalParamNode[params.size()];
 		for (int i = 0; i < params.size(); i++) {
-			paramsArray[i] = (FormalParamNode) params.elementAt(i);
+			paramsArray[i] = params.elementAt(i);
 		}
 		;
 
@@ -2027,7 +2030,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 ***********************************************************************/
 		ExprOrOpArgNode[] allArgsArray = new ExprOrOpArgNode[allArgs.size()];
 		for (int i = 0; i < allArgs.size(); i++) {
-			allArgsArray[i] = (ExprOrOpArgNode) allArgs.elementAt(i);
+			allArgsArray[i] = allArgs.elementAt(i);
 		}
 		;
 
@@ -2263,17 +2266,6 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		}
 
 		checkForUndefinedRecursiveOps(currentModule);
-
-		Vector vec = currentModule.recursiveOpDefNodes;
-		for (int i = 0; i < vec.size(); i++) {
-			OpDefNode node = (OpDefNode) vec.elementAt(i);
-// System.out.println("symbol " + node.getName() + ": recSect = " 
-//                    + node.recursiveSection + ", inRecSect = " 
-//                    + node.inRecursiveSection + ", letInLevel = "
-//                    + node.letInLevel);
-		}
-		;
-
 		moduleNestingLevel--;
 		return currentModule;
 
@@ -2283,7 +2275,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 	// the ModuleNode to support a getExtends() method that might reasonably
 	// be in the API.
 	private final void processExtendsList(TreeNode treeNodes[], ModuleNode cm) throws AbortException {
-		Vector extendeeVector = new Vector(2);
+		final Vector<ModuleNode> extendeeVector = new Vector<>(2);
 
 		if (treeNodes != null) {
 			// module names in the EXTENDS list are separated by commas; hence incr by 2
@@ -2438,7 +2430,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 	 * It creates an OpDef node and puts it * in ModuleNode cm's set of definitions.
 	 * *
 	 ************************************************************************/
-	private final void processOperator(TreeNode treeNode, Vector defs, ModuleNode cm) throws AbortException {
+	private final void processOperator(TreeNode treeNode, final Vector<SemanticNode> defs, ModuleNode cm) throws AbortException {
 		TreeNode syntaxTreeNode = treeNode;
 		UniqueString name = null;
 		int arity = 0;
@@ -2626,7 +2618,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		} // else
 
-		Hashtable ht = popLabelNodeSet();
+		final Hashtable<UniqueString, LabelNode> ht = popLabelNodeSet();
 		/*********************************************************************
 		 * Succeed or fail, we must execute popLabelNodeSet to match the * previous
 		 * pushLS. *
@@ -2646,7 +2638,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		// defs is non-null iff this definition is in the Let part of a
 		// Let-In expression
 		if (defs != null)
-			defs.addElement(symbolNode);
+			defs.addElement((OpDefNode)symbolNode);
 	} // processOperator
 
 	private final void processQuantBoundArgs(TreeNode[] treeNodeA, // node whose children include
@@ -2705,7 +2697,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 	}
 
 	// Process a function definition
-	private final void processFunction(TreeNode treeNode, Vector defs, ModuleNode cm) throws AbortException {
+	private final void processFunction(TreeNode treeNode, final Vector<SemanticNode> defs, ModuleNode cm) throws AbortException {
 		TreeNode syntaxTreeNode = treeNode;
 		boolean local = syntaxTreeNode.zero() != null;
 		TreeNode[] ss = syntaxTreeNode.one();
@@ -2859,7 +2851,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 * This isn't really necessary, since we're going to pop the * LS stack below,
 		 * but I hate to have a push without a pop. *
 		 *********************************************************************/
-		Hashtable ht = popLabelNodeSet();
+		final Hashtable<UniqueString, LabelNode> ht = popLabelNodeSet();
 		/*********************************************************************
 		 * The matching pop for the pushLS above. *
 		 *********************************************************************/
@@ -2894,8 +2886,8 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 	private final ExprNode processLetIn(TreeNode treeNode, TreeNode[] children, ModuleNode cm) throws AbortException {
 		TreeNode[] syntaxTreeNode = children[1].heirs(); // extract LetDefinitions
-		Vector defVec = new Vector(4);
-		Vector instVec = new Vector(1);
+		final Vector<SemanticNode> defVec = new Vector<>(4);
+		final Vector<InstanceNode> instVec = new Vector<>(1);
 
 		Context letCtxt = new Context(moduleTable);
 		symbolTable.pushContext(letCtxt);
@@ -2973,12 +2965,12 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 ***********************************************************************/
 		SymbolNode[] opDefs = new SymbolNode[defVec.size()];
 		for (int i = 0; i < opDefs.length; i++) {
-			opDefs[i] = (SymbolNode) defVec.elementAt(i);
+			opDefs[i] = (SymbolNode)defVec.elementAt(i);
 		}
 
 		InstanceNode[] insts = new InstanceNode[instVec.size()];
 		for (int i = 0; i < insts.length; i++) {
-			insts[i] = (InstanceNode) instVec.elementAt(i);
+			insts[i] = instVec.elementAt(i);
 		}
 		LetInNode letIn = new LetInNode(treeNode, opDefs, insts, body, letCtxt);
 		symbolTable.popContext();
@@ -4636,12 +4628,12 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		// Concatenate the list of args in the GenID object to the
 		// primary arg list just created
-		Vector genIDArgList = genID.getArgsVector();
+		final Vector<ExprOrOpArgNode> genIDArgList = genID.getArgsVector();
 		ExprOrOpArgNode[] finalArgList = new ExprOrOpArgNode[genIDArgList.size() + iarg];
 
 		// Copy the args from the prefix
 		for (int i = 0; i < genIDArgList.size(); i++) {
-			finalArgList[i] = (ExprOrOpArgNode) (genIDArgList.elementAt(i));
+			finalArgList[i] = genIDArgList.elementAt(i);
 		}
 		// Copy the primary args
 		for (int i = 0, j = genIDArgList.size(); i < iarg; i++, j++) {
@@ -4660,13 +4652,13 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 	/*************************************************************************
 	 * Note: the returned value does not seem to be used. *
 	 *************************************************************************/
-	private final OpDefNode processModuleDefinition(TreeNode treeNode, Vector defs,
+	private final OpDefNode processModuleDefinition(TreeNode treeNode, final Vector<SemanticNode> defs,
 			/*******************************************************
 			 * This is non-null when called from inside a LET, in * which case the OpDef
 			 * node is appended to defs. If * null, the OpDef node is appended to the *
 			 * module-level lists of such nodes. *
 			 *******************************************************/
-			Vector insts,
+			final Vector<InstanceNode> insts,
 			/*******************************************************
 			 * If non-null, then a vector of InstanceNode objects * to which the current
 			 * instance node is to be * appended. If null, cm.appendInstance is called to *
@@ -4782,13 +4774,13 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		/***********************************************************************
 		 * I have no idea why the module's getOpDefs method isn't used here. *
 		 ***********************************************************************/
-		Vector elts = instanceeCtxt.getByClass(OpDefNode.class);
+		final Vector<OpDefNode> elts = instanceeCtxt.getByClass(OpDefNode.class);
 
 		// For each definition in the instancee module, create a
 		// corresponding definition in the instancer module
 		for (int i = 0; i < elts.size(); i++) {
 			// Find the OpDefNode to be instantiated
-			OpDefNode odn = (OpDefNode) elts.elementAt(i);
+			OpDefNode odn = elts.elementAt(i);
 
 			/**********************************************************************
 			 * Ignore it if it is local or a builtin def. *
@@ -4867,13 +4859,13 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 **********************************************************************/
 		// Create a vector of all of the ThmOrAssumpDefNodes in the
 		// instancee module
-		Vector taelts = instanceeCtxt.getByClass(ThmOrAssumpDefNode.class);
+		final Vector<ThmOrAssumpDefNode> taelts = instanceeCtxt.getByClass(ThmOrAssumpDefNode.class);
 
 		// For each definition in the instancee module, create a
 		// corresponding definition in the instancer module
 		for (int i = 0; i < taelts.size(); i++) {
 			// Find the ThmOrAssumpDefNode to be instantiated
-			ThmOrAssumpDefNode taOdn = (ThmOrAssumpDefNode) taelts.elementAt(i);
+			ThmOrAssumpDefNode taOdn = taelts.elementAt(i);
 
 			/*********************************************************************
 			 * There are no builtin ThmOrAssumpDefNode objects. *
@@ -5158,7 +5150,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		// in the context of the module being instantiated (instancee).
 		// These are all the symbols that must have substitutions defined
 		// for them in the instantiation, either explicitly or implicitly.
-		Vector decls = instanceeCtxt.getByClass(OpDeclNode.class);
+		final Vector<OpDeclNode> decls = instanceeCtxt.getByClass(OpDeclNode.class);
 
 		// Create a SubstInNode to be used as a template for the SubstInNodes
 		// in the body of every newly instantiated OpDef in the module.
@@ -5309,7 +5301,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		// Create a vector of all of the OpDefNodes in the module being
 		// instantiated
-		Vector defs = instanceeCtxt.getByClass(OpDefNode.class);
+		final Vector<OpDefNode> defs = instanceeCtxt.getByClass(OpDefNode.class);
 
 		OpDefNode odn; // OpDefNode in module being instantiated (instancee)
 		OpDefNode newOdn; // Its counterpart current module (instancer)
@@ -5318,7 +5310,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		// Duplicate the OpDef records from the module being INSTANCE'd
 		for (int i = 0; i < defs.size(); i++) {
-			odn = (OpDefNode) defs.elementAt(i);
+			odn = defs.elementAt(i);
 			// OpDefNode in module being instantiated (instancee)
 
 			// Do not instantiate built-in or local operators, or those
@@ -5415,7 +5407,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 * code for doing this was copied and modified without * thinking from the code
 		 * above for OpDefNode objects *
 		 **********************************************************************/
-		Vector tadefs = instanceeCtxt.getByClass(ThmOrAssumpDefNode.class);
+		final Vector<ThmOrAssumpDefNode> tadefs = instanceeCtxt.getByClass(ThmOrAssumpDefNode.class);
 
 		ThmOrAssumpDefNode tadn;
 		// ThmOrAssumpDefNode in module being instantiated (instancee)
@@ -5426,7 +5418,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 
 		// Duplicate the OpDef records from the module being INSTANCE'd
 		for (int i = 0; i < tadefs.size(); i++) {
-			tadn = (ThmOrAssumpDefNode) tadefs.elementAt(i);
+			tadn = tadefs.elementAt(i);
 			// ThmOrAssumpDefNode in module being instantiated (instancee)
 
 			// Following statement added by LL on 30 Oct 2012 to handle locally
@@ -5698,7 +5690,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		}
 		;
 		LevelNode[] steps = new LevelNode[heirs.length - offset];
-		Vector iVec = new Vector();
+		final Vector<InstanceNode> iVec = new Vector<>();
 		/*********************************************************************
 		 * A vector to hold the InstanceNodes generated by steps of the form * Id ==
 		 * INSTANCE ... so they can be level checked. *
@@ -5871,7 +5863,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 				for (int j = defOffSet; j < defSTNs.length; j++) {
 					TreeNode defSTN = defSTNs[j];
 					;
-					Vector vec = new Vector();
+					final Vector<SemanticNode> vec = new Vector<>();
 					switch (defSTN.getKind()) {
 					/***************************************************************
 					 * Need to check if it's an operator, function, or module * definition. *
@@ -5887,7 +5879,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 						 * processModuleDefinition would add these definitions to to * the module's list
 						 * of top-level definitions.) *
 						 *************************************************************/
-						Vector defsVec = new Vector();
+						final Vector<SemanticNode> defsVec = new Vector<>();
 						vec.addElement(processModuleDefinition(defSTN, defsVec, iVec, cm));
 						break;
 					case N_OperatorDefinition:
@@ -5899,7 +5891,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 						break;
 					}
 					; // switch (def.getKind())
-					defs[j - defOffSet] = (OpDefNode) vec.elementAt(0);
+					defs[j - defOffSet] = (OpDefNode)vec.elementAt(0);
 				}
 				; // for j
 				pfNumNode = new DefStepNode(stepBodySTN, stepNum, defs);
@@ -6350,7 +6342,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		; // for i
 		InstanceNode[] insts = new InstanceNode[iVec.size()];
 		for (int i = 0; i < insts.length; i++) {
-			insts[i] = (InstanceNode) iVec.elementAt(i);
+			insts[i] = iVec.elementAt(i);
 		}
 		;
 
@@ -6461,7 +6453,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			errors.addError(ErrorCode.INTERNAL_ERROR, stn.getLocation(), "Empty BY, USE, or HIDE");
 			return new UseOrHideNode(kind, stn, new LevelNode[0], new SymbolNode[0], isOnly);
 		}
-		Vector vec = new Vector();
+		Vector<LevelNode> vec = new Vector<>();
 		/*********************************************************************
 		 * To hold the facts and then the defs. *
 		 *********************************************************************/
@@ -6528,7 +6520,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		; // while
 		LevelNode[] facts = new LevelNode[vec.size()];
 		for (int i = 0; i < vec.size(); i++) {
-			facts[i] = (LevelNode) vec.elementAt(i);
+			facts[i] = vec.elementAt(i);
 		}
 		;
 
@@ -6539,7 +6531,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		if (nextTok >= heirs.length) {
 			defs = new SymbolNode[0];
 		} else {
-			vec = new Vector();
+			vec = new Vector<LevelNode>();
 			nextTok++;
 			while (nextTok < heirs.length) {
 				if (heirs[nextTok].getKind() == TLAplusParserConstants.MODULE) {
@@ -6749,7 +6741,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			body = generateExpression(labelExpChildren[2], cm);
 		}
 		;
-		Hashtable ht = popLabelNodeSet();
+		final Hashtable<UniqueString, LabelNode> ht = popLabelNodeSet();
 
 		/***********************************************************************
 		 * We now create the LabelNode. *
@@ -6836,14 +6828,14 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		return retVal;
 	} // generateLabel
 
-	Vector LSlabels = new Vector();
 	/***********************************************************************
 	 * LSlabels.elementAt(i) is a HashTable that represents * LS.labels[i+1]. The
 	 * values in the Hashtable are LabelNode objects, * where ln.getName() is the
 	 * key of object ln. The empty set is * represented by null. *
 	 ***********************************************************************/
+	final Vector<Hashtable<UniqueString, LabelNode>> LSlabels = new Vector<>();
 
-	Vector LSparamSeq = new Vector();
+	final Vector<Vector<FormalParamNode[]>> LSparamSeq = new Vector<>();
 
 	/***********************************************************************
 	 * LsparamSeq.elementAt(i) is a Vector whose elements are of type *
@@ -6859,10 +6851,10 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 		 * it pushes an "empty" record onto the end of LS. *
 		 ***********************************************************************/
 		LSlabels.addElement(null);
-		LSparamSeq.addElement(new Vector());
+		LSparamSeq.addElement(new Vector<>());
 	}
 
-	Hashtable popLabelNodeSet() {
+	Hashtable<UniqueString, LabelNode> popLabelNodeSet() {
 		/***********************************************************************
 		 * Implements LS' = Front(LS) * return Last(LS).labels *
 		 ***********************************************************************/
@@ -6871,7 +6863,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			throw new WrongInvocationException("popLabelNodeSet called on empty stack.");
 		}
 		;
-		Hashtable retVal = (Hashtable) LSlabels.elementAt(size - 1);
+		final Hashtable<UniqueString, LabelNode> retVal = LSlabels.elementAt(size - 1);
 		LSlabels.removeElementAt(size - 1);
 		LSparamSeq.removeElementAt(size - 1);
 		return retVal;
@@ -6890,9 +6882,9 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			throw new WrongInvocationException("addLabelNodeToSet called on empty stack.");
 		}
 		;
-		Hashtable ht = (Hashtable) LSlabels.elementAt(size - 1);
+		Hashtable<UniqueString, LabelNode> ht = LSlabels.elementAt(size - 1);
 		if (ht == null) {
-			ht = new Hashtable();
+			ht = new Hashtable<>();
 			LSlabels.setElementAt(ht, size - 1);
 		}
 		boolean retVal = !ht.containsKey(ln.getName());
@@ -6914,7 +6906,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			return;
 		}
 		;
-		Vector lastFormalParams = (Vector) LSparamSeq.elementAt(LSparamSeq.size() - 1);
+		final Vector<FormalParamNode[]> lastFormalParams = LSparamSeq.elementAt(LSparamSeq.size() - 1);
 		lastFormalParams.addElement(odns);
 	}
 
@@ -6928,7 +6920,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			return;
 		}
 		;
-		Vector lastFormalParams = (Vector) LSparamSeq.elementAt(LSparamSeq.size() - 1);
+		final Vector<FormalParamNode[]> lastFormalParams = LSparamSeq.elementAt(LSparamSeq.size() - 1);
 		int size = lastFormalParams.size();
 		if (size == 0) {
 			throw new WrongInvocationException("popFormalParams called on empty stack.");
@@ -6959,10 +6951,10 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			}
 			;
 		} // for ;
-		Vector lastFormalParams = (Vector) LSparamSeq.elementAt(LSparamSeq.size() - 1);
+		final Vector<FormalParamNode[]> lastFormalParams = LSparamSeq.elementAt(LSparamSeq.size() - 1);
 		int size = lastFormalParams.size();
 		for (int i = 0; i < size; i++) {
-			FormalParamNode[] ops = (FormalParamNode[]) lastFormalParams.elementAt(i);
+			FormalParamNode[] ops = lastFormalParams.elementAt(i);
 			for (int j = 0; j < ops.length; j++) {
 				if (!opParams.remove(ops[j])) {
 					retVal = false;
@@ -7111,11 +7103,11 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 	 * A variable used in the Tarjan algorithm. *
 	 ***********************************************************************/
 
-	Vector nstack = new Vector(10);
 	/***********************************************************************
 	 * A vector of OpDefNode objects, representing the stack of the Tarjan *
 	 * algorithm. *
 	 ***********************************************************************/
+	final Vector<OpDefNode> nstack = new Vector<>(10);
 
 	int moduleNestingLevel = -1;
 
@@ -7291,7 +7283,7 @@ public class Generator implements ASTConstants, SyntaxTreeConstants, LevelConsta
 			 * at the current LET/IN level but not defined. *
 			 *********************************************************************/
 			for (int i = 0; i < cm.recursiveDecls.size(); i++) {
-				OpDefNode odn = (OpDefNode) cm.recursiveDecls.elementAt(i);
+				OpDefNode odn = cm.recursiveDecls.elementAt(i);
 				if ((odn.letInLevel == curLevel) && odn.inRecursive && (!odn.isDefined)) {
 					errors.addError(ErrorCode.RECURSIVE_OPERATOR_DECLARED_BUT_NOT_DEFINED,
 							odn.getTreeNode().getLocation(),

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LabelNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LabelNode.java
@@ -94,7 +94,7 @@ public class LabelNode extends ExprNode
     * beginning of OpDefOrLabelNode.java for an explanation.               *
     ***********************************************************************/
 
-  private Hashtable labels = null ;
+  private Hashtable<UniqueString, LabelNode> labels = null ;
     /***********************************************************************
     * This field is used to implement the OpDefOrLabel interface.  It is   *
     * a hashtable of OpDefNode objects representing labels within the      *
@@ -165,7 +165,7 @@ public class LabelNode extends ExprNode
   * There doesn't seem to be any easy way to write these methods only      *
   * once.                                                                  *
   *************************************************************************/
-  public void setLabels(Hashtable ht) {labels = ht; }
+  public void setLabels(Hashtable<UniqueString, LabelNode> ht) {labels = ht; }
     /***********************************************************************
     * Sets the set of labels.                                              *
     ***********************************************************************/
@@ -185,8 +185,8 @@ public class LabelNode extends ExprNode
     * as odn, then odn is added to the set and true is return; else the    *
     * set is unchanged and false is returned.                              *
     ***********************************************************************/
-    if (labels == null) {labels = new Hashtable(); } ;
-    if (labels.containsKey(odn)) {return false ;} ;
+    if (labels == null) {labels = new Hashtable<>(); } ;
+    if (labels.containsKey(odn.getName())) {return false ;} ;
     labels.put(odn.getName(), odn) ;
     return true;
    }
@@ -197,12 +197,12 @@ public class LabelNode extends ExprNode
     * `labels'.                                                            *
     ***********************************************************************/
     if (labels == null) {return new LabelNode[0];} ;
-    Vector v = new Vector() ;
-    Enumeration e = labels.elements() ;
+    final Vector<LabelNode> v = new Vector<>() ;
+    final Enumeration<LabelNode> e = labels.elements() ;
     while (e.hasMoreElements()) { v.addElement(e.nextElement()); } ;
     LabelNode[] retVal = new LabelNode[v.size()] ;
     for (int i = 0 ; i < v.size() ; i++)
-      {retVal[i] = (LabelNode) v.elementAt(i); } ;
+      {retVal[i] = v.elementAt(i); } ;
     return retVal ;
    }
 
@@ -316,9 +316,9 @@ public class LabelNode extends ExprNode
     ***********************************************************************/
     if (labels != null) {
        ret += "\n  Labels: " ;
-       Enumeration list = labels.keys() ;
+       Enumeration<UniqueString> list = labels.keys() ;
        while (list.hasMoreElements()) {
-          ret += ((UniqueString) list.nextElement()).toString() + "  " ;
+          ret += (list.nextElement()).toString() + "  " ;
          } ;
       }
     else {ret += "\n  Labels: null";} ;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/LetInNode.java
@@ -270,7 +270,7 @@ implements ExploreNode, LevelConstants {
     /***********************************************************************
     * Print context.                                                       *
     ***********************************************************************/
-    Vector contextEntries = context.getContextEntryStringVector(1,false, errors);
+    final Vector<String> contextEntries = context.getContextEntryStringVector(1,false, errors);
       /*********************************************************************
       * The depth argument 1 of getContextEntryStringVector causes only    *
       * the name and node uid of the entry and not the node itself to be   *
@@ -279,7 +279,7 @@ implements ExploreNode, LevelConstants {
     if (contextEntries != null) {
       for (int i = 0; i < contextEntries.size(); i++) {
         if (contextEntries.elementAt(i) != null) {
-          ret += Strings.indent(2, (String)contextEntries.elementAt(i));
+          ret += Strings.indent(2, contextEntries.elementAt(i));
         }
         else {
           ret += "*** null ***"; };

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ModuleNode.java
@@ -225,18 +225,18 @@ public class ModuleNode extends SymbolNode {
     * MCParser though.                                                     *
     ***********************************************************************/
 
-  Vector recursiveDecls = new Vector(8);
     /***********************************************************************
     * Contains the list of OpDefNode objects created by processing         *
     * RECURSIVE statements, in the order in which they were created.       *
     ***********************************************************************/
+  final Vector<OpDefNode> recursiveDecls = new Vector<>(8);
 
-  Vector<OpDefNode> opDefsInRecursiveSection = new Vector<>(16);
     /***********************************************************************
     * The list of all OpDefNode objects opd in this module, and in any     *
     * inner modules, with opd.recursiveSection >= 0.  (See the comments    *
     * for OpDefNode.recursiveSection to see what this field means.)        *
     ***********************************************************************/
+  final Vector<OpDefNode> opDefsInRecursiveSection = new Vector<>(16);
 
   int nestingLevel ;
     /***********************************************************************
@@ -307,28 +307,28 @@ public class ModuleNode extends SymbolNode {
   * uniquestr in ModuleNode mn, one calls                                  *
   * mn.getContext().getSymbol(uniquestr).                                  *
   *************************************************************************/
-  private Vector assumptionVec = new Vector();  // Vector of AssumeNodes
-  private Vector theoremVec    = new Vector();  // Vector of TheoremNodes
-  private Vector instanceVec   = new Vector();  // Vector of InstanceNodes
+  private final Vector<AssumeNode> assumptionVec = new Vector<>();
+  private final Vector<TheoremNode> theoremVec = new Vector<>();
+  private final Vector<InstanceNode> instanceVec = new Vector<>();
 
-  private Vector topLevelVec   = new Vector();
     /***********************************************************************
     * A vector containing all the entries in the preceding three vectors,  *
     * plus all top-level UseOrHideNode nodes, in the order in which they   *
     * appear in the module.                                                *
     ***********************************************************************/
+  private final Vector<SemanticNode> topLevelVec   = new Vector<>();
 
-  Vector recursiveOpDefNodes = new Vector();
-    /***********************************************************************
-    * A vector of all OpDefNodes for operators declared in RECURSIVE       *
-    * statements--even within LET expressions.                             *
-    ***********************************************************************/
-  
   /***********************************************************************
   * A vector of all records in the order in which they are defined       *
   * in the module.                             *
   ***********************************************************************/
-  private final Vector<OpApplNode> recordVec = new Vector<>();  // Vector of RecordNodes
+  private final Vector<OpApplNode> recordVec = new Vector<>();
+
+    /***********************************************************************
+    * A vector of all OpDefNodes for operators declared in RECURSIVE       *
+    * statements--even within LET expressions.                             *
+    ***********************************************************************/
+  final Vector<OpDefNode> recursiveOpDefNodes = new Vector<>();
 
   // Invoked only in Generator
   public ModuleNode(UniqueString us, Context ct, TreeNode stn) {
@@ -361,7 +361,7 @@ public class ModuleNode extends SymbolNode {
 	  return definitions;
   }
 
-  public final void createExtendeeArray(Vector<ModuleNode> extendeeVec) {
+  public final void createExtendeeArray(final Vector<ModuleNode> extendeeVec) {
     /***********************************************************************
     * This is called by Generator.processExtendsList to set the            *
     * ModuleNode's extendees field, which never seems to be used.          *
@@ -382,10 +382,10 @@ public class ModuleNode extends SymbolNode {
   public final OpDeclNode[] getConstantDecls() {
     if (constantDecls != null) return constantDecls;
 
-    Vector<SemanticNode> contextVec = ctxt.getConstantDecls();
+    final Vector<OpDeclNode> contextVec = ctxt.getConstantDecls();
     constantDecls = new OpDeclNode[contextVec.size()];
     for (int i = 0, j = constantDecls.length - 1; i < constantDecls.length; i++) {
-      constantDecls[j--] = (OpDeclNode)contextVec.elementAt(i);
+      constantDecls[j--] = contextVec.elementAt(i);
     }
     return constantDecls;
   }
@@ -398,10 +398,10 @@ public class ModuleNode extends SymbolNode {
    public final OpDeclNode[] getVariableDecls() {
     if (variableDecls != null) return variableDecls;
 
-    Vector<SemanticNode> contextVec = ctxt.getVariableDecls();
+    final Vector<OpDeclNode> contextVec = ctxt.getVariableDecls();
     variableDecls = new OpDeclNode[contextVec.size()];
     for (int i = 0, j = variableDecls.length - 1; i < variableDecls.length; i++) {
-      variableDecls[j--] = (OpDeclNode)contextVec.elementAt(i);
+      variableDecls[j--] = contextVec.elementAt(i);
     }
     return variableDecls;
   }
@@ -418,10 +418,10 @@ public class ModuleNode extends SymbolNode {
    */
   public final OpDefNode[] getOpDefs() {
     if (opDefs != null) return opDefs;
-    Vector contextVec = ctxt.getOpDefs();
+    final Vector<OpDefNode> contextVec = ctxt.getOpDefs();
     opDefs = new OpDefNode[contextVec.size()];
     for (int i = 0, j = opDefs.length - 1; i < opDefs.length; i++) {
-        opDefs[j--] = (OpDefNode)contextVec.elementAt(i);
+        opDefs[j--] = contextVec.elementAt(i);
     }
     return opDefs;
   }
@@ -442,11 +442,11 @@ public class ModuleNode extends SymbolNode {
   *************************************************************************/
   public final ThmOrAssumpDefNode[] getThmOrAssDefs() {
     if (thmOrAssDefs != null) return thmOrAssDefs;
-    Vector contextVec = ctxt.getThmOrAssDefs();
+    final Vector<ThmOrAssumpDefNode> contextVec = ctxt.getThmOrAssDefs();
     thmOrAssDefs = new ThmOrAssumpDefNode[contextVec.size()];
     for (int i = 0, j = thmOrAssDefs.length - 1;
                            i < thmOrAssDefs.length; i++) {
-        thmOrAssDefs[j--] = (ThmOrAssumpDefNode) contextVec.elementAt(i);
+        thmOrAssDefs[j--] = contextVec.elementAt(i);
     }
     return thmOrAssDefs;
   }
@@ -492,10 +492,10 @@ public class ModuleNode extends SymbolNode {
   public final ModuleNode[] getInnerModules() {
     if ( modDefs != null ) return modDefs;
 
-    Vector v = ctxt.getModDefs();
+    final Vector<ModuleNode> v = ctxt.getModDefs();
     modDefs = new ModuleNode[v.size()];
     for (int i = 0; i < modDefs.length; i++) {
-      modDefs[i] = (ModuleNode)v.elementAt(i);
+      modDefs[i] = v.elementAt(i);
     }
     return modDefs;
   }
@@ -855,8 +855,8 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
       * using recursiveAllParams.                                          *
       *********************************************************************/
       int maxRecursiveLevel = ConstantLevel ;
-      HashSet recursiveLevelParams = new HashSet() ;
-      HashSet recursiveAllParams = new HashSet() ;
+      HashSet<SymbolNode> recursiveLevelParams = new HashSet<>() ;
+      HashSet<SymbolNode> recursiveAllParams = new HashSet<>() ;
       for (int i = firstInSectIdx ; i < curNodeIdx ; i++) {
         curNode = opDefsInRecursiveSection.elementAt(i) ;
         if (curNode.inRecursive) {curNode.levelChecked = 0 ;} ;
@@ -993,9 +993,9 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
     for (int i = 0; i < opDefs.length; i++) {
       this.levelConstraints.putAll(opDefs[i].getLevelConstraints());
       this.argLevelConstraints.putAll(opDefs[i].getArgLevelConstraints());
-      Iterator iter = opDefs[i].getArgLevelParams().iterator();
+      Iterator<ArgLevelParam> iter = opDefs[i].getArgLevelParams().iterator();
       while (iter.hasNext()) {
-        ArgLevelParam alp = (ArgLevelParam)iter.next();
+        ArgLevelParam alp = iter.next();
         if (!alp.occur(opDefs[i].getParams())) {
           this.argLevelParams.add(alp);
         }
@@ -1189,9 +1189,9 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
                                  ? "none"
                                  : "" +errors.getNumErrors())));
 
-    Vector contextEntries = ctxt.getContextEntryStringVector(depth-1, b, errors);
+    final Vector<String> contextEntries = ctxt.getContextEntryStringVector(depth-1, b, errors);
     for (int i = 0; i < contextEntries.size(); i++) {
-      System.out.print(Strings.indent(2+indent, (String)contextEntries.elementAt(i)) );
+      System.out.print(Strings.indent(2+indent, contextEntries.elementAt(i)) );
     }
   }
 
@@ -1208,11 +1208,11 @@ final void addAssumption(TreeNode stn, ExprNode ass, SymbolTable st,
                               ? "none"
                               : "" + errors.getNumErrors()));
 
-    Vector contextEntries = ctxt.getContextEntryStringVector(depth-1,false, errors);
+    final Vector<String> contextEntries = ctxt.getContextEntryStringVector(depth-1,false, errors);
     if (contextEntries != null) {
       for (int i = 0; i < contextEntries.size(); i++) {
         if (contextEntries.elementAt(i) != null) {
-          ret += Strings.indent(2, (String)contextEntries.elementAt(i));
+          ret += Strings.indent(2, contextEntries.elementAt(i));
         }
         else {
           ret += "*** null ***";

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NonLeafProofNode.java
@@ -208,11 +208,11 @@ public class NonLeafProofNode extends ProofNode {
     * The following code for printing the context field copied without     *
     * understanding from ModuleNode.java.                                  *
     ***********************************************************************/
-    Vector contextEntries = context.getContextEntryStringVector(depth-1,false, errors);
+    final Vector<String> contextEntries = context.getContextEntryStringVector(depth-1,false, errors);
     if (contextEntries != null) {
       for (int i = 0; i < contextEntries.size(); i++) {
         if (contextEntries.elementAt(i) != null) {
-          ret += Strings.indent(2, (String)contextEntries.elementAt(i));
+          ret += Strings.indent(2, contextEntries.elementAt(i));
          }
         else { ret += "*** null ***"; } ;
          }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -390,7 +390,7 @@ public class OpDefNode extends OpDefOrDeclNode
     * the body that are not within the scope of an inner label or LET      *
     * definition.                                                          *
     ***********************************************************************/
-    private Hashtable labels = null ;
+    private Hashtable<UniqueString, LabelNode> labels = null ;
 
     private OpDefNode source = null ;
     
@@ -874,7 +874,7 @@ public class OpDefNode extends OpDefOrDeclNode
   * There doesn't seem to be any easy way to write these methods only      *
   * once.                                                                  *
   *************************************************************************/
-  public void setLabels(Hashtable ht) {labels = ht; }
+  public void setLabels(Hashtable<UniqueString, LabelNode> ht) {labels = ht; }
     /***********************************************************************
     * Sets the set of labels.                                              *
     ***********************************************************************/
@@ -885,7 +885,7 @@ public class OpDefNode extends OpDefOrDeclNode
     * then that LabelNode is returned; otherwise null is returned.         *
     ***********************************************************************/
     if (labels == null) {return null;} ;
-    return (LabelNode) labels.get(us) ;
+    return labels.get(us) ;
    }
 
   public boolean addLabel(LabelNode odn) {
@@ -894,8 +894,8 @@ public class OpDefNode extends OpDefOrDeclNode
     * as odn, then odn is added to the set and true is return; else the    *
     * set is unchanged and false is returned.                              *
     ***********************************************************************/
-    if (labels == null) {labels = new Hashtable(); } ;
-    if (labels.containsKey(odn)) {return false ;} ;
+    if (labels == null) {labels = new Hashtable<>(); } ;
+    if (labels.containsKey(odn.getName())) {return false ;} ;
     labels.put(odn.getName(), odn) ;
     return true;
    }
@@ -906,16 +906,16 @@ public class OpDefNode extends OpDefOrDeclNode
     * `labels'.                                                            *
     ***********************************************************************/
     if (labels == null) {return new LabelNode[0];} ;
-    Vector v = new Vector() ;
-    Enumeration e = labels.elements() ;
+    Vector<LabelNode> v = new Vector<>() ;
+    Enumeration<LabelNode> e = labels.elements() ;
     while (e.hasMoreElements()) { v.addElement(e.nextElement()); } ;
     LabelNode[] retVal = new LabelNode[v.size()] ;
     for (int i = 0 ; i < v.size() ; i++)
-      {retVal[i] = (LabelNode) v.elementAt(i); } ;
+      {retVal[i] = v.elementAt(i); } ;
     return retVal ;
    }
 
-  public Hashtable  getLabelsHT() {
+  public Hashtable<UniqueString, LabelNode> getLabelsHT() {
     /***********************************************************************
     * Return the labels field.  Used to "clone" an OpDefNode for module    *
     * instantiation.                                                       *
@@ -1100,7 +1100,7 @@ public class OpDefNode extends OpDefOrDeclNode
     }
 
     this.opLevelCond = new boolean[this.params.length][this.params.length][];
-    HashSet alpSet = this.body.getArgLevelParams();
+    final HashSet<ArgLevelParam> alpSet = this.body.getArgLevelParams();
     for (int i = 0; i < this.params.length; i++) {
       for (int j = 0; j < this.params.length; j++) {
         this.opLevelCond[i][j] = new boolean[this.params[i].getArity()];
@@ -1149,7 +1149,7 @@ public class OpDefNode extends OpDefOrDeclNode
     }
 
 //    this.argLevelParams = new HashSet();
-    Iterator iter = alpSet.iterator();
+    final Iterator<ArgLevelParam> iter = alpSet.iterator();
     while (iter.hasNext()) {
       ArgLevelParam alp = (ArgLevelParam)iter.next();
       if (!alp.op.occur(this.params) ||
@@ -1447,7 +1447,7 @@ public class OpDefNode extends OpDefOrDeclNode
     ***********************************************************************/
     if (labels != null) {
        ret += "\n  Labels: " ;
-       Enumeration list = labels.keys() ;
+       Enumeration<UniqueString> list = labels.keys() ;
        while (list.hasMoreElements()) {
           ret += ((UniqueString) list.nextElement()).toString() + "  " ;
          } ;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SubstInNode.java
@@ -99,7 +99,7 @@ public class SubstInNode extends ExprNode {
    * substitutions is to be produced.
    */
   public SubstInNode(TreeNode treeNode, SymbolTable instancerST,
-		     Vector<OpDeclNode> instanceeDecls, ModuleNode ingmn, ModuleNode edmn, Errors errors)
+		     final Vector<OpDeclNode> instanceeDecls, ModuleNode ingmn, ModuleNode edmn, Errors errors)
   throws AbortException {
     super(SubstInKind, treeNode);
     this.instantiatingModule = ingmn;
@@ -149,10 +149,10 @@ public class SubstInNode extends ExprNode {
    * OpApplNode or an OpArgNode substituted for each CONSTANT of
    * VARIABLE OpDeclNode in vector v.
    */
-  final void constructSubst(Vector<OpDeclNode> instanceeDecls, SymbolTable instancerST,
+  final void constructSubst(final Vector<OpDeclNode> instanceeDecls, SymbolTable instancerST,
 			    TreeNode treeNode, Errors errors)
   throws AbortException {
-    Vector<Subst> vtemp = new Vector<>();
+    final Vector<Subst> vtemp = new Vector<>();
 
     // for each CONSTANT or VARIABLE declared in module being
     // instantiated (the instancee)
@@ -204,7 +204,7 @@ public class SubstInNode extends ExprNode {
     // that are legally possible. Make an array out of them
     this.substs = new Subst[ vtemp.size() ];
     for (int i = 0; i < vtemp.size(); i++) {
-      this.substs[i] = (Subst)vtemp.elementAt(i);
+      this.substs[i] = vtemp.elementAt(i);
     }
   } // end constructSubst()
 
@@ -279,7 +279,7 @@ public class SubstInNode extends ExprNode {
    * then we have an error.
    * @param errors Log into which to emit errors.
    */
-  final void matchAll(Vector<OpDeclNode> decls, Errors errors) {
+  final void matchAll(final Vector<OpDeclNode> decls, Errors errors) {
     for (int i = 0; i < decls.size(); i++) {
       // Get the name of the i'th operator that must be substituted for
       UniqueString opName = decls.elementAt(i).getName();

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SymbolTable.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/SymbolTable.java
@@ -252,10 +252,10 @@ public class SymbolTable implements ASTConstants {
     String ret = "\n\n***SymbolTable\n\n*** top context";
 
     for (Context ct : contextStack) {
-      Vector v = ct.getContextEntryStringVector(1,true, errors);
+      final Vector<String> v = ct.getContextEntryStringVector(1,true, errors);
 
       for (int i = 0; i < v.size(); i++) {
-        ret += (String)v.elementAt(i);
+        ret += v.elementAt(i);
       }
       ret += "\n\n*** next context\n";
     }

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ThmOrAssumpDefNode.java
@@ -305,7 +305,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
     * then that LabelNode is returned; otherwise null is returned.         *
     ***********************************************************************/
     if (labels == null) {return null;} ;
-    return (LabelNode) labels.get(us) ;
+    return labels.get(us) ;
    }
 
   public boolean addLabel(LabelNode odn) {
@@ -326,8 +326,8 @@ public class ThmOrAssumpDefNode extends SymbolNode
     * `labels'.                                                            *
     ***********************************************************************/
     if (labels == null) {return new LabelNode[0];} ;
-    Vector<LabelNode> v = new Vector<>() ;
-    Enumeration<LabelNode> e = labels.elements() ;
+    final Vector<LabelNode> v = new Vector<>() ;
+    final Enumeration<LabelNode> e = labels.elements() ;
     while (e.hasMoreElements()) { v.addElement(e.nextElement()); } ;
     LabelNode[] retVal = new LabelNode[v.size()] ;
     for (int i = 0 ; i < v.size() ; i++)
@@ -625,7 +625,7 @@ public class ThmOrAssumpDefNode extends SymbolNode
     ***********************************************************************/
     if (labels != null) {
        ret += "\n  Labels: " ;
-       Enumeration<UniqueString> list = labels.keys() ;
+       final Enumeration<UniqueString> list = labels.keys() ;
        while (list.hasMoreElements()) {
           ret += list.nextElement().toString() + "  " ;
          } ;


### PR DESCRIPTION
Many usages of the internal SANY Vector class do not use a generic type parameter. This means there is a lot of unnecessary casting and confusion about what any given Vector instance contains. These changes add type parameters to all Vector usages, greatly improving code understandability. Unnecessary casts are also removed when found, and the `final` annotation was added to many uses.

While this is a large diff to review it is all checked by the type system so is safe.

[SANY][Refactor]