### PR TITLE
Migrate snapshot publishing from OSSRH to Central Publisher Portal.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,17 +250,17 @@ jobs:
         git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git --follow-tags --tags --force
 
       ##
-      ## Upload tla2tools.jar to OSS Sonatype.
+      ## Upload tla2tools.jar to Maven Central (via Central Publisher Portal).
       ##
-    - name: Upload to OSS Sonatype
+    - name: Upload to Maven Central
       if: matrix.operating-system == 'ubuntu-latest'
       continue-on-error: true
       run: |
            cd tlatools/org.lamport.tlatools/
            ## Strip packages from the tla2tools.jar fatjar that are declared dependencies of the maven package (see github.xml).
            zip -d dist/tla2tools.jar javax/\* com/\* META-INF/mailcap META-INF/javamail*
-           ## Upload tla2tools.jar maven packages to OSS Sonatype (see ossrh.xml.README).
-           mvn gpg:sign-and-deploy-file -Durl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryId=ossrh -DpomFile=ossrh.xml -Dfile=dist/tla2tools.jar -f ossrh.xml
+           ## Upload tla2tools.jar maven packages to Maven Central (see ossrh.xml.README).
+           mvn gpg:sign-and-deploy-file -Durl=https://central.sonatype.com/repository/maven-snapshots/ -DrepositoryId=ossrh -DpomFile=ossrh.xml -Dfile=dist/tla2tools.jar -f ossrh.xml
 
       ##
       ## Trigger build of CommunityModule as integration tests, unless it creates and endless 

--- a/tlatools/org.lamport.tlatools/ossrh.xml
+++ b/tlatools/org.lamport.tlatools/ossrh.xml
@@ -47,11 +47,11 @@
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
 		<repository>
 			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+			<url>https://central.sonatype.com/repository/maven-releases/</url>
 		</repository>
 	</distributionManagement>
 


### PR DESCRIPTION
In order to get it working, we will need a fresh token and enable snapshots on sonatype if they are not enabled yet. 

What you need to do to make this work:
1. Generate a new token: https://central.sonatype.com/usertoken
2. update the maven github secret MVN_SETTINGS_XML_2024:
```
  <settings>                                                
    <servers>
      <server>
        <id>ossrh</id>
        <username>...</username>
        <password>...</password>
      </server>
    </servers>
  </settings>
```
3. On sontype, enable snapshots for your namespace, go to [com/publishing/namespaces,](https://central.sonatype.com/publishing/namespaces)  find the org.lamport namespace, and select "Enable SNAPSHOTs" from the dropdown.

I was able to test it from my fork: https://github.com/FedericoPonzi/tlaplus/commit/10b64a25ee51d0ebee47498dc90bbce147070068 / ref run: https://github.com/FedericoPonzi/tlaplus/actions/runs/22020362786/job/63628412189 even though I used a simplified ci file, the upload command used is the same, so I expect it to work from master as well.
Fixes: #1220 