### PR TITLE
Fix `EvaluatingValue` crash when used as constant operator substitute

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EvaluatingValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EvaluatingValue.java
@@ -213,6 +213,13 @@ public class EvaluatingValue extends OpValue {
     }
   }
 
+  @Override
+  public final IValue initialize() {
+	  this.deepNormalize();
+	  // compare MethodValue#initialize
+	  return this;
+  }
+
   public final boolean isDefined() { return true; }
 
   public final IValue deepCopy() { return this; }

--- a/tlatools/org.lamport.tlatools/test-model/ConstantRank1TLCEval.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ConstantRank1TLCEval.tla
@@ -1,0 +1,12 @@
+---- MODULE ConstantRank1TLCEval ----
+EXTENDS TLC
+CONSTANT x0(_)
+VARIABLE x
+Init == x = TRUE
+Next == x' = (x0({"A"} \union {"B"}) = {"C"})
+====
+---- CONFIG ConstantRank1TLCEval ----
+INIT Init
+NEXT Next
+CONSTANT x0 <- TLCEval
+====

--- a/tlatools/org.lamport.tlatools/test-model/ConstantRank2AssertError.tla
+++ b/tlatools/org.lamport.tlatools/test-model/ConstantRank2AssertError.tla
@@ -1,0 +1,12 @@
+---- MODULE ConstantRank2AssertError ----
+EXTENDS TLCExt
+CONSTANT x0(_, _)
+VARIABLE x
+Init == x = TRUE
+Next == x' = x0("no error", TRUE)
+====
+---- CONFIG ConstantRank2AssertError ----
+INIT Init
+NEXT Next
+CONSTANT x0 <- AssertError
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstantRank1TLCEvalTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstantRank1TLCEvalTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ConstantRank1TLCEvalTest extends ModelCheckerTestCase {
+
+	public ConstantRank1TLCEvalTest() {
+		super("ConstantRank1TLCEval", new String[] { "-config", "ConstantRank1TLCEval.tla" }, EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstantRank2AssertErrorTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/ConstantRank2AssertErrorTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class ConstantRank2AssertErrorTest extends ModelCheckerTestCase {
+
+	public ConstantRank2AssertErrorTest() {
+		super("ConstantRank2AssertError", new String[] { "-config", "ConstantRank2AssertError.tla" },
+				EC.ExitStatus.SUCCESS);
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() throws IOException {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recorded(EC.TLC_SUCCESS));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "2", "0"));
+	}
+}


### PR DESCRIPTION
When an `@Evaluation`-annotated operator is used as a constant operator substitute (e.g., `CONSTANT x0 <- TLCEval`), `SpecProcessor#processConstantDefns` calls `IValue#initialize` on the tool object of the constant declaration. The default `IValue#initialize` calls fingerPrint, which throws for operator values like `EvaluatingValue`.

```
Error: TLC threw an unexpected exception.
This was probably caused by an error in the spec or model.
See the User Output or TLC Console for clues to what happened.
The exception was a java.lang.RuntimeException
: TLC has found a state in which the value of a variable contains <Java Method: public static synchronized tlc2.value.impl.Value tlc2.module.TLCExt.assertError(tlc2.tool.impl.Tool,tla2sany.semantic.ExprOrOpArgNode[],tlc2.util.Context,tlc2.tool.TLCState,tlc2.tool.TLCState,int,tlc2.tool.coverage.CostModel)>
```

`MethodValue` already overrides initialize to skip the fingerPrint call, but `EvaluatingValue` was missing this override.

Regression of Github issue #648
https://github.com/tlaplus/tlaplus/issues/648

[Regression][TLC]