### PR TITLE
fix: Allow simultaneous use of -loadTrace and -dumpTrace options

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
@@ -4,14 +4,15 @@ LOCAL INSTANCE TLCExt
 LOCAL INSTANCE Json
 LOCAL INSTANCE Sequences
 
-CONSTANT _JsonTraceFile
+CONSTANT _JsonTraceOutputFile  \* Used by -dumpTrace json
+CONSTANT _JsonTraceInputFile   \* Used by -loadTrace json
 
 _JsonTrace ==
     IF CounterExample.state = {} \/ ("console" \in DOMAIN CounterExample /\ CounterExample["console"] = FALSE) THEN TRUE ELSE
         /\ LET trace == ToTrace(CounterExample)
                vars  == UNION { DOMAIN trace[i] : i \in DOMAIN trace }
-           IN JsonSerialize(_JsonTraceFile, [counterexample |-> CounterExample, vars |-> vars])
-        /\ PrintT("CounterExample written: " \o _JsonTraceFile)
+           IN JsonSerialize(_JsonTraceOutputFile, [counterexample |-> CounterExample, vars |-> vars])
+        /\ PrintT("CounterExample written: " \o _JsonTraceOutputFile)
 
 ----------------------------------------------------------------------------
 \* Deserialize a trace created by _JsonTrace above.
@@ -22,7 +23,7 @@ LOCAL _TLCState(level) ==
 
 LOCAL _JsonTraceConstraint ==
     LET level == TLCGet("level")
-        dump  == JsonDeserialize(_JsonTraceFile)
+        dump  == JsonDeserialize(_JsonTraceInputFile)
         trace == dump["counterexample"]["state"]
         \* JSON deserializes sets as tuples, so convert back to a set
         vars  == {dump["vars"][i] : i \in DOMAIN dump["vars"]}

--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCActionTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCActionTrace.tla
@@ -18,10 +18,10 @@ LOCAL _next ==
         ToDisjunct(i, r) == "\\/ " \o ToString(i) \o " = _idx /\\ " \o Signature(r) \o "\n"
     IN FoldSet(LAMBDA a, acc: acc \o ToDisjunct(a[1][1], a[2]), "", CounterExample.action)
 
-CONSTANT _TLCTraceFile
+CONSTANT _TLCTraceOutputFile  \* Used by -dumpTrace tlcaction
 
 LOCAL _TLCTraceModule ==
-	LET ModuleName == ReplaceFirstSubSeq("", ".tla", _TLCTraceFile) 
+	LET ModuleName == ReplaceFirstSubSeq("", ".tla", _TLCTraceOutputFile) 
         L == ToString(Cardinality(CounterExample.action)) IN
 	"---- MODULE " \o ModuleName \o " ----\n" \o
 	 \*TODO callsignature symbols may not be defined in the same modules where the actions are defined.
@@ -36,13 +36,13 @@ LOCAL _TLCTraceModule ==
 _TLCTrace ==
     IF CounterExample.action = {} \/ ("console" \in DOMAIN CounterExample /\ CounterExample["console"] = FALSE) THEN TRUE ELSE
         /\ Serialize(_TLCTraceModule,
-    			_TLCTraceFile,
+    			_TLCTraceOutputFile,
     			[
     				format |-> "TXT",
     				charset |-> "UTF-8",
     				openOptions |-> <<"WRITE", "CREATE", "TRUNCATE_EXISTING">>
     			]
            ).exitValue = 0
-        /\ PrintT("CounterExample written: " \o _TLCTraceFile)
+        /\ PrintT("CounterExample written: " \o _TLCTraceOutputFile)
 
 ======

--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTESpec.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTESpec.tla
@@ -17,7 +17,7 @@ LOCAL _Vars ==
 LOCAL _ToConjunt(v, prime, idx) ==
     "/\\ " \o v \o prime \o " = Trace[" \o idx \o "]." \o v \o "\n"
 
-CONSTANT _TLCTraceFile
+CONSTANT _TLCTraceOutputFile  \* Used by -dumpTrace tlcTESpec
 
 LOCAL _conjunct(prime, idx) ==
     FoldSet(LAMBDA v, acc: acc \o _ToConjunt(v, prime, idx), "", _Vars)
@@ -26,7 +26,7 @@ LOCAL _subVars ==
     FoldSet(LAMBDA v, acc: acc \o (IF acc = "" THEN "" ELSE ", ") \o v, "", _Vars)
 
 LOCAL _TLCTraceModule ==
-	LET ModuleName == ReplaceFirstSubSeq("", ".tla", _TLCTraceFile) IN
+	LET ModuleName == ReplaceFirstSubSeq("", ".tla", _TLCTraceOutputFile) IN
 	"---- MODULE " \o ModuleName \o " ----\n" \o
 	 \*TODO E.g., model values are typically defined in the MC file.
         _extends \o "\n\n" \o
@@ -47,13 +47,13 @@ LOCAL _TLCTraceModule ==
 _TLCTrace ==
     IF CounterExample.state = {} \/ ("console" \in DOMAIN CounterExample /\ CounterExample["console"] = FALSE) THEN TRUE ELSE
         /\ Serialize(_TLCTraceModule,
-    			_TLCTraceFile,
+    			_TLCTraceOutputFile,
     			[
     				format |-> "TXT",
     				charset |-> "UTF-8",
     				openOptions |-> <<"WRITE", "CREATE", "TRUNCATE_EXISTING">>
     			]
            ).exitValue = 0
-        /\ PrintT("CounterExample written: " \o _TLCTraceFile)
+        /\ PrintT("CounterExample written: " \o _TLCTraceOutputFile)
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTrace.tla
@@ -14,14 +14,15 @@ LOCAL _TLCTraceSerialize(val, absoluteFilename) ==
 ----------------------------------------------------------------------------
 \* Serialize a trace to a file.
 
-CONSTANT _TLCTraceFile
+CONSTANT _TLCTraceOutputFile  \* Used by -dumpTrace tlc
+CONSTANT _TLCTraceInputFile   \* Used by -loadTrace tlc
 
 LOCAL _TLCTrace0(verbose) ==
     IF CounterExample.state = {} \/ ("console" \in DOMAIN CounterExample /\ CounterExample["console"] = FALSE) THEN TRUE ELSE
         /\ LET trace == ToTrace(CounterExample)
                vars  == UNION { DOMAIN trace[i] : i \in DOMAIN trace }
-           IN _TLCTraceSerialize([trace |-> trace, vars |-> vars], _TLCTraceFile)
-        /\ IF verbose THEN PrintT("CounterExample written: " \o _TLCTraceFile) ELSE TRUE
+           IN _TLCTraceSerialize([trace |-> trace, vars |-> vars], _TLCTraceOutputFile)
+        /\ IF verbose THEN PrintT("CounterExample written: " \o _TLCTraceOutputFile) ELSE TRUE
 
 LOCAL _TLCTraceSilent ==
     _TLCTrace0(FALSE)
@@ -33,7 +34,7 @@ _TLCTrace ==
 \* Deserialize a trace created by _TLCTrace above.
 
 LOCAL _TLCTraceFileDeserialized ==
-    _TLCTraceDeserialize(_TLCTraceFile)
+    _TLCTraceDeserialize(_TLCTraceInputFile)
 
 \* This operator has a Java module override (tlc2.module._TLCTrace#tlcState).
 LOCAL _TLCState(level) ==

--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTracePlain.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTracePlain.tla
@@ -5,10 +5,10 @@ LOCAL INSTANCE TLCExt
 LOCAL INSTANCE Sequences
 LOCAL INSTANCE SequencesExt
 
-CONSTANT _TLCTraceFile
+CONSTANT _TLCTraceOutputFile  \* Used by -dumpTrace tlcplain
 
 LOCAL _TLCTraceModule ==
-	LET ModuleName == ReplaceFirstSubSeq("", ".tla", _TLCTraceFile) IN
+	LET ModuleName == ReplaceFirstSubSeq("", ".tla", _TLCTraceOutputFile) IN
 	"---- MODULE " \o ModuleName \o " ----\n" \o
     "LOCAL INSTANCE TLC\n\n" \o
     "Trace == \n\t" \o
@@ -18,13 +18,13 @@ LOCAL _TLCTraceModule ==
 _TLCTrace ==
     IF CounterExample.state = {} \/ ("console" \in DOMAIN CounterExample /\ CounterExample["console"] = FALSE) THEN TRUE ELSE
         /\ Serialize(_TLCTraceModule,
-    			_TLCTraceFile,
+    			_TLCTraceOutputFile,
     			[
     				format |-> "TXT",
     				charset |-> "UTF-8",
     				openOptions |-> <<"WRITE", "CREATE", "TRUNCATE_EXISTING">>
     			]
            ).exitValue = 0
-        /\ PrintT("CounterExample written: " \o _TLCTraceFile)
+        /\ PrintT("CounterExample written: " \o _TLCTraceOutputFile)
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -663,13 +663,13 @@ public class TLC {
 						final List<Constraint> computeIfAbsent = (List<Constraint>) params
 								.computeIfAbsent(ParameterizedSpecObj.CONSTRAINTS, k -> new ArrayList<Constraint>());
 						computeIfAbsent.add(
-								new Constraint("_TLCTrace", "_TLCTraceConstraint", "_TLCTraceFile", args[index++]));
+								new Constraint("_TLCTrace", "_TLCTraceConstraint", "_TLCTraceInputFile", args[index++]));
 					} else if ("json".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<Constraint> computeIfAbsent = (List<Constraint>) params
 								.computeIfAbsent(ParameterizedSpecObj.CONSTRAINTS, k -> new ArrayList<Constraint>());
 						computeIfAbsent.add(
-								new Constraint("_JsonTrace", "_JsonTraceConstraint", "_JsonTraceFile", args[index++]));
+								new Constraint("_JsonTrace", "_JsonTraceConstraint", "_JsonTraceInputFile", args[index++]));
 					} else {
 						printErrorMsg("Error: Unknown format " + fmt + " given to -loadTrace.");
 						return false;
@@ -687,7 +687,7 @@ public class TLC {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(
 								ParameterizedSpecObj.POST_CONDITIONS, k -> new ArrayList<PostCondition>());
-						pcs.add(new PostCondition("_JsonTrace", "_JsonTrace", "_JsonTraceFile", args[index++]));
+						pcs.add(new PostCondition("_JsonTrace", "_JsonTrace", "_JsonTraceOutputFile", args[index++]));
 					} else if ("tla".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(
@@ -698,22 +698,22 @@ public class TLC {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(
 								ParameterizedSpecObj.POST_CONDITIONS, k -> new ArrayList<PostCondition>());
-						pcs.add(new PostCondition("_TLCTrace", "_TLCTrace", "_TLCTraceFile", args[index++]));
+						pcs.add(new PostCondition("_TLCTrace", "_TLCTrace", "_TLCTraceOutputFile", args[index++]));
 					} else if ("tlcplain".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(
 								ParameterizedSpecObj.POST_CONDITIONS, k -> new ArrayList<PostCondition>());
-						pcs.add(new PostCondition("_TLCTracePlain", "_TLCTrace", "_TLCTraceFile", args[index++]));
+						pcs.add(new PostCondition("_TLCTracePlain", "_TLCTrace", "_TLCTraceOutputFile", args[index++]));
 					} else if ("tlcTESpec".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(
 								ParameterizedSpecObj.POST_CONDITIONS, k -> new ArrayList<PostCondition>());
-						pcs.add(new PostCondition("_TLCTESpec", "_TLCTrace", "_TLCTraceFile", args[index++]));
+						pcs.add(new PostCondition("_TLCTESpec", "_TLCTrace", "_TLCTraceOutputFile", args[index++]));
 					} else if ("tlcaction".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(
 								ParameterizedSpecObj.POST_CONDITIONS, k -> new ArrayList<PostCondition>());
-						pcs.add(new PostCondition("_TLCActionTrace", "_TLCTrace", "_TLCTraceFile", args[index++]));
+						pcs.add(new PostCondition("_TLCActionTrace", "_TLCTrace", "_TLCTraceOutputFile", args[index++]));
 					} else if ("dot".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<PostCondition> pcs = (List<PostCondition>) params.computeIfAbsent(

--- a/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorationSpec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TraceExplorationSpec.java
@@ -67,7 +67,7 @@ public class TraceExplorationSpec {
 		// Always dump the trace in binary format in case that the textual trace is
 		// prohibitively large making it infeasible to parse and process with SANY.
 		final Path resolve = this.outputPath.resolve(teSpecModuleName + TLAConstants.Files.TLA_TRACE_EXTENSION);
-		pcs.add(new PostCondition("_TLCTrace", "_TLCTraceSilent", "_TLCTraceFile", resolve.toFile().toString()));
+		pcs.add(new PostCondition("_TLCTrace", "_TLCTraceSilent", "_TLCTraceOutputFile", resolve.toFile().toString()));
 	}
 
 	public void generate(ITool specInfo) {


### PR DESCRIPTION
## Problem

When using `-loadTrace` and `-dumpTrace` together, TLC fails:

```bash
java -jar tla2tools.jar -loadTrace json trace.json -dumpTrace json output.json <spec>.tla
# Error: output.json (No such file or directory)
```

**Root cause:** Both options share the same constant (`_JsonTraceFile`), so `-dumpTrace` overwrites `-loadTrace`'s value, causing the constraint to read from the non-existent output file.

## Solution

Separate the constants:
- `_JsonTraceInputFile` / `_TLCTraceInputFile` — for `-loadTrace`
- `_JsonTraceOutputFile` / `_TLCTraceOutputFile` — for `-dumpTrace`
