### PR TITLE
Allow simultaneous use of `-loadTrace` and `-dumpTrace` options.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
@@ -16,13 +16,15 @@ _JsonTrace ==
 ----------------------------------------------------------------------------
 \* Deserialize a trace created by _JsonTrace above.
 
+CONSTANT _JsonTraceInputFile   \* Used by -loadTrace json
+
 \* This operator has a Java module override (tlc2.module._JsonTrace#tlcState).
 LOCAL _TLCState(level) ==
 	Trace[level]
 
 LOCAL _JsonTraceConstraint ==
     LET level == TLCGet("level")
-        dump  == JsonDeserialize(_JsonTraceFile)
+        dump  == JsonDeserialize(_JsonTraceInputFile)
         trace == dump["counterexample"]["state"]
         \* JSON deserializes sets as tuples, so convert back to a set
         vars  == {dump["vars"][i] : i \in DOMAIN dump["vars"]}

--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTrace.tla
@@ -32,8 +32,10 @@ _TLCTrace ==
 ----------------------------------------------------------------------------
 \* Deserialize a trace created by _TLCTrace above.
 
+CONSTANT _TLCTraceInputFile   \* Used by -loadTrace tlc
+
 LOCAL _TLCTraceFileDeserialized ==
-    _TLCTraceDeserialize(_TLCTraceFile)
+    _TLCTraceDeserialize(_TLCTraceInputFile)
 
 \* This operator has a Java module override (tlc2.module._TLCTrace#tlcState).
 LOCAL _TLCState(level) ==

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -663,13 +663,13 @@ public class TLC {
 						final List<Constraint> computeIfAbsent = (List<Constraint>) params
 								.computeIfAbsent(ParameterizedSpecObj.CONSTRAINTS, k -> new ArrayList<Constraint>());
 						computeIfAbsent.add(
-								new Constraint("_TLCTrace", "_TLCTraceConstraint", "_TLCTraceFile", args[index++]));
+								new Constraint("_TLCTrace", "_TLCTraceConstraint", "_TLCTraceInputFile", args[index++]));
 					} else if ("json".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<Constraint> computeIfAbsent = (List<Constraint>) params
 								.computeIfAbsent(ParameterizedSpecObj.CONSTRAINTS, k -> new ArrayList<Constraint>());
 						computeIfAbsent.add(
-								new Constraint("_JsonTrace", "_JsonTraceConstraint", "_JsonTraceFile", args[index++]));
+								new Constraint("_JsonTrace", "_JsonTraceConstraint", "_JsonTraceInputFile", args[index++]));
 					} else {
 						printErrorMsg("Error: Unknown format " + fmt + " given to -loadTrace.");
 						return false;

--- a/tlatools/org.lamport.tlatools/test/tlc2/debug/Debug05SimTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/debug/Debug05SimTest.java
@@ -99,8 +99,8 @@ public class Debug05SimTest extends TLCDebuggerTestCase {
 			ea.setFrameId(stackFrame.getId());
 
 			String traceFile = "Debug05SimTest.json";
-			ea.setExpression(
-					"LET J == INSTANCE _JsonTrace WITH _JsonTraceFile <- \"" + traceFile + "\" IN J!_JsonTrace");
+			ea.setExpression("LET J == INSTANCE _JsonTrace WITH _JsonTraceFile <- \"" + traceFile
+					+ "\", _JsonTraceInputFile <- \"" + traceFile + "\" IN J!_JsonTrace");
 			assertEquals("TRUE", debugger.evaluate(ea).get().getResult());
 
 			// Validate the content of the generated file (by using the very functionality
@@ -112,8 +112,8 @@ public class Debug05SimTest extends TLCDebuggerTestCase {
 			// 88888888888888888888888888888888888888888888888888888 //
 			
 			traceFile = "Debug05SimTest.bin";
-			ea.setExpression(
-					"LET J == INSTANCE _TLCTrace WITH _TLCTraceFile <- \"" + traceFile + "\" IN J!_TLCTrace");
+			ea.setExpression("LET J == INSTANCE _TLCTrace WITH _TLCTraceFile <- \"" + traceFile
+					+ "\", _TLCTraceInputFile <- \"" + traceFile + "\" IN J!_TLCTrace");
 			assertEquals("TRUE", debugger.evaluate(ea).get().getResult());
 
 			// 88888888888888888888888888888888888888888888888888888 //


### PR DESCRIPTION
Enable a trace replay workflow in TLC. Users can now load an existing trace with `-loadTrace`, replay it in TLC while applying a new ALIAS, and dump the resulting derived trace in the same run.

This allows TLC to act as a single-step trace post-processing or conversion tool by supporting `-loadTrace` and `-dumpTrace` together.

The constant name `_JsonTraceFile` remains unchanged to preserve backward compatibility.

Part of Github PR #1293
https://github.com/tlaplus/tlaplus/pull/1293

[Feature][TLC]