### PR TITLE
Assess severity of `FcnLambdaValue.toTuple()` ignores this.excepts

### DIFF
--- a/tlatools/org.lamport.tlatools/test-model/Github1145b.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/Github1145b.cfg
@@ -1,0 +1,3 @@
+INIT Init
+NEXT Next
+INVARIANT Inv

--- a/tlatools/org.lamport.tlatools/test-model/Github1145b.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github1145b.tla
@@ -1,0 +1,25 @@
+\* Regression test for https://github.com/tlaplus/tlaplus/issues/1145
+\*
+\* The trailing [1] function application (OPCODE_fa) sets EvalControl.KeepLazy,
+\* which propagates through F's body into the evaluation of the EXCEPT expression.
+\* KeepLazy prevents OPCODE_fc from eagerly converting the FcnLambdaValue to
+\* FcnRcdValue, so SubSeq receives a FcnLambdaValue whose toTuple()—before the
+\* fix—ignores the EXCEPT and returns <<0,0,0,0>> instead of <<0,1,0,0>>.
+\*
+\* With the fix:    x = 1, Inv is violated  → TLC reports VIOLATION_SAFETY.
+\* Without the fix: x = 0, Inv holds        → TLC reports SUCCESS (soundness bug).
+---- MODULE Github1145b ----
+
+EXTENDS Sequences, Naturals
+
+F(seq) == SubSeq(seq, 2, 2)
+
+VARIABLE x
+
+Init == x = F([[i \in 1..4 |-> 0] EXCEPT ![2] = 1])[1]
+
+Next == UNCHANGED x
+
+Inv == x # 1
+
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/Github1145bTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/Github1145bTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.output.EC.ExitStatus;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+/**
+ * Integration test for https://github.com/tlaplus/tlaplus/issues/1145
+ * (companion to the ASSUME-based Github1145Test).
+ *
+ * The spec computes a value through the buggy path: F([[i \in 1..4 |-> 0]
+ * EXCEPT ![2] = 1])[1] The trailing [1] (OPCODE_fa) sets EvalControl.KeepLazy,
+ * which prevents OPCODE_fc from eagerly converting the FcnLambdaValue to
+ * FcnRcdValue. SubSeq then calls FcnLambdaValue.toTuple(), which—before the
+ * fix—ignores the EXCEPT and computes x = 0 instead of x = 1.
+ *
+ * With the fix, x = 1 and the invariant x # 1 is violated in the initial state.
+ * Without the fix, x = 0 and TLC incorrectly reports success (a soundness bug).
+ */
+public class Github1145bTest extends ModelCheckerTestCase {
+
+	public Github1145bTest() {
+		super("Github1145b", ExitStatus.VIOLATION_SAFETY);
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_INVARIANT_VIOLATED_INITIAL, "Inv", "x = 1\n"));
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDump() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+}


### PR DESCRIPTION
Add tests reproducing FcnLambdaValue#toTuple ignoring excepts.

Add tests that deterministically reproduce the `FcnLambdaValue#toTuple` bug fixed in PR #1146, where `toTuple()` evaluated the body directly via `tool.eval()` and ignored the excepts array. These tests guard against regressions and document the failure mode.

#### Github1145bTest (soundness):
Model-checks a spec where `F([[i \in 1..4 |-> 0] EXCEPT ![2] = 1])[1]` is stored in a state variable `x`. The invariant `x # 1` should be violated, but the buggy `toTuple()` causes TLC to compute `x = 0` and miss the counterexample.

#### FcnLambdaValueTest:
- testToTupleWithExceptIntervalDomain:
   toTuple() on [x \in 1..3 |-> 42] EXCEPT ![2] = 99 must yield
   <<42, 99, 42>>, not <<42, 42, 42>> (IntervalValue branch)
- testToTupleWithExceptSetEnumDomain:
   same assertion for the SetEnumValue branch
- testToTupleWithExceptFP:
   fingerprint of toTuple() result must match a freshly constructed
   correct tuple, i.e., equivalent values hash identically (soundness)

Part of Github issue #1145
https://github.com/tlaplus/tlaplus/issues/1145

Part of Github PR #1146
https://github.com/tlaplus/tlaplus/pull/1146

[Test][TLC]