### PR TITLE
Trim whitespace from pre-comments text in XMLExporter test.

### DIFF
--- a/tlatools/org.lamport.tlatools/test/tla2sany/xml/TestXMLExporterModule.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/xml/TestXMLExporterModule.java
@@ -479,7 +479,7 @@ public class TestXMLExporterModule {
 
 		for (int i = 0; i < preCommentsNodes.getLength(); i++) {
 			Element preComment = (Element) preCommentsNodes.item(i);
-			String commentText = preComment.getTextContent();
+			String commentText = preComment.getTextContent().trim();
 
 			Element parent = (Element) preComment.getParentNode();
 			NodeList uniqueNames = parent.getElementsByTagName("uniquename");


### PR DESCRIPTION
getTextContent() includes whitespace from XML pretty-printing indentation around CDATA sections, causing exact string comparison to fail.