### PR TITLE
Fix XML export for CASE OTHER

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpApplNode.java
@@ -1362,7 +1362,8 @@ public class OpApplNode extends ExprNode implements ExploreNode {
     for (int i=0; i< operands.length; i++) {
       // dealing with the $Case OTHER null bug
       if (i == 0 && operands[0] == null && context.hasFlag(SymbolContext.OTHER_BUG)) {
-        ope.appendChild(appendText(doc,"StringNode","$Other"));
+        Element otherValue = appendText(doc, "StringValue", "$Other");
+        ope.appendChild(appendElement(doc, "StringNode", otherValue));
       }
       else {
         ope.appendChild(operands[i].export(doc,context, filter));

--- a/tlatools/org.lamport.tlatools/test-model/CaseOtherXml.tla
+++ b/tlatools/org.lamport.tlatools/test-model/CaseOtherXml.tla
@@ -1,0 +1,3 @@
+---- MODULE CaseOtherXml ----
+op == CASE TRUE -> FALSE [] OTHER -> TRUE
+====


### PR DESCRIPTION
- Summary: Fix CASE OTHER XML export to emit schema-valid StringNode and add a regression test.
- Root cause: XML export used a text child for StringNode ($Other), which violates sany.xsd element-only content.
- Fix: Emit StringNode/StringValue for OTHER and add a minimal CASE OTHER test module plus XML export test.
- Tests: `ant -f customBuild.xml test-set -Dtest.testcases="tla2sany/xml/TestXMLExporterModule.java"`

Fixes #1291
