### PR TITLE
SANY: output everything to stdout by default

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -471,7 +471,7 @@ public class SANY {
 
     final SanyOutput out = new OutErrSanyOutput(
         ToolIO.out,
-        ToolIO.err,
+        Boolean.getBoolean(SANY.class.getName() + ".errors2stderr") ? ToolIO.err : ToolIO.out,
         LogLevel.INFO,
         LogLevel.ERROR
     );


### PR DESCRIPTION
Changes in PR #1209 split some SANY output between stderr and stdout. This was a breaking change to tools which parse SANY's command line output and might capture only one of stdout and stderr, like the VS Code extension. This changes SANY to only output to stdout by default. In the future, command line parameters can be added to better control SANY's output according to user preferences.

Changes are in response to https://github.com/tlaplus/vscode-tlaplus/issues/433