### PR TITLE
XML Exporter: don't dump exception if parsing fails

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -259,10 +259,12 @@ public class SANY {
       catch (ParseException e) 
       {
           // get here if either the TLAPlusParser.parse() threw a ParseException or spec.ParseErrors was not empty
+          spec.errorLevel = 2;
           throw new ParseException();
       }
       catch (Exception e) 
       {
+          spec.errorLevel = 2;
           out.log(LogLevel.ERROR, "\nFatal errors while parsing TLA+ spec in file %s\n", spec.getFileName());
           out.log(LogLevel.ERROR, e.toString());
           out.log(LogLevel.ERROR, spec.parseErrors.toString());


### PR DESCRIPTION
Before these changes, the XML Exporter would dump an XMLExportingException right to the console if module parsing failed. These changes ensure that does not happened, so users simply see the usual human-friendly SANY parsing failure messages. It makes use of SANY returning a nonzero exit code on failure. These changes also fixed two code paths which did not appropriately set the SANY error level.

[SANY][Bugfix][Feature]