### PR TITLE
Fix equality checks on polymorphic sequences inside functions

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/RecordValue.java
@@ -354,6 +354,15 @@ public class RecordValue extends Value implements FunctionValue {
       }
       // Then, compare values iff domains are equal.
       for (int i = 0; i < len; i++) {
+        // If neither value is a ModelValue, ensure they have the same type
+        // to prevent Assert.fail() in downstream equals() methods
+        // This can happen e.g. with polymorphic records during liveness checking.
+        if (!(this.values[i] instanceof ModelValue || rcd.values[i] instanceof ModelValue)) {
+          if (!this.values[i].getClass().equals(rcd.values[i].getClass())) {
+            return false;
+          }
+        }
+
         if (!(this.values[i].equals(rcd.values[i]))) {
         	  return false;
         }


### PR DESCRIPTION
Prevent errors like the below during liveness checking of specs using polymorphic sequences.

Attempted to check equality of string "U_OF_UNIT" with non-string

Works with Apalache 0.52.1.

Testcase:

```tla
\* tla2tools.jar -config PolymorphicSeq.cfg -workers 8 PolymorphicSeq.tla
\* apalache-mc check --debug --write-intermediate PolymorphicSeq.tla

------------------------------- MODULE PolymorphicSeq -------------------------------
EXTENDS Integers, Sequences, Variants

\* Bug reproduction: "Attempted to check equality of integer 1 with non-integer: "U_OF_UNIT""
\* The bug requires mixing UNIT and integer variants with extendDomain

\* Message types - need both UNIT and integer variants to trigger the bug
FirstVariantUnit == Variant("FirstVariant", UNIT)

\* @typeAlias: myVariant = FirstVariant(UNIT) | SecondVariant(Int);
TYPES == TRUE

\* Critical component - the bug requires extendDomain
\* @type: ((a -> b), a, b) => (a -> b);
extendDomain(f, key, value) == [x \in (DOMAIN f) \cup {key} |-> IF x = key THEN value ELSE f[x]]

VARIABLES
  \* Polymorphic queue
  \* @type: Int -> Seq($myVariant);
  queue

Init == queue = extendDomain([ k \in {} |-> <<>> ], 100, <<>>)

\* Mix of UNIT and integer variants
Next ==
  \E msgChoice \in 1..2:
    LET msg == CASE msgChoice = 1 -> FirstVariantUnit
                 [] msgChoice = 2 -> Variant("SecondVariant", 1)
    IN
    queue' = [queue EXCEPT ![100] = Append(@, msg)]

Spec == Init /\ [][Next]_queue

\* Force equality check with UNIT variants
MyInvariant ==
  \A k \in DOMAIN queue:
    \A i \in 1..Len(queue[k]):
      LET msg == queue[k][i] IN
      \/ msg = FirstVariantUnit
      \/ VariantTag(msg) = "SecondVariant"

=============================================================================
```

TLC's `.cfg` file:

```
SPECIFICATION Spec
INVARIANT
  MyInvariant
```