### PR TITLE
Upload tla2tools.jar as separate artifact in PR workflow.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -64,6 +64,12 @@ jobs:
       with:
           check_name: JUnit Test Report on ${{ matrix.operating-system }}
           report_paths: 'tlatools/org.lamport.tlatools/target/surefire-reports/TEST-*.xml'
+    - name: Upload tla2tools.jar
+      uses: actions/upload-artifact@v4
+      if: matrix.operating-system == 'ubuntu-latest'
+      with:
+          name: tla2tools
+          path: tlatools/org.lamport.tlatools/dist/tla2tools.jar
     - name: Clone tlaplus/CommunityModules
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
In addition to the Toolbox artifacts, the PR workflow now uploads tla2tools.jar as a separate artifact. While tla2tools.jar can be extracted from the Toolbox artifacts, the CLI tools jar is only a few MBs, whereas the Toolbox artifacts are an order of magnitude larger. This allows easier access to the built jar for testing without downloading the much larger Toolbox packages.

[Build]