### PR TITLE
Restrict macOS signing to trusted PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -112,19 +112,20 @@ jobs:
       ## Sign Toolbox macOS zip file.
       ##
     - name: Set up Apple Certs
-      if: matrix.operating-system == 'macos-latest'
+      # Forked PRs do not have access to macOS signing secrets.
+      if: matrix.operating-system == 'macos-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       run: 'echo "$APPLE_CODESIGN_CERTS" > certs.pem'
       shell: bash
       env:
         APPLE_CODESIGN_CERTS: ${{ secrets.APPLE_CODESIGN_CERTS }}
     - name: Set up Apple Key (dev)
-      if: matrix.operating-system == 'macos-latest'
+      if: matrix.operating-system == 'macos-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       run: 'echo "$APPLE_CODESIGN_DEVELOPER_PRIVKEY" > dev.pem'
       shell: bash
       env:
         APPLE_CODESIGN_DEVELOPER_PRIVKEY: ${{ secrets.APPLE_CODESIGN_DEVELOPER_PRIVKEY }}
     - name: Create macOS keychain, unzip, sign, and zip up TLA+ Toolbox for macOS
-      if: matrix.operating-system == 'macos-latest'
+      if: matrix.operating-system == 'macos-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       run: |
            ## Convert pems stored as Github secrets to .p12 files that 'security import' accepts.
            openssl pkcs12 -export -inkey dev.pem -in certs.pem -out dev.p12 -passin pass:${{ secrets.APPLE_CERT_PASSWORD }} -passout pass:${{ secrets.APPLE_CERT_PASSWORD }}
@@ -240,4 +241,3 @@ jobs:
           --examples_root "$EXAMPLES_DIR"                                 \
           --enable_assertions                                             \
           --skip "specifications/KnuthYao/SimKnuthYao.cfg"
-


### PR DESCRIPTION
**Purpose**: Gate the macOS signing steps in `pr.yml` so they only run on trusted sources (non-fork PRs or branches in the main repo).

## Rationale
Forked PRs don’t have access to the Apple signing secrets, so the macOS signing job fails and wastes CI time. This change prevents the signing steps from running when secrets aren’t available. Signing will remain unchanged for trusted PRs.

## Notes
- No other workflow behavior is affected; only the macOS signing steps are guarded.