### PR TITLE
Remove RMI dependency from FPSet for CheerpJ compatibility

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/FPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/FPSet.java
@@ -6,9 +6,7 @@
 package tlc2.tool.fp;
 
 import java.io.IOException;
-import java.rmi.NoSuchObjectException;
 import java.rmi.RemoteException;
-import java.rmi.server.UnicastRemoteObject;
 
 import tlc2.tool.TLCTrace;
 import tlc2.tool.distributed.fp.DistributedFPSet;
@@ -23,7 +21,7 @@ import tlc2.util.LongVec;
  * guarantee that their methods are thread-safe.
  */
 @SuppressWarnings("serial")
-public abstract class FPSet extends UnicastRemoteObject implements FPSetRMI
+public abstract class FPSet implements FPSetRMI
 {
 	/**
 	 * Size of a Java long in bytes
@@ -214,11 +212,9 @@ public abstract class FPSet extends UnicastRemoteObject implements FPSetRMI
 	}
 
 	/**
-	 * @see UnicastRemoteObject#unexportObject(java.rmi.Remote, boolean)
-	 * @param force
-	 * @throws NoSuchObjectException
+	 * No-op: RMI export/unexport not needed for non-distributed TLC.
 	 */
-	public void unexportObject(boolean force) throws NoSuchObjectException {
-		UnicastRemoteObject.unexportObject(this, force);
+	public void unexportObject(boolean force) {
+		// no-op: RMI not used
 	}
 }

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/MultiFPSet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/MultiFPSet.java
@@ -5,9 +5,7 @@
 package tlc2.tool.fp;
 
 import java.io.IOException;
-import java.rmi.NoSuchObjectException;
 import java.rmi.RemoteException;
-import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -143,11 +141,10 @@ public class MultiFPSet extends FPSet {
 	/* (non-Javadoc)
 	 * @see tlc2.tool.fp.FPSet#unexportObject(boolean)
 	 */
-	public void unexportObject(boolean force) throws NoSuchObjectException {
+	public void unexportObject(boolean force) {
 		for (FPSet fpSet : sets) {
 			fpSet.unexportObject(force);
 		}
-		UnicastRemoteObject.unexportObject(this, force);
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
FPSet extended UnicastRemoteObject which triggers native RMI library loading on construction. CheerpJ (Java-in-browser via WebAssembly) does not support native RMI sockets.

Change `FPSet` to implement `Serializable` instead of extending `UnicastRemoteObject`. The `unexportObject` method becomes a no-op. This only affects distributed TLC which is on path of [deprecation](https://github.com/tlaplus/tlaplus/issues/718) anyways.

More info:
`FPSet` extended UnicastRemoteObject, which is an RMI class. On construction,  UnicastRemoteObject automatically calls `System.loadLibrary("rmi") `to load the native RMI library and exports the object for remote access over the network.
CheerpJ runs Java in WebAssembly in the browser — it has no native RMI library and no network sockets. So every time TLC created an `FPSet`, it crashed with `UnsatisfiedLinkError: no rmi in java.library.path`.