### PR TITLE
Remove CloudTLC from Toolbox.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
 		<!-- bundles -->
 		<module>toolbox/org.lamport.tla.toolbox.rss</module>
 		<module>toolbox/org.lamport.tla.toolbox</module>
-		<module>toolbox/org.lamport.tla.toolbox.jclouds</module>
 		<module>toolbox/org.lamport.tla.toolbox.jnlp</module>
 		<module>toolbox/org.lamport.tla.toolbox.doc</module>
 		<module>toolbox/org.lamport.tla.toolbox.editor.basic</module>
@@ -62,7 +61,6 @@
 		<module>toolbox/org.lamport.tla.toolbox.feature.base</module>
 		<module>toolbox/org.lamport.tla.toolbox.feature.editor</module>
 		<module>toolbox/org.lamport.tla.toolbox.feature.jnlp</module>
-		<module>toolbox/org.lamport.tla.toolbox.feature.jclouds</module>
 		<module>toolbox/org.lamport.tla.toolbox.feature.help</module>
 		<module>toolbox/org.lamport.tla.toolbox.feature.prover</module>
 		<module>toolbox/org.lamport.tla.toolbox.feature.tla2tex</module>

--- a/toolbox/org.lamport.tla.toolbox.feature.standalone/feature.xml
+++ b/toolbox/org.lamport.tla.toolbox.feature.standalone/feature.xml
@@ -95,14 +95,6 @@
          version="0.0.0"/>
 
    <includes
-         id="org.lamport.tla.toolbox.feature.jclouds"
-         version="0.0.0"/>
-
-   <includes
-         id="org.apache.jclouds.feature"
-         version="0.0.0"/>
-
-   <includes
          id="com.abstratt.eclipsegraphviz.feature"
          version="0.0.0"/>
 

--- a/toolbox/org.lamport.tla.toolbox.product.product/TLAToolbox.target
+++ b/toolbox/org.lamport.tla.toolbox.product.product/TLAToolbox.target
@@ -8,11 +8,11 @@
 <unit id="javax.activation" version="0.0.0"/>
 <unit id="javax.mail" version="0.0.0"/>
 <unit id="org.easymock" version="0.0.0"/>
-<repository id="eclipse-orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository/"/>
+<repository id="eclipse-orbit" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="0.0.0"/>
-<repository id="eclipse-orbit-newer" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
+<repository id="eclipse-orbit-newer" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532//repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.ide.feature.group" version="0.0.0"/>
@@ -20,10 +20,6 @@
 <unit id="org.eclipse.swtbot.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="0.0.0"/>
 <repository id="eclipse-swtbot" location="http://download.eclipse.org/technology/swtbot/releases/2.7.0/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.apache.jclouds.feature.feature.group" version="0.0.0"/>
-<repository id="github-jclouds" location="http://lemmster.de/jclouds2p2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.help.feature.group" version="0.0.0"/>

--- a/toolbox/org.lamport.tla.toolbox.product.product/org.lamport.tla.toolbox.product.product.product
+++ b/toolbox/org.lamport.tla.toolbox.product.product/org.lamport.tla.toolbox.product.product.product
@@ -79,11 +79,6 @@ openFile
    </features>
 
    <configurations>
-      <plugin id="aws-ec2" autoStart="true" startLevel="4" />
-      <plugin id="azurecompute-arm" autoStart="true" startLevel="4" />
-      <plugin id="com.jcraft.jsch" autoStart="true" startLevel="4" />
-      <plugin id="ec2" autoStart="true" startLevel="4" />
-      <plugin id="jclouds-core" autoStart="true" startLevel="4" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
@@ -92,9 +87,6 @@ openFile
       <plugin id="org.eclipse.equinox.http.registry" autoStart="true" startLevel="3" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
       <plugin id="org.eclipse.update.configurator" autoStart="false" startLevel="10" />
-      <plugin id="org.lamport.tla.toolbox.jclouds" autoStart="true" startLevel="4" />
-      <plugin id="packet" autoStart="true" startLevel="4" />
-      <plugin id="sts" autoStart="true" startLevel="4" />
       <property name="eclipse.buildId" value="1.8.0" />
    </configurations>
 


### PR DESCRIPTION
A dependency of CloudTLC is causing notarization to fail on macOS. Since CloudTLC is unlikely to still be in use by many users, it is removed from the Toolbox.

```
-> % xcrun notarytool log 22b35405-c20f-4fef-8952-7468376c632b --apple-id *** --team-id ***
{
  "logFormatVersion": 1,
  "jobId": "22b35405-c20f-4fef-8952-7468376c632b",
  "status": "Invalid",
  "statusSummary": "Archive contains critical validation errors",
  "statusCode": 4000,
  "archiveFilename": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip",
  "uploadDate": "2025-09-06T00:01:16.192Z",
  "sha256": "5007b1c25df54e6f04f2ba12e3d381158aa83bd5756b4d633fbb3066982afac4",
  "ticketContents": null,
  "issues": [
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.1.0.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The binary is not signed.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "i386"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.1.0.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The signature does not include a secure timestamp.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733",
      "architecture": "i386"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.1.0.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The binary is not signed.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "x86_64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.1.0.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The signature does not include a secure timestamp.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733",
      "architecture": "x86_64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.5.1.v20190425-1842.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The binary is not signed.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "i386"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.5.1.v20190425-1842.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The signature does not include a secure timestamp.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733",
      "architecture": "i386"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.5.1.v20190425-1842.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The binary is not signed.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721",
      "architecture": "x86_64"
    },
    {
      "severity": "error",
      "code": null,
      "path": "TLAToolbox-1.8.0-macosx.cocoa.x86_64.zip/TLA+ Toolbox.app/Contents/Eclipse/plugins/com.sun.jna_4.5.1.v20190425-1842.jar/com/sun/jna/darwin/libjnidispatch.jnilib",
      "message": "The signature does not include a secure timestamp.",
      "docUrl": "https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733",
      "architecture": "x86_64"
    }
  ]
```

[Bug][Build][Toolbox]