### PR TITLE
Add ARM64 (aarch64) build targets for macOS and Linux

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,11 +266,25 @@
 							<arch>x86_64</arch>
 						</environment>
 
-						<!-- Mac -->
+						<!-- Mac x86_64 -->
 						<environment>
 							<os>macosx</os>
 							<ws>cocoa</ws>
 							<arch>x86_64</arch>
+						</environment>
+
+						<!-- Mac ARM64 (Apple Silicon) -->
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>aarch64</arch>
+						</environment>
+
+						<!-- Linux ARM64 -->
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>aarch64</arch>
 						</environment>
 
 					</environments>


### PR DESCRIPTION
## Summary
Add ARM64 architecture support for macOS (Apple Silicon) and Linux platforms.

## Changes
- Add `macosx/cocoa/aarch64` environment for Apple Silicon Macs
- Add `linux/gtk/aarch64` environment for ARM64 Linux

## Motivation
- Apple Silicon Macs are increasingly common
- Current Homebrew cask requires Rosetta 2 emulation
- ARM64 Linux servers/devices are growing in popularity

## Testing
Successfully built and tested on Apple Silicon Mac (M-series) using the existing build system.
All existing x86_64 platforms remain unchanged.

## Notes
This PR only adds build targets to `pom.xml`. The existing JustJ JRE configuration automatically resolves platform-specific JREs based on target environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)