### PR TITLE
Report SANY exceptions for invalid breakpoint, watch, or debug expressions.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -14,13 +14,16 @@ import java.util.Set;
 
 import pcal.Validator;
 import pcal.Validator.ValidationResult;
+import tla2sany.drivers.SemanticException;
 import tla2sany.output.SanyOutput;
+import tla2sany.parser.ParseException;
 import tla2sany.semantic.AbortException;
 import tla2sany.semantic.ErrorCode;
 import tla2sany.semantic.Errors;
 import tla2sany.semantic.ExprNode;
 import tla2sany.semantic.ExternalModuleTable;
 import tla2sany.semantic.ModuleNode;
+import tla2sany.semantic.OpDefNode;
 import tla2sany.st.Location;
 import tla2sany.st.TreeNode;
 import tla2sany.utilities.Vector;
@@ -1069,7 +1072,12 @@ public class SpecObj
 		return new ArrayList<>();
 	}
 
-	public List<Action> getInvariants(SpecProcessor specProcessor) {
+	public List<Action> getInvariants(SpecProcessor specProcessor) throws ParseException, SemanticException, AbortException {
+		// overridden by sub-classes.
+		return new ArrayList<>();
+	}
+
+	public List<OpDefNode> getConstraints() {
 		// overridden by sub-classes.
 		return new ArrayList<>();
 	}

--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import tlc2.output.EC;
+
 /**
  * An enumeration of standardized codes for errors during semantic checking.
  * Recorded in the {@link Errors} class. Since the error codes are standard
@@ -34,6 +36,8 @@ import java.util.stream.Collectors;
  * documented here with comments.
  */
 public enum ErrorCode {
+
+  GENERAL (EC.GENERAL, ErrorLevel.ERROR, ErrorCode.VARIADIC_PARAMETERS),
 
   /**
    * Used for internal errors that function more like assertions; should

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebugger.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebugger.java
@@ -460,15 +460,10 @@ public abstract class TLCDebugger extends AbstractDebugger implements IDebugTarg
 					breakpoint.setMessage("A Next breakpoint does not support a hit condition.");
 				}
 				
-				if (moduleNode != null && sbp.getCondition() != null && !sbp.getCondition().isEmpty()) {
-					// see tlc2.debug.TLCStateStackFrame.matches(TLCSourceBreakpoint)
-					final OpDefNode odn = moduleNode.getOpDef(sbp.getCondition());
-					if (odn == null) {
-						breakpoint.setVerified(false);
-						breakpoint.setMessage(String.format(
-								"The  %s  definition, used as the breakpoint expression, could not be found in the specification  %s.",
-								sbp.getCondition(), module));
-					}
+				if (moduleNode != null && sbp.getCondition() != null && !sbp.getCondition().isEmpty()
+						&& sbp.getConditionException() != null) {
+					breakpoint.setVerified(false);
+					breakpoint.setMessage(sbp.getConditionException().getMessage());
 				}
 				
 				final Source source = args.getSource();

--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCStackFrame.java
@@ -531,23 +531,6 @@ public class TLCStackFrame extends StackFrame {
 		return TLCState.Empty;
 	}
 
-	public EvaluateResponse getWatch(final String name) {
-		if (name == null) {
-			return new EvaluateResponse();
-		} 
-		
-		// 1) Try to resolve the name to an existing expression.
-		final ModuleNode module = tool.getSpecProcessor().getRootModule();
-
-		// 2) Expression doesn't exist. Check if name is an ad-hoc expression.
-		OpDefNode odn = module.getOpDef(name);
-		if (odn == null) {
-			odn = TLCDebuggerExpression.process(tool.getSpecProcessor(), module, name);
-		}
-
-		return getWatch(odn);
-	}
-
 	public EvaluateResponse getWatch(final OpDefNode odn) {
 		if (odn == null) {
 			return new EvaluateResponse();

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ParameterizedSpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ParameterizedSpecObj.java
@@ -32,10 +32,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import tla2sany.drivers.SemanticException;
 import tla2sany.modanalyzer.ModulePointer;
 import tla2sany.modanalyzer.ParseUnit;
 import tla2sany.modanalyzer.SpecObj;
 import tla2sany.output.SanyOutput;
+import tla2sany.parser.ParseException;
 import tla2sany.semantic.AbortException;
 import tla2sany.semantic.Errors;
 import tla2sany.semantic.ExprNode;
@@ -137,7 +139,7 @@ public class ParameterizedSpecObj extends SpecObj {
 			this.modules = modules;
 		}
 		
-		public abstract Action getAction(final SpecProcessor spec);
+		public abstract Action getAction(final SpecProcessor spec) throws ParseException, SemanticException, AbortException;
 
 		public Set<String> getModules() {
 			// TODO:
@@ -153,24 +155,20 @@ public class ParameterizedSpecObj extends SpecObj {
 	public static class RuntimeInvariantTemplate extends InvariantTemplate {
 		private final String expr;
 
-		public RuntimeInvariantTemplate(final String expr) {
-			this(Set.of(), expr);
-		}
-
 		public RuntimeInvariantTemplate(final Set<String> modules, final String expr) {
 			super(modules);
 			this.expr = expr;
 		}
 
 		@Override
-		public Action getAction(final SpecProcessor spec) {
+		public Action getAction(final SpecProcessor spec) throws ParseException, SemanticException, AbortException {
 			final OpDefNode opDef = TLCDebuggerExpression.process(spec, spec.getRootModule(), expr);
 			return new Action(opDef.getBody(), Context.Empty, opDef, false, true);
 		}
 	}
 
 	@Override
-	public List<Action> getInvariants(final SpecProcessor specProcessor) {
+	public List<Action> getInvariants(final SpecProcessor specProcessor) throws ParseException, SemanticException, AbortException {
 		final List<Action> res = new ArrayList<>();
 
 		@SuppressWarnings("unchecked")

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/SpecProcessor.java
@@ -43,11 +43,14 @@ import java.util.stream.Collectors;
 
 import tla2sany.drivers.FrontEndException;
 import tla2sany.drivers.SANY;
+import tla2sany.drivers.SemanticException;
 import tla2sany.modanalyzer.SpecObj;
 import tla2sany.output.LogLevel;
 import tla2sany.output.SanyOutput;
 import tla2sany.output.SimpleSanyOutput;
+import tla2sany.parser.ParseException;
 import tla2sany.semantic.APSubstInNode;
+import tla2sany.semantic.AbortException;
 import tla2sany.semantic.AssumeNode;
 import tla2sany.semantic.DecimalNode;
 import tla2sany.semantic.ExprNode;
@@ -902,15 +905,19 @@ public class SpecProcessor implements ValueConstants, ToolGlobals {
 		// class of Tool) is still null at this point; the implementation of
 		// getInvariants requires access to SpecProcessor in order to process
 		// RuntimeInvariantTemplates.
-        final java.util.List<Action> overrides = specObj.getInvariants(this);
+		try {
+			java.util.List<Action> overrides = specObj.getInvariants(this);
 
-        final ArrayList<Action> a = new ArrayList<>(Arrays.asList(this.invariants));
-		a.addAll(overrides);
-        this.invariants = a.toArray(Action[]::new);
+			final ArrayList<Action> a = new ArrayList<>(Arrays.asList(this.invariants));
+			a.addAll(overrides);
+			this.invariants = a.toArray(Action[]::new);
 
-        final ArrayList<String> b = new ArrayList<>(Arrays.asList(this.invNames));
-        b.addAll(overrides.stream().map(act -> act.getNameOfDefault()).collect(Collectors.toList()));
-        this.invNames = b.toArray(String[]::new);
+			final ArrayList<String> b = new ArrayList<>(Arrays.asList(this.invNames));
+			b.addAll(overrides.stream().map(act -> act.getNameOfDefault()).collect(Collectors.toList()));
+			this.invNames = b.toArray(String[]::new);
+		} catch (ParseException | SemanticException | AbortException e) {
+			Assert.fail(EC.TLC_PARSING_FAILED2, e);
+		}
         
 		// Process the model constraints in the config. It's done after all
 		// other config processing because it used to be processed lazy upon the

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/TLCDebuggerTestCase.java
@@ -626,9 +626,18 @@ public abstract class TLCDebuggerTestCase extends ModelCheckerTestCase implement
 			// Set new breakpoint.
 			return setBreakpoints(rootModule, line);
 		}
+		public Breakpoint[] replaceAllBreakpointsWith(final String rootModule, int line, String expr) throws Exception {
+			unsetBreakpoints();
+			// Set new breakpoint.
+			return setBreakpoints(rootModule, line, expr);
+		}
 		
 		public Breakpoint[] setBreakpoints(final String rootModule, int line) throws Exception {
 			return setBreakpoints(createBreakpointArgument(rootModule, line)).get().getBreakpoints();
+		}
+
+		public Breakpoint[] setBreakpoints(final String rootModule, int line, final String expr) throws Exception {
+			return setBreakpoints(createBreakpointArgument(rootModule, line, expr)).get().getBreakpoints();
 		}
 
 		public void unsetBreakpoints() {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/InvParameterizedCTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/InvParameterizedCTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class InvParameterizedCTest extends ModelCheckerTestCase {
+
+	private static final String INV_EXPR = "garbled input to cause parse error";
+
+	public InvParameterizedCTest() {
+		super("InvParameterizedTest", new String[] { "-config", "InvParameterizedTest.tla", "-inv", INV_EXPR },
+				ExitStatus.ERROR_SPEC_PARSE);
+	}
+
+	@Test
+	public void testSpec() throws FileNotFoundException, IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDump() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+}


### PR DESCRIPTION
Report SANY exceptions for invalid breakpoint, watch, or debug expressions.

This change improves error reporting in the debugger by propagating SANY parsing and semantic analysis exceptions directly to the debugger frontend, rather than silently logging them to ToolIO.err.

Previously, when users entered invalid TLA+ expressions in breakpoint conditions, watch expressions, or debug console inputs, the debugger would catch ParseException, SemanticException, and AbortException internally, print error messages to standard error, and return null. This left users without clear feedback in the debugger UI about what went wrong with their expressions.

With this change, TLCDebuggerExpression.process() now throws these exceptions instead of catching them, allowing calling code in TLCDebugger, TLCSourceBreakpoint, and TLCStackFrame to handle them appropriately. Invalid expressions now display user-friendly error messages directly in the debugger UI via breakpoint.setMessage() and evaluate response results.

As a side effect of propagating exceptions through SpecObj.getInvariants(), invalid expressions passed to TLC on the command-line with `-inv expr` are now also properly reported with clear error messages, rather than being silently ignored or logged to standard error.

Test coverage has been extended to verify that syntax errors (e.g., "garbled input not parsable"), semantic errors (e.g., referencing non-existent modules), and other SANY failures are properly reported to users through the
debugger protocol. A new test (InvParameterizedCTest) verifies that invalid invariant expressions on the command-line are properly handled.

[Feature][TLC][Debugger]