### PR TITLE
Show state trace in debugger call stack for BFS mode

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/Debug03Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/Debug03Test.java
@@ -47,8 +47,9 @@ public class Debug03Test extends TLCDebuggerTestCase {
 		debugger.setSpecBreakpoint();
 
 		StackFrame[] stackFrames = debugger.continue_();
-		assertEquals(1, stackFrames.length);
+		assertEquals(2, stackFrames.length);
 		assertTLCNextStatesFrame(stackFrames[0], 14, 16, 14, 19, RM, Context.Empty, 9);
+		assertTLCSyntheticStateStackFrame(stackFrames[1], 7, 5, 7, 14, RM, Context.Empty, 1);
 		
 		// Remove all breakpoints and run the spec to completion.
 		debugger.unsetBreakpoints();

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD840DebuggerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD840DebuggerTest.java
@@ -91,6 +91,7 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 			stackFrames = debugger.continue_();
 
 			assertEquals(6, stackFrames.length);
+			assertTLCInitStatesFrame(stackFrames[5], 20, 3, 23, 21, RM, Context.Empty, -1);
 			assertTLCStateFrame(stackFrames[4], 20, 23, RM, vars);
 			assertTLCStateFrame(stackFrames[3], 20, 20, RM, vars);
 			assertTLCStateFrame(stackFrames[2], 21, 21, RM, vars[0], vars[2], vars[3]);
@@ -103,25 +104,25 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 		stackFrames = debugger.continue_();
 
 		// First frame captures the complete action.
-		assertEquals(2, stackFrames.length);
+		assertEquals(3, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 26, 31, RM, vars);
 
 		// Second frame captures the first line.
 		stackFrames = debugger.stepIn();
-		assertEquals(3, stackFrames.length);
+		assertEquals(4, stackFrames.length);
 		assertTLCActionFrame(stackFrames[1], 26, 31, RM, vars);
 		assertTLCActionFrame(stackFrames[0], 26, 26, RM, vars);
 
 		// Third frame.
 		stackFrames = debugger.stepIn();
-		assertEquals(4, stackFrames.length);
+		assertEquals(5, stackFrames.length);
 		assertTLCActionFrame(stackFrames[2], 26, 31, RM, vars);
 		assertTLCActionFrame(stackFrames[1], 26, 26, RM, vars);
 		assertTLCActionFrame(stackFrames[0], 26, 26, RM, vars);
 
 		// Fourth frame.
 		stackFrames = debugger.stepIn(2);
-		assertEquals(4, stackFrames.length);
+		assertEquals(5, stackFrames.length);
 		assertTLCActionFrame(stackFrames[2], 26, 31, RM, vars);
 		assertTLCActionFrame(stackFrames[1], 26, 26, RM, vars);
 		assertTLCActionFrame(stackFrames[0], 27, 27, RM, vars);
@@ -129,7 +130,7 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 		// Debug the SendMsg action of the next-state relation.
 		debugger.replaceAllBreakpointsWith(RM, 46);
 		stackFrames = debugger.continue_();
-		assertEquals(5, stackFrames.length);
+		assertEquals(6, stackFrames.length);
 		Context context = Context.Empty.cons(null, IntValue.ValOne).cons(null, IntValue.ValOne);
 		/*
 		  /\ active[i]
@@ -160,7 +161,7 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
         		/\ active' = [active EXCEPT ![j] = TRUE]
 		 */
 		stackFrames = debugger.stepIn();
-		assertEquals(6, stackFrames.length);
+		assertEquals(7, stackFrames.length);
 		context = Context.Empty.cons(null, IntValue.ValOne).cons(null, IntValue.ValOne);
 		assertTLCActionFrame(stackFrames[4], 44, 48, RM, context, vars);
 		assertTLCActionFrame(stackFrames[3], 44, 44, RM, context, vars);
@@ -175,20 +176,20 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 				takes precedence.
 		 */
 		stackFrames = debugger.stepIn();
-		assertEquals(7, stackFrames.length);
+		assertEquals(8, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 46, 46, RM, context, vars);
 		/*
 		        /\ color' = [color EXCEPT ![i] = IF j>i THEN "black" ELSE @]
 		 */
 		stackFrames = debugger.stepIn(5);
-		assertEquals(8, stackFrames.length);
+		assertEquals(9, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 47, 47, RM, context, vars[0], vars[2], vars[3]);
 
 		/*
   				/\ UNCHANGED <<tpos, tcolor>>
 		 */
 		stackFrames = debugger.stepIn(8);
-		assertEquals(8, stackFrames.length);
+		assertEquals(9, stackFrames.length);
 		context = Context.Empty.cons(null, IntValue.ValOne).cons(null, IntValue.ValOne);
 		assertTLCActionFrame(stackFrames[0], 48, 48, RM, context, vars[0], vars[2]);
 		
@@ -196,7 +197,7 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 		debugger.replaceAllBreakpointsWith(MDL, 16);
 		stackFrames = debugger.continue_();
 		stackFrames = debugger.stepIn(13);
-		assertEquals(11, stackFrames.length);
+		assertEquals(12, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 16, 54, 16, 64, MDL, Context.Empty.cons(null, IntValue.ValZero));
 		Variable[] contextVariables = ((TLCStateStackFrame) stackFrames[0]).getVariables();
 		assertNotNull(contextVariables);
@@ -209,19 +210,19 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 		// 8888888888888888888 Action Constraint 8888888888888888888 //
 		debugger.replaceAllBreakpointsWith(MDL, 19);
 		stackFrames = debugger.continue_();
-		assertEquals(9, stackFrames.length);
+		assertEquals(10, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 19, 21, MDL);
 		
 		// 8888888888888888888 Invariant Inv 8888888888888888888 //
 		debugger.replaceAllBreakpointsWith(RM, 94);
 		stackFrames = debugger.continue_();
-		assertEquals(10, stackFrames.length);
+		assertEquals(11, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 94, 3, 96, 26, RM, Context.Empty);
 
 		debugger.unsetBreakpoints();
 		debugger.setSpecBreakpoint();
 		stackFrames = debugger.continue_();
-		assertEquals(1, stackFrames.length);
+		assertEquals(2, stackFrames.length);
 		assertTLCNextStatesFrame(stackFrames[0], 68, 20, 68, 23, RM, Context.Empty, 3);
 
 		// 8888888888888888888 ALIAS Alias 8888888888888888888 //
@@ -234,9 +235,11 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 		// (s4, s5), (s5, s6).  For s6, the alias expression is then evaluated on the
 		// pair (s6, s6).  This is done after the for loop.
 		debugger.replaceAllBreakpointsWith(MDL, 33);
-		for (int i = 0; i < 5; i++) {
-			stackFrames = debugger.continue_();
-			assertEquals(7, stackFrames.length);
+		for (int i = 0; i < 4; i++) {
+			// Continuing from the initial state introduces an extra stack frame.
+			// The root cause is unclear, but the behavior is acceptable for now.
+			stackFrames = debugger.continue_(i == 0 ? 2 : 1);
+			assertEquals(8 + i, stackFrames.length);
 			// null context to ignore TLCExt!Trace in context added via Tool#evalAlias.
 			assertTLCActionFrame(stackFrames[0], 33, 20, 33, 49, MDL, (Context) null);
 			assertTLCActionFrame(stackFrames[1], 28, 5, 34, 5, MDL, (Context) null);
@@ -246,7 +249,7 @@ public class EWD840DebuggerTest extends TLCDebuggerTestCase {
 			assertTLCActionFrame(stackFrames[5], 51, 3, 53, 38, RM, context, vars);
 		}
 		stackFrames = debugger.continue_();
-		assertEquals(7, stackFrames.length);
+		assertEquals(11, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 33, 20, 33, 49, MDL, (Context) null);
 		assertTLCActionFrame(stackFrames[1], 28, 5, 34, 5, MDL, (Context) null);
 		assertTLCActionFrame(stackFrames[2], 53, 6, 53, 38, RM, context, vars[0], vars[2], vars[3]);

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD840ErrorActionDebuggerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD840ErrorActionDebuggerTest.java
@@ -56,7 +56,7 @@ public class EWD840ErrorActionDebuggerTest extends TLCDebuggerTestCase {
 		debugger.unsetBreakpoints();
 		stackFrames = debugger.continue_();
 		// Error occurs after TLC generated the first initial state.
-		int i = 16;
+		int i = 17;
 		assertEquals(i, stackFrames.length);
 		for (int j = i - 1; j > 0 ; j--) {
 			assertNull(((TLCStackFrame) stackFrames[j]).exception);

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD840ErrorDebuggerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD840ErrorDebuggerTest.java
@@ -59,8 +59,9 @@ public class EWD840ErrorDebuggerTest extends TLCDebuggerTestCase {
 		debugger.unsetBreakpoints();
 		stackFrames = debugger.continue_();
 		// Error occurs after TLC generated the first initial state.
-		int i = 8;
+		int i = 9;
 		assertEquals(i, stackFrames.length);
+		i--;
 		assertTLCFrame(stackFrames[--i], 20, 3, 23, 21, RM);
 		assertTLCStateFrame(stackFrames[--i], 20, 3, 23, 21, RM, Context.Empty, vars);
 		assertNull(((TLCStackFrame) stackFrames[i]).exception);

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD998ChanDebuggerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/EWD998ChanDebuggerTest.java
@@ -233,8 +233,9 @@ public class EWD998ChanDebuggerTest extends TLCDebuggerTestCase {
 		debugger.replaceAllBreakpointsWith(UTILS, 13);
 		stackFrames = debugger.continue_();
 		
-		int i = 18;
+		int i = 19;
 		assertEquals(i, stackFrames.length);
+		i--;
 		assertTLCFrame(stackFrames[--i], 43, 49, RM);
 		assertTLCStateFrame(stackFrames[--i], 43, 49, RM, vars);
 		assertTLCStateFrame(stackFrames[--i], 43, 43, RM, vars);
@@ -329,16 +330,16 @@ public class EWD998ChanDebuggerTest extends TLCDebuggerTestCase {
 		// Step through the evaluation of a mildly complex expression. 
 		debugger.replaceAllBreakpointsWith(RM, 119);
 		stackFrames = debugger.continue_();
-		assertEquals(9, stackFrames.length);
+		assertEquals(10, stackFrames.length);
 		Context context = Context.Empty.cons(null, IntValue.ValOne).cons(null, IntValue.ValOne).cons(null, IntValue.ValOne);
 		assertTLCActionFrame(stackFrames[0], 119, 119, RM, context, vars[3]);
 
 		stackFrames = debugger.stepIn();
-		assertEquals(10, stackFrames.length);
+		assertEquals(11, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 119, 119, RM, context, vars[3]);
 
 		stackFrames = debugger.stepIn(3);
-		assertEquals(11, stackFrames.length);
+		assertEquals(12, stackFrames.length);
 		Set<Variable> variables = new HashSet<>();
 		variables.add(createVariable("i","1",IntValue.ValZero.getTypeString()));
 		variables.add(createVariable("j","1",IntValue.ValZero.getTypeString()));
@@ -346,12 +347,12 @@ public class EWD998ChanDebuggerTest extends TLCDebuggerTestCase {
 		assertTLCActionFrame(stackFrames[0], 119, 44, 119, 57, RM, variables, vars[3]);
 
 		stackFrames = debugger.stepIn();
-		assertEquals(12, stackFrames.length);
+		assertEquals(13, stackFrames.length);
 		variables.add(createVariable("s","<<[type |-> \"pl\"]>>",TupleValue.EmptyTuple.getTypeString()));
 		assertTLCActionFrame(stackFrames[0], 29, 29, UTILS, variables, vars[3]);
 
 		stackFrames = debugger.stepIn(13);
-		assertEquals(10, stackFrames.length);
+		assertEquals(11, stackFrames.length);
 		variables = new HashSet<>();
 		variables.add(createVariable("i","1",IntValue.ValZero.getTypeString()));
 		variables.add(createVariable("j","1",IntValue.ValZero.getTypeString()));
@@ -360,13 +361,13 @@ public class EWD998ChanDebuggerTest extends TLCDebuggerTestCase {
 		// 8888888888888888888 Invariant TypeOK 8888888888888888888 //
 		debugger.replaceAllBreakpointsWith(RM, 29);
 		stackFrames = debugger.continue_();
-		assertEquals(10, stackFrames.length);
+		assertEquals(12, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 29, 3, 37, 25, RM, Context.Empty);
 		
 		// 8888888888888888888 Invariant EWD998!Inv 8888888888888888888 //
 		debugger.replaceAllBreakpointsWith(FOLDER, 150);
 		stackFrames = debugger.continue_();
-		assertEquals(10, stackFrames.length);
+		assertEquals(12, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 150, 3, 162, 34, FOLDER, (Context) null); //TODO Assert context that contains the refinement mapping
 		
 		// 8888888888888888888 Test resolving a location (e.g. editor hovering) to a value 888888888888888 //
@@ -474,7 +475,7 @@ public class EWD998ChanDebuggerTest extends TLCDebuggerTestCase {
 		
 		// before the UNCHANGED is evaluated
 		stackFrames = debugger.continue_();
-		assertEquals(7, stackFrames.length);
+		assertEquals(8, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 107, 6, 107, 32, RM, (Context) null, vars[0], vars[1]);
 
 		// Run to the state-constraint and a hit condition.
@@ -483,14 +484,14 @@ public class EWD998ChanDebuggerTest extends TLCDebuggerTestCase {
 		sba.getBreakpoints()[0].setHitCondition("3");
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(8, stackFrames.length);
+		assertEquals(10, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 148, 3, 153, 45, RM, Context.Empty);
 
 		// Check Next action has expected number of successor states.
 		debugger.unsetBreakpoints();
 		debugger.setSpecBreakpoint();
 		stackFrames = debugger.continue_();
-		assertEquals(1, stackFrames.length);
+		assertEquals(3, stackFrames.length);
 		assertTLCNextStatesFrame(stackFrames[0], 134, 20, 134, 23, RM, Context.Empty, 3);
 		
 		stackFrame = (TLCStackFrame) stackFrames[0];

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/EchoDebuggerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/EchoDebuggerTest.java
@@ -200,7 +200,7 @@ public class EchoDebuggerTest extends TLCDebuggerTestCase {
 		// Debug type correctness property during Init //
 		debugger.replaceAllBreakpointsWith(RM, 167);
 		stackFrames = debugger.continue_();
-		assertEquals(12, stackFrames.length);
+		assertEquals(13, stackFrames.length);
 		// Invariants are shown as TLCStateFrames, not TLCActionFrames, which would make
 		// the debugger show a predecessor state.
 		assertTLCStateFrame(stackFrames[0], 167, 6, 167, 63, RM, Context.Empty);
@@ -211,27 +211,31 @@ public class EchoDebuggerTest extends TLCDebuggerTestCase {
 		assertEquals(new RecordValue(frame.state), ((DebugTLCVariable) trace[0]).getTLCValue());
 		assertEquals("1: <Init line 95, col 9 to line 101, col 43 of module Echo>", trace[trace.length - 1].getName());
 
+		assertTLCSyntheticStateStackFrame(stackFrames[12], 95, 9, 101, 43, RM, Context.Empty, 1);
+		
 		// Debug type correctness property during n0 (next-state relation)
 		// (Run to n0, then run to TypeOK)
 		debugger.unsetBreakpoints();
 		debugger.replaceAllBreakpointsWith(RM, 104);
 		stackFrames = debugger.continue_();
-		assertEquals(4, stackFrames.length);
+		assertEquals(5, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 104, 16, 107, 40, RM, (Context) null, getVars());
+		assertTLCSyntheticStateStackFrame(stackFrames[4], 95, 9, 101, 43, RM, Context.Empty, 1);
 		
 		debugger.replaceAllBreakpointsWith(RM, 167);
 		stackFrames = debugger.continue_();
-		assertEquals(10, stackFrames.length);
+		assertEquals(11, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 167, 6, 167, 63, RM, Context.Empty);
 		frame = (TLCStateStackFrame) stackFrames[0];
 		assertEquals(2, frame.state.getLevel());
+		assertTLCSyntheticStateStackFrame(stackFrames[10], 95, 9, 101, 43, RM, Context.Empty, 1);
 		
 		// Debug TypeOK with a debug expression breakpoint that is referencing TypeOK via NotTypeOK.
 		debugger.unsetBreakpoints();
 		SetBreakpointsArguments sba = createBreakpointArgument(RM, 167, "NotNotTypeOK");
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(11, stackFrames.length);
+		assertEquals(12, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 167, 6, 167, 63, RM, Context.Empty);
 
 		// Replace the previous breakpoint with the same one except for a hit condition
@@ -241,39 +245,42 @@ public class EchoDebuggerTest extends TLCDebuggerTestCase {
 		sba.getBreakpoints()[0].setHitCondition("5");
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(4, stackFrames.length);
+		assertEquals(7, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 104, 16, 107, 40, RM, (Context) null, getVars());
+		assertTLCSyntheticStateStackFrame(stackFrames[4], 103, 13, 109, 59, RM, (Context) null, 3);
+		assertTLCSyntheticStateStackFrame(stackFrames[5], 103, 13, 109, 59, RM, (Context) null, 2);
+		assertTLCSyntheticStateStackFrame(stackFrames[6], 95, 9, 101, 43, RM, Context.Empty, 1);
 
 		sba = createBreakpointArgument(RM, 103, "DebugExpression"); // Inline breakpoint set on the LHS of Action definition.
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(2, stackFrames.length);
+		assertEquals(5, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 103, 13, 109, 59, RM, Context.Empty.cons(null, new StringValue("b"))
 				.cons(null, new StringValue("b")).cons(null, new StringValue("b")), getVars());
 
 		sba = createBreakpointArgument(RM, 103, "DebugExpression2"); // Inline breakpoint set on the LHS of Action definition.
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(2, stackFrames.length);
+		assertEquals(5, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 103, 13, 109, 59, RM, Context.Empty.cons(null, new StringValue("a"))
 				.cons(null, new StringValue("a")).cons(null, new StringValue("a")), getVars());
 
 		sba = createBreakpointArgument(RM, 112, 0, 13);
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(4, stackFrames.length);
+		assertEquals(15, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 112, 16, 129, 71, RM, (Context) null, getVars());
 		
 		sba = createBreakpointArgument(RM, 133, "DebugExpression");
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(4, stackFrames.length);
+		assertEquals(15, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 133, 16, 138, 40, RM, (Context) null, getVars());
 
 		sba = createBreakpointArgument(MDL, 38, "View");
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(10, stackFrames.length);
+		assertEquals(22, stackFrames.length);
 		assertTLCStateFrame(stackFrames[0], 38, 9, 38, 12, MDL, Context.Empty);
 		
 		frame = (TLCStateStackFrame) stackFrames[0];
@@ -303,11 +310,65 @@ public class EchoDebuggerTest extends TLCDebuggerTestCase {
 		assertEquals(1, nested.length);
 		assertEquals(new RecordValue(frame.state), ((DebugTLCVariable) nested[0]).getTLCValue());
 
+		assertTLCSyntheticStateStackFrame(stackFrames[10], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")),
+				12);
+		assertTLCSyntheticStateStackFrame(stackFrames[11], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")),
+				11);
+		assertTLCSyntheticStateStackFrame(stackFrames[12], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("a")).cons(null, new StringValue("a")).cons(null, new StringValue("a")),
+				10);
+		assertTLCSyntheticStateStackFrame(stackFrames[13], 132, 13, 140, 59, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 9);
+		assertTLCSyntheticStateStackFrame(stackFrames[14], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 8);
+		assertTLCSyntheticStateStackFrame(stackFrames[15], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 7);
+		assertTLCSyntheticStateStackFrame(stackFrames[16], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 6);
+		assertTLCSyntheticStateStackFrame(stackFrames[17], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 5);
+		assertTLCSyntheticStateStackFrame(stackFrames[18], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 4);
+		assertTLCSyntheticStateStackFrame(stackFrames[19], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 3);
+		assertTLCSyntheticStateStackFrame(stackFrames[20], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("a")).cons(null, new StringValue("a")).cons(null, new StringValue("a")), 2);
+		assertTLCSyntheticStateStackFrame(stackFrames[21], 95, 9, 101, 43, RM, Context.Empty, 1);
+
 		// Check Next action has expected number of successor states.
 		debugger.setSpecBreakpoint();
 		stackFrames = debugger.continue_();
-		assertEquals(1, stackFrames.length);
+		assertEquals(13, stackFrames.length);
 		assertTLCNextStatesFrame(stackFrames[0], 151, 20, 151, 23, RM, Context.Empty, 1);
+
+		assertTLCSyntheticStateStackFrame(stackFrames[1], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")),
+				12);
+		assertTLCSyntheticStateStackFrame(stackFrames[2], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")),
+				11);
+		assertTLCSyntheticStateStackFrame(stackFrames[3], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("a")).cons(null, new StringValue("a")).cons(null, new StringValue("a")),
+				10);
+		assertTLCSyntheticStateStackFrame(stackFrames[4], 132, 13, 140, 59, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 9);
+		assertTLCSyntheticStateStackFrame(stackFrames[5], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 8);
+		assertTLCSyntheticStateStackFrame(stackFrames[6], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 7);
+		assertTLCSyntheticStateStackFrame(stackFrames[7], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 6);
+		assertTLCSyntheticStateStackFrame(stackFrames[8], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 5);
+		assertTLCSyntheticStateStackFrame(stackFrames[9], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 4);
+		assertTLCSyntheticStateStackFrame(stackFrames[10], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 3);
+		assertTLCSyntheticStateStackFrame(stackFrames[11], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("a")).cons(null, new StringValue("a")).cons(null, new StringValue("a")), 2);
+		assertTLCSyntheticStateStackFrame(stackFrames[12], 95, 9, 101, 43, RM, Context.Empty, 1);
 
 		// Ad-hoc expression-based breakpoint
 		
@@ -315,14 +376,41 @@ public class EchoDebuggerTest extends TLCDebuggerTestCase {
 		sba = createBreakpointArgument(RM, 133, 19, 1, "\\E n \\in Node: inbox[n] = {}"); // Ad-hoc defined expression built from constant and variable value. // TODO Support ctxt, i.e., self!
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(5, stackFrames.length);
+		assertEquals(16, stackFrames.length);
 		assertTLCActionFrame(stackFrames[0], 133, 19, 133, 34, RM, (Context) null, getVars());
+
+		// The last three frames differ from the previous breakpoint hit because BFS
+		// advanced to a different part of the state graph.
+		assertTLCSyntheticStateStackFrame(stackFrames[5], 132, 13, 140, 59, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")),
+				11);
+		assertTLCSyntheticStateStackFrame(stackFrames[6], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")),
+				10);
+		assertTLCSyntheticStateStackFrame(stackFrames[7], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 9);
+
+		assertTLCSyntheticStateStackFrame(stackFrames[8], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 8);
+		assertTLCSyntheticStateStackFrame(stackFrames[9], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 7);
+		assertTLCSyntheticStateStackFrame(stackFrames[10], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 6);
+		assertTLCSyntheticStateStackFrame(stackFrames[11], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("c")).cons(null, new StringValue("c")).cons(null, new StringValue("c")), 5);
+		assertTLCSyntheticStateStackFrame(stackFrames[12], 111, 13, 130, 27, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 4);
+		assertTLCSyntheticStateStackFrame(stackFrames[13], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("b")).cons(null, new StringValue("b")).cons(null, new StringValue("b")), 3);
+		assertTLCSyntheticStateStackFrame(stackFrames[14], 103, 13, 109, 59, RM, Context.Empty
+				.cons(null, new StringValue("a")).cons(null, new StringValue("a")).cons(null, new StringValue("a")), 2);
+		assertTLCSyntheticStateStackFrame(stackFrames[15], 95, 9, 101, 43, RM, Context.Empty, 1);
 
 		debugger.unsetBreakpoints();
 		sba = createBreakpointArgument(RM, 140, 16, 1, "\\E n \\in Node: inbox'[n] = {}"); // Ad-hoc defined expression built from constant and variable value. // TODO Support ctxt, i.e., self!
 		debugger.setBreakpoints(sba);
 		stackFrames = debugger.continue_();
-		assertEquals(9, stackFrames.length);
+		assertEquals(20, stackFrames.length);
 		final OpDeclNode[] vars = getVars();
 		assertTLCActionFrame(stackFrames[0], 140, 16, 140, 59, RM, (Context) null, vars[1], vars[2], vars[3], vars[4]);
 		

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
@@ -471,7 +471,20 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			assertTrue(o.isEmpty());
 		}
 	}
-	
+
+	protected static void assertTLCSyntheticStateStackFrame(final StackFrame stackFrame, final int beginLine,
+			final int beginColumn, final int endLine, final int endColumn, String spec, Context c,
+			final int expectedLevel) {
+		assertTLCStateFrame(stackFrame, beginLine, endLine, spec, c);
+		assertEquals(beginColumn, stackFrame.getColumn());
+		assertEquals(endColumn + 1, (int) stackFrame.getEndColumn());
+		assertTrue(stackFrame instanceof TLCSyntheticStateStackFrame);
+		final TLCSyntheticStateStackFrame f = (TLCSyntheticStateStackFrame) stackFrame;
+
+		assertEquals(expectedLevel, f.state.getLevel());
+		assertTrue(f.state.allAssigned());
+	}
+
 	private static void assertStateVars(TLCStateStackFrame frame, final TLCState st) {
 		final Map<Integer, DebugTLCVariable> old = new HashMap<>(frame.nestedVariables);
 		try {


### PR DESCRIPTION
This change extends the debugger’s Call Stack to display the state trace when running in BFS mode, bringing it closer to the behavior already supported in simulation mode.

Previously, only the current trace was exposed to the frontend Call Stack during simulation, where Watch expressions are evaluated based on the selected Call Stack frame (i.e., the selected state in the trace). With this update, BFS mode now also surfaces the state trace in the Call Stack, enabling more consistent debugging workflows across execution modes.

Related to git commit 6ca661ba936c297628a8d2e80ec5f4564377f15a

[Feature][TLC][Debugger]