### PR TITLE
Add warnings about debugger limitations when using multiple TLC workers.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebugger.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/debug/TLCDebugger.java
@@ -290,6 +290,24 @@ public abstract class TLCDebugger extends AbstractDebugger implements IDebugTarg
 			baseFilters.add(violations);
 		}
 
+		// Add a warning dummy breakpoint if TLC is running with multiple workers.
+		// The debugger only attaches to one worker, so breakpoints will only fire
+		// for that worker.
+		// NOTE: A similar warning message is also sent to the Debug Console in
+		// AttachingDebugger.launch().
+		if (TLCGlobals.getNumWorkers() > 1) {
+			final ExceptionBreakpointsFilter warning = new ExceptionBreakpointsFilter();
+			warning.setDefault_(false);
+			warning.setFilter("MultiWorkerWarningFilter");
+			warning.setLabel("⚠️  MULTIPLE WORKER WARNING: Breakpoints only fire for one worker (use -workers 1)");
+			warning.setDescription(
+					"The debugger only attaches to one worker thread. With multiple workers, the breakpoints in this list will only fire if they occur in the attached worker. Breakpoint triggers in other workers will be missed. To consistently catch all breakpoint triggers, restart TLC with -workers 1.");
+			warning.setSupportsCondition(false);
+
+			// Prepend the warning filter to the list
+			baseFilters.add(0, warning);
+		}
+
 		return baseFilters.toArray(new ExceptionBreakpointsFilter[0]);
 	}
 


### PR DESCRIPTION
Add warnings about debugger limitations when using multiple TLC workers.

Historically, the TLA+ Debugger did not support multiple TLC workers. This restriction was later relaxed to help diagnose runaway models, where state-space exploration can take a very long time, with minimal performance impact. In this setup, the debugger attaches to a single worker and provides introspection while only affecting that worker’s performance.

As a consequence, global breakpoints—such as Halt (break) after Init and Next, Violation, and Exception—may not fire if the triggering event occurs in a worker other than the one being debugged.

To make this limitation explicit, two warnings are added:
* A startup warning emitted in the debugger console.
* A conditional warning shown as a dummy breakpoint next to Halt (break) ... when TLC is running with multiple workers.

<img width="458" height="161" alt="image" src="https://github.com/user-attachments/assets/e808a0bd-4de7-4544-b4bf-084c78fe432d" />


[Feature][TLC][Debugger]

/cc @craft095 