### PR TITLE
Improve error messages when action-level formulas are used as PROPERTY.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -321,6 +321,9 @@ public interface EC
     public static final int TLC_CANT_HANDLE_CONJUNCT = 2239;
     public static final int TLC_CANT_HANDLE_TOO_MANY_NEXT_STATE_RELS = 2240;
     public static final int TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED = 2241;
+    public static final int TLC_CONFIG_PROPERTY_ACTION_LEVEL = 2272;
+    public static final int TLC_CONFIG_PROPERTY_ACTION_LEVEL_SQUARE_A_SUB_V = 2273;
+    public static final int TLC_CONFIG_PROPERTY_ACTION_LEVEL_ANGLE_A_SUB_V = 2274;
     public static final int TLC_CONFIG_OP_ARITY_INCONSISTENT = 2242;
     public static final int TLC_CONFIG_NO_STATE_TYPE = 2243;
     public static final int TLC_CANT_HANDLE_REAL_NUMBERS = 2244;
@@ -439,6 +442,9 @@ public interface EC
 	        case TLC_CANT_HANDLE_CONJUNCT:
 	        case TLC_CANT_HANDLE_TOO_MANY_NEXT_STATE_RELS:
 	        case TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED:
+	        case TLC_CONFIG_PROPERTY_ACTION_LEVEL:
+	        case TLC_CONFIG_PROPERTY_ACTION_LEVEL_SQUARE_A_SUB_V:
+	        case TLC_CONFIG_PROPERTY_ACTION_LEVEL_ANGLE_A_SUB_V:
 	        case TLC_CONFIG_OP_ARITY_INCONSISTENT:
 	        case TLC_CONFIG_NO_STATE_TYPE:
 	        case TLC_CANT_HANDLE_REAL_NUMBERS: // might also be in the spec

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -1297,6 +1297,28 @@ public class MP
                     + "\nbut TLC can only handle behaviors of length up to 65535 states. The last\n"
                     + "state in the behavior is:\n%1%");
         	break;
+        case EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_SQUARE_A_SUB_V:
+            b.append("The formula %1% at %2% is an action-level formula (i.e., it contains no temporal operators). "
+            		+ "Only temporal-level (or state-level) formulas are allowed under PROPERTY or PROPERTIES. "
+            		+ "To check that action %1% holds in *every* step of the behavior, define a temporal property "
+            		+ "by applying the \"always\" temporal operator ([]) to the formula at %2% (compare page 90 of "
+            		+ "Specifying Systems at https://lamport.azurewebsites.net/tla/book.html).");
+            break;
+        case EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_ANGLE_A_SUB_V:
+            b.append("The formula %1% at %2% is an action-level formula (i.e., it contains no temporal operators). "
+            		+ "Only temporal-level (or state-level) formulas are allowed under PROPERTY or PROPERTIES. "
+            		+ "To check that infinitely many %1% steps occur, define a temporal property by applying "
+            		+ "the \"always eventually\" temporal operator combination ([]<>) to the formula at "
+            		+ "%2% (compare page 91 of Specifying Systems at https://lamport.azurewebsites.net/tla/book.html).");
+            break;
+        case EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL:
+            b.append("The formula %1% at %2% is an action-level formula (i.e., it contains no temporal operators). "
+            		+ "Only temporal-level (or state-level) formulas are allowed under PROPERTY or PROPERTIES. "
+            		+ "To check that action %1% holds in *every* step of the behavior, define a temporal property: "
+            		+ "Let A be the formula at %2%; rewrite A as [][A]_v, where v is a state function (typically "
+            		+ "the tuple of variables) (compare page 90 of Specifying Systems at "
+            		+ "https://lamport.azurewebsites.net/tla/book.html).");
+            break;
         case EC.TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED:
             b.append("The property %1% is not correctly defined.");
             break;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -1691,8 +1691,25 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
         {
             this.impliedTemporalVec.addElement(new Action(Specs.addSubsts(pred, subs), c));
             this.impliedTemporalNameVec.addElement(name);
+        } else if (level == 2)
+        {
+			if (pred instanceof OpApplNode
+					&& BuiltInOPs.getOpCode(((OpApplNode) pred).getOperator().getName()) == OPCODE_sa) {
+				// PROPERTY A where formula A == [ ... ]_v 
+				Assert.fail(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_SQUARE_A_SUB_V,
+						new String[] { name, pred.getLocation().toString() });
+			} else if (pred instanceof OpApplNode
+					&& BuiltInOPs.getOpCode(((OpApplNode) pred).getOperator().getName()) == OPCODE_aa) {
+				// PROPERTY A where formula A == << ... >>_v 
+				Assert.fail(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_ANGLE_A_SUB_V,
+						new String[] { name, pred.getLocation().toString() });				
+			} else {
+				Assert.fail(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL,
+						new String[] { name, pred.getLocation().toString() });
+        	}
         } else
         {
+        	// There is no other level beyond 0..3, but let's keep this branch to be on the safe side.
             Assert.fail(EC.TLC_CONFIG_PROPERTY_NOT_CORRECTLY_DEFINED, name);
         }
     }

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelProp.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelProp.tla
@@ -1,0 +1,38 @@
+---- MODULE ActionLevelProp ----
+EXTENDS Naturals
+
+VARIABLE x
+vars == x
+
+Init ==
+    x = 0
+
+Next ==
+    /\ x < 5
+    /\ x' = x + 1
+
+Spec ==
+    Init /\ [][Next]_vars
+
+------
+
+ActionLivePropA ==
+    x' > x
+
+ActionLivePropB ==
+	Next
+
+ActionLivePropC ==
+    Next \/ UNCHANGED vars
+
+ActionLivePropD ==
+    [Next]_vars
+
+ActionLivePropE ==
+    <<Next>>_vars
+
+=============================================================================
+The following formulas are state level and, thus, out of scope.
+    ENABLED Next
+    ENABLED [Next]_vars
+    ENABLED <<Next>>_vars

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropA.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropA.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropA

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropB.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropB.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropB

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropC.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropC.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropC

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropD.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropD.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropD

--- a/tlatools/org.lamport.tlatools/test-model/ActionLevelPropE.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/ActionLevelPropE.cfg
@@ -1,0 +1,2 @@
+SPECIFICATION Spec
+PROPERTY ActionLivePropE

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropATest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropATest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropATest extends ModelCheckerTestCase {
+
+	public ActionLevelPropATest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropA.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropBTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropBTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropBTest extends ModelCheckerTestCase {
+
+	public ActionLevelPropBTest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropB.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropCTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropCTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropCTest extends ModelCheckerTestCase {
+
+	public ActionLevelPropCTest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropC.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropDTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropDTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropDTest extends ModelCheckerTestCase {
+
+	public ActionLevelPropDTest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropD.cfg" }, ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_SQUARE_A_SUB_V));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropETest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ActionLevelPropETest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ActionLevelPropETest extends ModelCheckerTestCase {
+
+	public ActionLevelPropETest() {
+		super("ActionLevelProp", new String[] { "-config", "ActionLevelPropE.cfg" },
+				ExitStatus.ERROR_CONFIG_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recorded(EC.TLC_CONFIG_PROPERTY_ACTION_LEVEL_ANGLE_A_SUB_V));
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false; // No coverage for this test.
+	}
+}


### PR DESCRIPTION
TLC has always prevented action-level formulas from being used as temporal properties in the configuration file. This commit significantly improves the error messages to better explain why such usage is incorrect and how to fix it.

Introduced two new error codes (TLC_CONFIG_PROPERTY_ACTION_LEVEL and TLC_CONFIG_PROPERTY_ACTION_LEVEL_AND_STUTTERING_SENSITIVE) with detailed explanations. The messages clarify that using an action-level formula as a PROPERTY would only check it on the initial action, which is typically not the intended behavior. They guide users to wrap action formulas with the □ (always) operator and, when necessary, make them stuttering insensitive using the [A]_v notation.

Added comprehensive test cases covering various action-level formula scenarios, including stuttering-sensitive and stuttering-insensitive cases.

[Feature][TLC]