### PR TITLE
Fix explain.tlapl.us root 404 with index page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="refresh" content="0; url=https://github.com/tlaplus/tlaplus/tree/master/docs" />
+  <link rel="canonical" href="https://github.com/tlaplus/tlaplus/tree/master/docs" />
+  <title>TLA+ / TLC Explanations</title>
+</head>
+<body>
+  <p>Redirecting to the docs index on GitHub…</p>
+  <p>If you are not redirected, <a href="https://github.com/tlaplus/tlaplus/tree/master/docs">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Adds `docs/index.html` to list the existing explanation articles so the root URL no longer 404s. Fixes #1266. Docs-only change.
