### PR TITLE
Add documentation on ASSUME and INVARIANT usage in TLA+.

### DIFF
--- a/docs/assumptions-and-invariants.md
+++ b/docs/assumptions-and-invariants.md
@@ -1,6 +1,28 @@
 # When to use ASSUME/ASSUMPTION and when to use INVARIANT/INVARIANTS with TLC?
 
-The `ASSUME` (or `ASSUMPTION`) construct in TLA+ is used to introduce constant-level (level 0) formulas—facts that must hold about the constants and fixed structures of a specification. These constraints are evaluated before TLC begins exploring behaviors and are not interpreted as properties of system states.
-A constant-level (level 0) formula contains no state variables, no primed variables, and no temporal operators. It expresses purely mathematical truths about constants, sets, or other static objects. Such formulas might assert, for example, that a constant N is a natural number or that a given set S is nonempty. These belong in ASSUME clauses within the module.
+The `ASSUME` (or `ASSUMPTION`) keyword in TLA+ is used to introduce constant-level (level 0) formulas—facts that must hold about the constants and fixed structures of a specification. These constraints are evaluated before TLC begins exploring behaviors and are not interpreted as invariants or properties of system states.
+A constant-level (level 0) formula contains no state variables, no primed variables, and no temporal operators. It expresses purely mathematical truths about constants, sets, or other static objects. Such formulas might assert, for example, that a constant N is a natural number or that a given set S is nonempty.
 
 In contrast, `INVARIANT` (or `INVARIANTS`) entries in a TLC configuration file refer to state-level (level 1) formulas—predicates about the values of state variables in a single state. Although these predicates must be true in every reachable state, they are not temporal formulas themselves; rather, TLC interprets them as safety checks. An invariant might state that a counter never becomes negative or that two variables always remain equal.
+
+```tla
+---- MODULE Example ----
+CONSTANT N
+
+ASSUME N \subseteq (Nat \ {0})
+
+VARIABLE x
+
+...
+
+Inv == x \in N
+====
+```
+
+```cfg
+...
+CONSTANT N = {1, 2, 3}
+INVARIANT Inv
+```
+
+Note that `ASSUME` is a keyword in TLA+, whereas `INVARIANT` is a keyword used in TLC configuration files. Furthermore, assumptions introduced with `ASSUME` are automatically checked by TLC, while a state predicate such as `Inv` is checked only if the configuration file explicitly instructs TLC to do so by including it under an `INVARIANT` entry.

--- a/docs/invariants-and-properties.md
+++ b/docs/invariants-and-properties.md
@@ -3,7 +3,7 @@
 The `INVARIANT` (or `INVARIANTS`) keyword in a TLC configuration file is used to specify a state-level (level 1) formula—a condition that must hold in all reachable states of the system. This is typically how safety properties are expressed—asserting that "something bad never happens." For instance, an invariant might state that a certain variable is always non-negative.
 A state-level (level 1) formula is a predicate about the values of state variables in a single state. It contains state variables but no primed variables and no temporal operators.
 
-However, the same condition can also be written as a temporal-level (level 3) formula using TLA+ syntax. In this case, assuming an invariant `I`, it would be written as `[]I` (read as "always I") in the TLA+ specification. Then, in the config file, instead of using `INVARIANT I`, you would use `PROPERTY []I`.
+However, the same condition can also be written as a temporal-level (level 3) formula using TLA+ syntax. In this case, assuming an invariant `I`, it would be written as `[]I` (read as "always I") in the TLA+ specification. Then, in the config file, instead of using `INVARIANT I`, you would use `PROPERTY I`.
 A temporal-level (level 3) formula contains temporal operators such as `[]` (always), `<>` (eventually), or the leads-to operator `~>`, and expresses properties about sequences of states.
 
 Important note: If you switch from `INVARIANT I` to `PROPERTY I` without updating the definition of `I` to include the temporal `[]` operator, the meaning changes drastically. Without the `[]`, TLC will only check that `I` holds in the initial states—not in all reachable states—potentially missing violations of the intended property.

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -321,6 +321,8 @@ public interface EC
     public static final int TLC_CANT_HANDLE_CONJUNCT = 2239;
     public static final int TLC_CANT_HANDLE_TOO_MANY_NEXT_STATE_RELS = 2240;
     public static final int TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED = 2241;
+    public static final int TLC_CONFIG_PROPERTY_ACTION_LEVEL = 2272;
+    public static final int TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE = 2273;
     public static final int TLC_CONFIG_OP_ARITY_INCONSISTENT = 2242;
     public static final int TLC_CONFIG_NO_STATE_TYPE = 2243;
     public static final int TLC_CANT_HANDLE_REAL_NUMBERS = 2244;
@@ -439,6 +441,8 @@ public interface EC
 	        case TLC_CANT_HANDLE_CONJUNCT:
 	        case TLC_CANT_HANDLE_TOO_MANY_NEXT_STATE_RELS:
 	        case TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED:
+	        case TLC_CONFIG_PROPERTY_ACTION_LEVEL:
+	        case TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE:
 	        case TLC_CONFIG_OP_ARITY_INCONSISTENT:
 	        case TLC_CONFIG_NO_STATE_TYPE:
 	        case TLC_CANT_HANDLE_REAL_NUMBERS: // might also be in the spec

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -1297,6 +1297,31 @@ public class MP
                     + "\nbut TLC can only handle behaviors of length up to 65535 states. The last\n"
                     + "state in the behavior is:\n%1%");
         	break;
+        case EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE:
+            b.append("The formula %1% is an action-level formula (i.e., it contains no temporal operators), "
+            		+ "but it was used as a PROPERTY, where a temporal formula is normally required. "
+            		+ "Interpreting an action-level formula as a PROPERTY amounts to asserting that it holds "
+            		+ "only for the first step (i.e., the initial action) of every behavior, which is typically "
+            		+ "not what is intended. For this reason, TLC does not support checking action-level "
+            		+ "formulas as properties.\n"
+            		+ "If your intention is to check that the action formula %1% holds on every step of every "
+            		+ "behavior, you should wrap it with the \"always\" operator (□), which asserts that %1% holds "
+            		+ "in all steps of all behaviors. Additionally, the formula %1% is stuttering sensitive, which "
+            		+ "TLA does not allow. To make it stuttering insensitive, you must wrap it in [%1%]_v, where "
+            		+ "v is an appropriate state-level predicate. Thus, the property should likely be written as "
+            		+"□[%1%]_v.");
+            break;
+        case EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL:
+            b.append("The formula %1% is an action-level formula (i.e., it contains no temporal operators), "
+            		+ "but it was used as a PROPERTY, where a temporal formula is normally required. "
+            		+ "Interpreting an action-level formula as a PROPERTY amounts to asserting that it holds "
+            		+ "only for the first step (i.e., the initial action) of every behavior, which is typically "
+            		+ "not what is intended. For this reason, TLC does not support checking action-level "
+            		+ "formulas as properties.\n"
+            		+ "If your intention is to check that the action formula %1% holds on every step of every "
+            		+ "behavior, you should wrap it with the \"always\" operator (□), which asserts that %1% holds "
+            		+ "in all steps of all behaviors.");
+            break;
         case EC.TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED:
             b.append("The property %1% is not correctly defined.");
             break;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -1691,8 +1691,23 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
         {
             this.impliedTemporalVec.addElement(new Action(Specs.addSubsts(pred, subs), c));
             this.impliedTemporalNameVec.addElement(name);
+        } else if (level == 2)
+        {
+			if (pred instanceof OpApplNode
+					&& BuiltInOPs.getOpCode(((OpApplNode) pred).getOperator().getName()) == OPCODE_sa) {
+        		// [A]_v is a stuttering insensitive action.
+        		Assert.fail(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL, name);
+        	} else {
+				// Arbitrary action-level formulas are stuttering sensitive. Although some
+				// action-level formulas such as (A \/ UNCHANGED vars) or (x' \in {x, x + 1})
+				// are stuttering insensitive, TLA requires user to write such formulas in terms
+				// of [A]_v. Thus, we issue an error message here saying that action-level
+				// properties are a) not supported, and b) should be stuttering insensitive.
+        		Assert.fail(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE, name);
+        	}
         } else
         {
+        	// There is no other level beyond 0..3, but let's keep this branch to be on the safe side.
             Assert.fail(EC.TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED, name);
         }
     }

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelProp.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelProp.tla
@@ -1,0 +1,38 @@
+---- MODULE ActionLevelProp ----
+EXTENDS Naturals
+
+VARIABLE x
+vars == x
+
+Init ==
+    x = 0
+
+Next ==
+    /\ x < 5
+    /\ x' = x + 1
+
+Spec ==
+    Init /\ [][Next]_vars
+
+------
+
+ActionLivePropA ==
+    x' > x
+
+ActionLivePropB ==
+	Next
+
+ActionLivePropC ==
+    Next \/ UNCHANGED vars \* stuttering insensitive; This is [Next]_vars
+
+ActionLivePropD ==
+    [Next]_vars
+
+ActionLivePropE ==
+    <<Next>>_vars
+
+=============================================================================
+The following formulas are state level and, thus, out of scope.
+    ENABLED Next
+    ENABLED [Next]_vars
+    ENABLED <<Next>>_vars

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropA.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropA.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropA

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropB.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropB.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropB

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropC.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropC.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropC

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropD.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropD.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropD

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropE.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropE.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropE

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropATest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropATest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropATest extends ModelCheckerTestCase {
+
+	public ActionLevelPropATest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropA.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropBTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropBTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropBTest extends ModelCheckerTestCase {
+
+	public ActionLevelPropBTest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropB.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropCTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropCTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropCTest extends ModelCheckerTestCase {
+
+	public ActionLevelPropCTest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropC.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropDTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropDTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropDTest extends ModelCheckerTestCase {
+
+	public ActionLevelPropDTest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropD.cfg" }, ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		// State-level property with no fairness should trigger warning
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropETest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropETest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropETest extends ModelCheckerTestCase {
+
+	public ActionLevelPropETest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropE.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}


### PR DESCRIPTION
Created a new document outlining the differences between the `ASSUME` and `INVARIANT` constructs in TLA+. This includes explanations of constant-level and state-level formulas, along with examples of their usage. Additionally, reference this new documentation at explain.tlapl.us for better user guidance on constant-level formulas.

[Feature][TLC]