### PR TITLE
Handle LetInNode in SpecProcessor#processConfigSpec and processConfigProps

### DIFF
--- a/tlatools/org.lamport.tlatools/test-model/LetDef1Boxed.tla
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef1Boxed.tla
@@ -1,0 +1,31 @@
+--------------------------- MODULE LetDef1Boxed ----------------------------
+VARIABLE
+    x
+vars == x
+x0 == x
+Init == x = TRUE
+Next == x' = ~x
+Spec == Init /\ [][Next]_vars
+
+Prop ==
+    LET
+        x1(x2) == x2
+    IN x1([][x']_x0)
+
+-----
+
+x1(def_arg) == def_arg
+
+Prop2 == x1([][x']_x0)
+
+Spec3 ==
+    LET
+        id(a) == a
+    IN id(Init /\ [][Next]_vars)
+
+Spec4 == x1(Init /\ [][Next]_vars)
+===========================================================================
+---- CONFIG LetDef1Boxed ----
+SPECIFICATION Spec
+PROPERTY Prop
+======

--- a/tlatools/org.lamport.tlatools/test-model/LetDef1Boxedb.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef1Boxedb.cfg
@@ -1,0 +1,4 @@
+\* Prop2 is the top-level equivalent of Prop (LET/IN).
+\* Exercises processConfigProps without LetInNode.
+SPECIFICATION Spec
+PROPERTY Prop2

--- a/tlatools/org.lamport.tlatools/test-model/LetDef1Boxedc.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef1Boxedc.cfg
@@ -1,0 +1,3 @@
+\* Spec3 wraps Init /\ [][Next]_vars through a LET-defined identity.
+\* Exercises processConfigSpec with LetInNode.
+SPECIFICATION Spec3

--- a/tlatools/org.lamport.tlatools/test-model/LetDef1Boxedd.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef1Boxedd.cfg
@@ -1,0 +1,3 @@
+\* Spec4 is the top-level equivalent of Spec3 (LET/IN).
+\* Exercises processConfigSpec without LetInNode.
+SPECIFICATION Spec4

--- a/tlatools/org.lamport.tlatools/test-model/LetDef2Boxed.tla
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef2Boxed.tla
@@ -1,0 +1,35 @@
+---- MODULE LetDef2Boxed ----
+VARIABLE
+    x
+vars == x
+x0 == x
+Init == x = TRUE
+Next == x' = ~x
+Spec == Init /\ [][Next]_vars
+
+x3(def_arg) == def_arg
+Prop ==
+    LET
+        x1(x2(_)) == x2([][x']_x0)
+    IN x1(x3)
+
+-------
+
+x2(def_arg) == def_arg
+x1(def_arg(_)) == def_arg([][x']_x0)
+Prop2 == x1(x2)
+
+s1(sa(_)) == sa(Init /\ [][Next]_vars)
+
+Spec3 ==
+    LET
+        id(a(_)) == a(Init /\ [][Next]_vars)
+    IN id(x3)
+
+Spec4 == s1(x3)
+
+====
+---- CONFIG LetDef2Boxed ----
+SPECIFICATION Spec
+PROPERTY Prop
+====

--- a/tlatools/org.lamport.tlatools/test-model/LetDef2Boxedb.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef2Boxedb.cfg
@@ -1,0 +1,4 @@
+\* Prop2 is the top-level equivalent of Prop (LET/IN).
+\* Exercises processConfigProps without LetInNode.
+SPECIFICATION Spec
+PROPERTY Prop2

--- a/tlatools/org.lamport.tlatools/test-model/LetDef2Boxedc.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef2Boxedc.cfg
@@ -1,0 +1,3 @@
+\* Spec3 wraps Init /\ [][Next]_vars through a LET-defined identity.
+\* Exercises processConfigSpec with LetInNode.
+SPECIFICATION Spec3

--- a/tlatools/org.lamport.tlatools/test-model/LetDef2Boxedd.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/LetDef2Boxedd.cfg
@@ -1,0 +1,3 @@
+\* Spec4 is the top-level equivalent of Spec3 (LET/IN).
+\* Exercises processConfigSpec without LetInNode.
+SPECIFICATION Spec4

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxedTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxedTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef1BoxedTest extends ModelCheckerTestCase {
+
+	public LetDef1BoxedTest() {
+		super("LetDef1Boxed", new String[] { "-config", "LetDef1Boxed.tla" }, EC.ExitStatus.VIOLATION_LIVENESS);
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "2", "0"));
+
+		assertTrue(recorder.recorded(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR));
+
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(2);
+		expectedTrace.add("x = TRUE");
+		expectedTrace.add("x = FALSE");
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace);
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxedbTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxedbTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef1BoxedbTest extends ModelCheckerTestCase {
+
+	public LetDef1BoxedbTest() {
+		super("LetDef1Boxed", new String[] { "-config", "LetDef1Boxedb.cfg" }, EC.ExitStatus.VIOLATION_LIVENESS);
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "2", "0"));
+
+		assertTrue(recorder.recorded(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR));
+
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(2);
+		expectedTrace.add("x = TRUE");
+		expectedTrace.add("x = FALSE");
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace);
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxedcTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxedcTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef1BoxedcTest extends ModelCheckerTestCase {
+
+	public LetDef1BoxedcTest() {
+		super("LetDef1Boxed", new String[] { "-config", "LetDef1Boxedc.cfg" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxeddTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef1BoxeddTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef1BoxeddTest extends ModelCheckerTestCase {
+
+	public LetDef1BoxeddTest() {
+		super("LetDef1Boxed", new String[] { "-config", "LetDef1Boxedd.cfg" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxedTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxedTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef2BoxedTest extends ModelCheckerTestCase {
+
+	public LetDef2BoxedTest() {
+		super("LetDef2Boxed", new String[] { "-config", "LetDef2Boxed.tla" }, EC.ExitStatus.VIOLATION_LIVENESS);
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "2", "0"));
+
+		assertTrue(recorder.recorded(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR));
+
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(2);
+		expectedTrace.add("x = TRUE");
+		expectedTrace.add("x = FALSE");
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace);
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxedbTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxedbTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef2BoxedbTest extends ModelCheckerTestCase {
+
+	public LetDef2BoxedbTest() {
+		super("LetDef2Boxed", new String[] { "-config", "LetDef2Boxedb.cfg" }, EC.ExitStatus.VIOLATION_LIVENESS);
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "2", "2", "0"));
+
+		assertTrue(recorder.recorded(EC.TLC_ACTION_PROPERTY_VIOLATED_BEHAVIOR));
+
+		assertTrue(recorder.recorded(EC.TLC_STATE_PRINT2));
+		final List<String> expectedTrace = new ArrayList<String>(2);
+		expectedTrace.add("x = TRUE");
+		expectedTrace.add("x = FALSE");
+		assertTraceWith(recorder.getRecords(EC.TLC_STATE_PRINT2), expectedTrace);
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxedcTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxedcTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef2BoxedcTest extends ModelCheckerTestCase {
+
+	public LetDef2BoxedcTest() {
+		super("LetDef2Boxed", new String[] { "-config", "LetDef2Boxedc.cfg" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxeddTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/LetDef2BoxeddTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class LetDef2BoxeddTest extends ModelCheckerTestCase {
+
+	public LetDef2BoxeddTest() {
+		super("LetDef2Boxed", new String[] { "-config", "LetDef2Boxedd.cfg" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+}


### PR DESCRIPTION
PR https://github.com/tlaplus/tlaplus/pull/1321 (commit 9b5afe73f) made TLC accept temporal formulas passed through top-level parameterized operators in SPECIFICATION and PROPERTY declarations (e.g., Prop2 == id([][x']_x0) where id is defined at module level).  However, the semantically equivalent LET/IN formulations were not supported (e.g., Prop == LET id(a) == a IN id([][x']_x0)).

The root cause is that neither processConfigSpec nor processConfigProps handled LetInNode.  When a SPECIFICATION or PROPERTY formula was a LET/IN expression, the LetInNode fell through to the level-based catch-all at the bottom of each method.  For processConfigSpec this meant the init/next-state decomposition never happened ("did not specify the initial state predicate"); for processConfigProps the temporal formula was added to impliedTemporalVec without structural decomposition, causing "TLC cannot handle the temporal formula" in the liveness checker.

Add LetInNode handlers that recurse on the body (the IN part).  The LET-defined operators need no explicit registration because SANY's AST links operator references in the body directly to their OpDefNode, so the existing OpApplNode handler and getOpContext inlining resolve them. This is the same pattern used for LetInKind throughout the codebase (Tool#getActions, getInitStates, getNextStates; Liveness#astToLive; Spec#collectPrimedLocs; SpecProcessor.SubscriptCollector#enter).

Tests cover two formula shapes, each in four variants: PROPERTY with LET/IN (a), PROPERTY with top-level equivalent (b), SPECIFICATION with LET/IN (c), SPECIFICATION with top-level equivalent (d).

Related to PR #1321
https://github.com/tlaplus/tlaplus/pull/1321

[Feature][TLC][Test]