### PR TITLE
Add -suppressMessages and -warningsAsErrors CLI flags to SANY

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -5,13 +5,17 @@ package tla2sany.drivers;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import tla2sany.explorer.Explorer;
 import tla2sany.explorer.ExplorerQuitException;
 import tla2sany.linter.Linter;
 import tla2sany.modanalyzer.ParseUnit;
 import tla2sany.modanalyzer.SpecObj;
+import tla2sany.semantic.ErrorCode;
 import tla2sany.output.LogLevel;
 import tla2sany.output.OutErrSanyOutput;
 import tla2sany.output.SanyOutput;
@@ -90,6 +94,16 @@ public class SANY {
   private static final boolean doValidatePCalTranslationDefault = true;
 
   /**
+   * Set of message codes to silence by default
+   */
+  private static final Set<ErrorCode> defaultSuppressedCodes = Set.of();
+
+  /**
+   * Set of message codes to elevate to errors by default
+   */
+  private static final Set<ErrorCode> defaultMessagesAsErrorCodes = Set.of();
+
+  /**
    * Use {@link SANY#frontEndMain(SpecObj, String, SanyOutput, SanySettings)}
    * instead for greater control of output and settings. This method will
    * print all human-readable log messages to the provided syserr parameter.
@@ -117,7 +131,9 @@ public class SANY {
         doSemanticAnalysis,
         doLevelChecking,
         doLinting,
-        doValidatePCalTranslationDefault
+        doValidatePCalTranslationDefault,
+        defaultSuppressedCodes,
+        defaultMessagesAsErrorCodes
       );
     return parse(spec, fileName, out, settings).code();
   }
@@ -173,15 +189,24 @@ public class SANY {
       frontEndInitialize();
     
       // **** Parsing 
-      frontEndParse(spec, out, settings.validatePCalTranslation);
+      frontEndParse(spec, out, settings);
     
       // **** Semantic analysis and level checking
       if (settings.doSemanticAnalysis) 
-            {frontEndSemanticAnalysis(spec, out, settings.doLevelChecking);} ;
+            {frontEndSemanticAnalysis(spec, out, settings);} ;
 
       // **** Linting
-      if (settings.doLinting) 
-            {frontEndLinting(spec, out); } ;
+      if (settings.doLinting) {
+        final int warnsBefore = spec.semanticErrors.getWarningDetails().size();
+        frontEndLinting(spec, out);
+        // Print linting warnings, respecting suppressed/elevated codes.
+        final List<ErrorDetails> allWarnings = spec.semanticErrors.getWarningDetails();
+        final List<ErrorDetails> lintingWarnings = allWarnings.subList(warnsBefore, allWarnings.size());
+        final boolean errorElevated = reportMessages(out, filterVisibleMessages(lintingWarnings, settings), settings);
+        if (errorElevated) {
+          spec.errorLevel = SanyExitCode.SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE.code();
+        }
+      }
 
     }
     catch (ParseException pe) {
@@ -200,6 +225,43 @@ public class SANY {
         : SanyExitCode.OK;
   }
 
+  /**
+   * Checks if a message should be treated as an error.
+   */
+  private static boolean isMessageElevated(ErrorDetails message, SanySettings settings) {
+    return settings.messagesAsErrorCodes.contains(message.getCode());
+  }
+
+  /**
+   * Filters the visible messages based on the settings.
+   */
+  private static List<ErrorDetails> filterVisibleMessages(List<ErrorDetails> messages, SanySettings settings) {
+    return messages.stream()
+        .filter(w -> !settings.suppressedCodes.contains(w.getCode()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Reports the messages to the output. Returns true if any elevated messages were encountered.
+   */
+  private static boolean reportMessages(SanyOutput out, List<ErrorDetails> messages, SanySettings settings) {
+    boolean errorElevated = false;
+    // Print non-elevated messages first.
+    for (ErrorDetails message : messages) {
+      if (!isMessageElevated(message, settings)) {
+        out.log(LogLevel.WARNING, "%s\n\n\n", message);
+      }
+    }
+    // Print elevated messages as errors.
+    for (ErrorDetails message : messages) {
+      if (isMessageElevated(message, settings)) {
+        out.log(LogLevel.ERROR, "Warning treated as error: %s\n\n\n", message);
+        errorElevated = true;
+      }
+    }
+    return errorElevated;
+  }
+
   /** 
    * Initialize the all parts of the FrontEnd to handle a new specification.
    */
@@ -208,7 +270,7 @@ public class SANY {
   } // frontEndInitialize
 
   /**
-   * Use {@link SANY#frontEndParse(SpecObj, SanyOutput)} instead for greater
+   * Use {@link SANY#frontEndParse(SpecObj, SanyOutput, SanySettings)} instead for greater
    * control of output.
    */
   @Deprecated
@@ -224,7 +286,7 @@ public class SANY {
   }
 
   /**
-   * Use {@link SANY#frontEndParse(SpecObj, SanyOutput, boolean)} instead for greater
+   * Use {@link SANY#frontEndParse(SpecObj, SanyOutput, SanySettings)} instead for greater
    * control of output.
    */
   @Deprecated
@@ -233,7 +295,29 @@ public class SANY {
     frontEndParse(spec, new SimpleSanyOutput(sysErr, LogLevel.INFO), validatePCalTranslation);
   }
 
-  public static void frontEndParse(SpecObj spec, SanyOutput out, boolean validatePCalTranslation) 
+  /**
+   * Use {@link SANY#frontEndParse(SpecObj, SanyOutput, SanySettings)} instead.
+   */
+  @Deprecated
+  public static void frontEndParse(SpecObj spec, SanyOutput out, boolean validatePCalTranslation)
+  throws ParseException {
+    SanySettings settings = new SanySettings(
+      doStrictErrorCodes,
+      doSemanticAnalysis,
+      doLevelChecking,
+      doLinting,
+      validatePCalTranslation,
+      defaultSuppressedCodes,
+      defaultMessagesAsErrorCodes
+    );
+
+    frontEndParse(spec, out, settings);
+  }
+
+  /**
+   * Parses the specification.
+   */
+  public static void frontEndParse(SpecObj spec, SanyOutput out, SanySettings settings)
   throws ParseException {
       /***********************************************************************
        * Modified on 12 May 2008 by LL to remove "throws AbortException",     *
@@ -243,13 +327,16 @@ public class SANY {
       try 
       {
           // Actual parsing method called from inside loadSpec()
-          spec.loadSpec(spec.getFileName(), spec.parseErrors, validatePCalTranslation, out);
+          spec.loadSpec(spec.getFileName(), spec.parseErrors, settings.validatePCalTranslation, out);
 
           List<ErrorDetails> warnings = spec.parseErrors.getWarningDetails();
-          if (!warnings.isEmpty()) {
-            out.log(LogLevel.WARNING, "Warnings (%d) during syntax parsing of %s:\n\n", warnings.size(), spec.getFileName());
-            for (ErrorDetails warning : warnings) {
-              out.log(LogLevel.WARNING, "%s\n\n\n", warning);
+          // Filter and display warnings, respecting suppressed/elevated codes.
+          final List<ErrorDetails> visibleWarnings = filterVisibleMessages(warnings, settings);
+          if (!visibleWarnings.isEmpty()) {
+            out.log(LogLevel.WARNING, "Warnings (%d) during syntax parsing of %s:\n\n", visibleWarnings.size(), spec.getFileName());
+            final boolean errorElevated = reportMessages(out, visibleWarnings, settings);
+            if (errorElevated) {
+              spec.errorLevel = SanyExitCode.SYNTAX_PARSING_FAILURE.code();
             }
           }
 
@@ -279,7 +366,7 @@ public class SANY {
   } //
 
   /**
-   * Use {@link SANY#frontEndSemanticAnalysis(SpecObj, SanyOutput, boolean)}
+   * Use {@link SANY#frontEndSemanticAnalysis(SpecObj, SanyOutput, SanySettings)}
    * for greater control over output.
    */
   @Deprecated
@@ -290,9 +377,32 @@ public class SANY {
     frontEndSemanticAnalysis(spec, new SimpleSanyOutput(syserr, LogLevel.INFO), levelCheck);
   }
 
+  /**
+   * Use {@link SANY#frontEndSemanticAnalysis(SpecObj, SanyOutput, SanySettings)} instead.
+   */
+  @Deprecated
   public static void frontEndSemanticAnalysis(SpecObj spec,
                                               SanyOutput out,
                                               boolean levelCheck) 
+  throws SemanticException {
+    SanySettings settings = new SanySettings(
+      doStrictErrorCodes,
+      doSemanticAnalysis,
+      levelCheck,
+      doLinting,
+      doValidatePCalTranslationDefault,
+      defaultSuppressedCodes,
+      defaultMessagesAsErrorCodes
+    );
+    frontEndSemanticAnalysis(spec, out, settings);
+  }
+
+  /**
+   * Performs semantic analysis on the specification.
+   */
+  public static void frontEndSemanticAnalysis(SpecObj spec,
+                                              SanyOutput out,
+                                              SanySettings settings)
   throws SemanticException {
     String      moduleStringName;
     TreeNode    syntaxTreeRoot;
@@ -314,7 +424,7 @@ public class SANY {
         // if semantic analysis has not already been done on this module
         if (externalModuleTable.getContext( UniqueString.uniqueStringOf( moduleStringName)) == null ) {
           parseUnit = (ParseUnit)spec.parseUnitContext.get(moduleStringName);;
-      
+
           // get reference to the syntax tree for the module
           syntaxTreeRoot = parseUnit.getParseTree();
 
@@ -351,7 +461,7 @@ public class SANY {
                                   moduleNode);
   
           // Level check if semantic analysis succeeded and levelCheck is true.
-          if (moduleNode != null && semanticErrors.isSuccess() && levelCheck ) {
+          if (moduleNode != null && semanticErrors.isSuccess() && settings.doLevelChecking ) {
             moduleNode.levelCheck(semanticErrors);
           }
 
@@ -362,8 +472,25 @@ public class SANY {
           }
 
           if (semanticErrors.getNumMessages() > 0) {
-            // TODO: split warnings & errors out into appropriate log level
-            out.log(LogLevel.ERROR, "Semantic errors:\n\n%s", semanticErrors);
+            // Print warnings, respecting suppressed/elevated codes
+            final List<ErrorDetails> allWarnings = semanticErrors.getWarningDetails();
+            final List<ErrorDetails> visibleWarnings = filterVisibleMessages(allWarnings, settings);
+            if (!visibleWarnings.isEmpty()) {
+              out.log(LogLevel.WARNING, "*** Warnings: %d\n", visibleWarnings.size());
+              final boolean errorElevated = reportMessages(out, visibleWarnings, settings);
+              if (errorElevated) {
+                spec.errorLevel = SanyExitCode.SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE.code();
+              }
+            }
+
+            // Print errors at ERROR level.
+            final List<ErrorDetails> errors = semanticErrors.getErrorDetails();
+            if (!errors.isEmpty()) {
+              out.log(LogLevel.ERROR, "Semantic errors:\n\n*** Errors: %d\n", errors.size());
+              for (ErrorDetails error : errors) {
+                out.log(LogLevel.ERROR, "%s\n\n", error);
+              }
+            }
 
             // indicate fatal error during semantic analysis or level-checking
             if ( semanticErrors.getNumErrors() > 0 ) {
@@ -428,6 +555,17 @@ public class SANY {
           "'2' Error during parsing.\n" +
           "'4' Error during semantic analysis or level-checking.", true));
       variant.add(new UsageGenerator.Argument(
+          "-suppressMessages", "codes",
+          "Suppress specific messages; comma-separated list of message codes.\n" +
+          "Suppressed messages are not printed and do not cause SANY to fail.\n" + 
+          "Errors cannot be suppressed.\n " +
+          "Message codes can be found in https://github.com/tlaplus/tlaplus/blob/master/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java#L38", true));
+      variant.add(new UsageGenerator.Argument(
+          "-messagesAsErrors", "codes",
+          "Treat specific message codes as errors; comma-separated list of message codes.\n" +
+          "When triggered, SANY exits with failure.\n" +
+          "Message codes can be found in https://github.com/tlaplus/tlaplus/blob/master/tlatools/org.lamport.tlatools/src/tla2sany/semantic/ErrorCode.java#L38", true));
+      variant.add(new UsageGenerator.Argument(
           "-d", "Opens the semantic graph explorer prompt. The prompt accepts the following commands:\n" +
           "'cst' Prints out the concrete syntax tree.\n" +
           "'dot' Emits the semantic graph to a ModuleName.dot file in the DOT graph" +
@@ -470,6 +608,12 @@ public class SANY {
       printUsage();
       throw new SANYExitException(SanyExitCode.ERROR, "No arguments provided");
     }
+    // set of message codes to silence; populated by -suppressMessages CLI flag
+    final Set<ErrorCode> suppressedCodes = new HashSet<>();
+
+    // set of message codes to elevate to errors; populated by -messagesAsErrors CLI flag
+    final Set<ErrorCode> messagesAsErrorCodes = new HashSet<>();
+
     int i;
     // Parse and process the command line switches, which are
     // distinguished by the fact that they begin with a '-' character.
@@ -490,6 +634,52 @@ public class SANY {
       }
       else if (args[i].toLowerCase().equals("-error-codes"))
            doStrictErrorCodes = true;
+      else if (args[i].toLowerCase().equals("-suppressmessages")) {
+           i++;
+           if (i >= args.length) {
+             ToolIO.out.println("Error: -suppressMessages requires a comma-separated list of codes.");
+             throw new SANYExitException(SanyExitCode.ERROR, "-suppressMessages requires an argument");
+           }
+           for (String token : args[i].split(",")) {
+             token = token.trim();
+             try {
+               final int code = Integer.parseInt(token);
+               final ErrorCode messageCode = ErrorCode.fromStandardValue(code); // validate; throws if unknown
+               if (messageCode.getSeverityLevel() == ErrorCode.ErrorLevel.ERROR) {
+                 ToolIO.out.println("Error: -suppressMessages: code " + token + " is an error and cannot be suppressed.");
+                 throw new SANYExitException(SanyExitCode.ERROR, "-suppressMessages: unsuppressable code: " + token);
+               }
+               suppressedCodes.add(messageCode);
+             } catch (NumberFormatException nfe) {
+               ToolIO.out.println("Error: -suppressMessages: not an integer: " + token);
+               throw new SANYExitException(SanyExitCode.ERROR, "-suppressMessages: not an integer: " + token);
+             } catch (IllegalArgumentException iae) {
+               ToolIO.out.println("Error: -suppressMessages: unknown message code: " + token);
+               throw new SANYExitException(SanyExitCode.ERROR, "-suppressMessages: unknown code: " + token);
+             }
+           }
+      }
+      else if (args[i].toLowerCase().equals("-messagesaserrors")) {
+           i++;
+           if (i >= args.length) {
+             ToolIO.out.println("Error: -messagesAsErrors requires a comma-separated list of codes.");
+             throw new SANYExitException(SanyExitCode.ERROR, "-messagesAsErrors requires an argument");
+           }
+           for (String token : args[i].split(",")) {
+             token = token.trim();
+             try {
+               final int code = Integer.parseInt(token);
+               final ErrorCode errorCode = ErrorCode.fromStandardValue(code); // validate; throws if unknown
+               messagesAsErrorCodes.add(errorCode);
+             } catch (NumberFormatException nfe) {
+               ToolIO.out.println("Error: -messagesAsErrors: not an integer: " + token);
+               throw new SANYExitException(SanyExitCode.ERROR, "-messagesAsErrors: not an integer: " + token);
+             } catch (IllegalArgumentException iae) {
+               ToolIO.out.println("Error: -messagesAsErrors: unknown message code: " + token);
+               throw new SANYExitException(SanyExitCode.ERROR, "-messagesAsErrors: unknown code: " + token);
+             }
+           }
+      }
       else if (args[i].toLowerCase().equals("-help")) {
            printUsage();
            return;
@@ -504,6 +694,17 @@ public class SANY {
       ToolIO.out.println("At least 1 filename is required.");
       ToolIO.out.println("Try 'SANY -help' for more information.");
       throw new SANYExitException(SanyExitCode.ERROR, "No filename provided");
+    }
+
+    // Check that suppressMessages and messagesAsErrors do not intersect and report an error if they do.
+    Set<ErrorCode> intersection = new HashSet<>(suppressedCodes);
+    intersection.retainAll(messagesAsErrorCodes);
+    if (!intersection.isEmpty()) {
+        ToolIO.out.println("Error: The following codes were set to both -suppressMessages and -messagesAsErrors: " + intersection);
+        throw new SANYExitException(
+            SanyExitCode.ERROR,
+            "Options -suppressMessages and -messagesAsErrors overlap for codes: " + intersection
+        );
     }
 
     final SanyOutput out = new OutErrSanyOutput(
@@ -538,7 +739,9 @@ public class SANY {
                   SANY.doSemanticAnalysis,
                   SANY.doLevelChecking,
                   SANY.doLinting,
-                  SANY.doValidatePCalTranslationDefault
+                  SANY.doValidatePCalTranslationDefault,
+                  suppressedCodes,
+                  messagesAsErrorCodes
               );
               final SanyExitCode result = parse(spec, args[i], out, settings);
               if (result != SanyExitCode.OK) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SanySettings.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SanySettings.java
@@ -22,6 +22,10 @@
  ******************************************************************************/
 package tla2sany.drivers;
 
+import java.util.Set;
+
+import tla2sany.semantic.ErrorCode;
+
 /**
  * Encapsulates various settings controlling SANY execution. This is intended
  * to replace global static settings derived from parsing command line args
@@ -70,6 +74,20 @@ public final class SanySettings {
   public final boolean validatePCalTranslation;
 
   /**
+   * The set of error codes whose messages should be silenced (not printed).
+   * An empty set means all messages are shown. Messages with codes in this
+   * set are neither printed nor cause SANY to fail.
+   */
+  public final Set<ErrorCode> suppressedCodes;
+
+  /**
+   * The set of message codes that should be elevated to errors. An empty set
+   * means no messages are elevated. When a message with a code in this set is
+   * encountered, SANY will treat it as an error.
+   */
+  public final Set<ErrorCode> messagesAsErrorCodes;
+
+  /**
    * Sensible default settings with meaningful error codes and all stages of
    * the validation process enabled. A good choice when you intend to present
    * SANY warnings & errors directly to the user.
@@ -77,7 +95,7 @@ public final class SanySettings {
    * @return A {@link SanySettings} instance with sensible default settings.
    */
   public static SanySettings defaultSettings() {
-    return new SanySettings(true, true, true, true);
+    return new SanySettings(true, true, true, true, Set.of(), Set.of());
   }
 
   /**
@@ -90,11 +108,13 @@ public final class SanySettings {
    * @return A {@link SanySettings} instance for only producing a valid AST.
    */
   public static SanySettings validAstSettings() {
-    return new SanySettings(true, true, false, false);
+    return new SanySettings(true, true, false, false, Set.of(), Set.of());
   }
 
   /**
    * Use this constructor if you want full control over SANY settings.
+   * The new {@code suppressedCodes} and {@code messagesAsErrorCodes} sets
+   * default to empty (no suppression, no elevation).
    */
   public SanySettings(
       final boolean doSemanticAnalysis,
@@ -106,7 +126,31 @@ public final class SanySettings {
         doSemanticAnalysis,
         doLevelChecking,
         doLinting,
-        validatePCalTranslation
+        validatePCalTranslation,
+        Set.of(),
+        Set.of()
+      );
+  }
+
+  /**
+   * Use this constructor if you want full control over SANY settings,
+   * including per-code message suppression and elevation.
+   */
+  public SanySettings(
+      final boolean doSemanticAnalysis,
+      final boolean doLevelChecking,
+      final boolean doLinting,
+      final boolean validatePCalTranslation,
+      final Set<ErrorCode> suppressedCodes,
+      final Set<ErrorCode> messagesAsErrorCodes) {
+    this(
+        true,
+        doSemanticAnalysis,
+        doLevelChecking,
+        doLinting,
+        validatePCalTranslation,
+        suppressedCodes,
+        messagesAsErrorCodes
       );
   }
 
@@ -120,11 +164,15 @@ public final class SanySettings {
       final boolean doSemanticAnalysis,
       final boolean doLevelChecking,
       final boolean doLinting,
-      final boolean validatePCalTranslation) {
+      final boolean validatePCalTranslation,
+      final Set<ErrorCode> suppressedCodes,
+      final Set<ErrorCode> messagesAsErrorCodes) {
     this.doStrictErrorCodes = doStrictErrorCodes;
     this.doSemanticAnalysis = doSemanticAnalysis;
     this.doLevelChecking = doLevelChecking;
     this.doLinting = doLinting;
     this.validatePCalTranslation = validatePCalTranslation;
+    this.suppressedCodes = suppressedCodes != null ? Set.copyOf(suppressedCodes) : Set.of();
+    this.messagesAsErrorCodes = messagesAsErrorCodes != null ? Set.copyOf(messagesAsErrorCodes) : Set.of();
   }
 }

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IllegalOperatorTest.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IllegalOperatorTest.java
@@ -42,11 +42,9 @@ public class IllegalOperatorTest  {
 		SANY.SANYmain(
 				new String[] { CommonTestCase.BASE_PATH + "IllegalOperatorTest" });
 		
-		testPrintStream.assertSubstring("*** Errors: 1\n" + 
-				"\n" + 
-				"line 3, col 8 to line 3, col 11 of module IllegalOperatorTest\n" + 
-				"\n" + 
-				"Argument number 1 to operator 'D' \n" + 
-				"should be a 1-parameter operator.");
+		testPrintStream.assertSubstring("*** Errors: 1\n");
+		testPrintStream.assertSubstring("line 3, col 8 to line 3, col 11 of module IllegalOperatorTest\n");
+		testPrintStream.assertSubstring("Argument number 1 to operator 'D' \n");
+		testPrintStream.assertSubstring("should be a 1-parameter operator.");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/WarningControlTest.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/WarningControlTest.java
@@ -1,0 +1,267 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+package tla2sany.drivers;
+
+import java.io.File;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tlc2.tool.CommonTestCase;
+import tla2sany.SANYTest;
+import tla2sany.modanalyzer.SpecObj;
+import tla2sany.output.LogLevel;
+import tla2sany.output.RecordedSanyOutput;
+import tla2sany.semantic.ErrorCode;
+import util.SimpleFilenameToStream;
+import util.TestPrintStream;
+import util.ToolIO;
+
+/**
+ * Tests for the {@code -suppressMessages} and {@code -messagesAsErrors} CLI
+ * flags and corresponding {@link SanySettings} API fields, as part of GitHub
+ * issue #1186.
+ *
+ * <p>The fixture spec {@code W4802_Pre_Test.tla} triggers warning 4802
+ * ({@link ErrorCode#RECORD_CONSTRUCTOR_FIELD_NAME_CLASH}) reliably: it defines
+ * {@code Foo == TRUE} and then constructs {@code [Foo |-> 42]}, where the field
+ * name {@code Foo} clashes with the existing definition.
+ */
+public class WarningControlTest extends SANYTest {
+
+  private static final String TEST_SPEC_DIR = CommonTestCase.BASE_DIR + File.separator +
+      "test" + File.separator + "tla2sany" + File.separator + "semantic" + File.separator + 
+      "error_corpus" + File.separator;
+  private static final String TEST_SPEC_PATH = TEST_SPEC_DIR + "W4802_Pre_Test.tla";
+
+  private static final ErrorCode CODE_4802 = ErrorCode.RECORD_CONSTRUCTOR_FIELD_NAME_CLASH;
+
+  // ── API-level tests: SANY.parse() + SanySettings ─────────────────────────
+
+  /**
+   * Baseline: with default settings the warning fires and SANY succeeds.
+   */
+  @Test
+  public void testWarningAppearsWithDefaultSettings() throws Exception {
+    final RecordedSanyOutput out = new RecordedSanyOutput(LogLevel.WARNING);
+    final SpecObj spec = new SpecObj(TEST_SPEC_PATH, new SimpleFilenameToStream(TEST_SPEC_DIR));
+    final SanyExitCode result = SANY.parse(spec, TEST_SPEC_PATH, out, SanySettings.defaultSettings());
+
+    Assert.assertEquals(SanyExitCode.OK, result);
+    Assert.assertTrue("Expected field-name-clash warning in output",
+        out.getMessages().stream()
+            .anyMatch(m -> m.getLevel() == LogLevel.WARNING
+                        && m.getText().contains("Foo")));
+  }
+
+  /**
+   * Suppressing code 4802 via {@link SanySettings#suppressedCodes} silences
+   * the warning and SANY still succeeds.
+   */
+  @Test
+  public void testSuppressMessagesViaSettings() throws Exception {
+    final RecordedSanyOutput out = new RecordedSanyOutput(LogLevel.WARNING);
+    final SpecObj spec = new SpecObj(TEST_SPEC_PATH, new SimpleFilenameToStream(TEST_SPEC_DIR));
+    final SanySettings settings = new SanySettings(
+        true, true, true, true,
+        Set.of(CODE_4802),
+        Set.of());
+    final SanyExitCode result = SANY.parse(spec, TEST_SPEC_PATH, out, settings);
+
+    Assert.assertEquals(SanyExitCode.OK, result);
+    Assert.assertFalse("Expected no warnings in output when code is suppressed",
+        out.getMessages().stream().anyMatch(m -> m.getLevel() == LogLevel.WARNING));
+  }
+
+  /**
+   * Elevating code 4802 via {@link SanySettings#messagesAsErrorCodes} causes
+   * {@link SanyExitCode#SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE} and emits
+   * a "Warning treated as error" message at ERROR level.
+   */
+  @Test
+  public void testMessagesAsErrorsViaSettings() throws Exception {
+    final RecordedSanyOutput out = new RecordedSanyOutput(LogLevel.WARNING);
+    final SpecObj spec = new SpecObj(TEST_SPEC_PATH, new SimpleFilenameToStream(TEST_SPEC_DIR));
+    final SanySettings settings = new SanySettings(
+        true,         // doStrictErrorCodes
+        true, true, true, true,
+        Set.of(),
+        Set.of(CODE_4802));
+    final SanyExitCode result = SANY.parse(spec, TEST_SPEC_PATH, out, settings);
+
+    Assert.assertEquals(SanyExitCode.SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE, result);
+    Assert.assertTrue("Expected 'Warning treated as error' message at ERROR level",
+        out.getMessages().stream()
+            .anyMatch(m -> m.getLevel() == LogLevel.ERROR
+                        && m.getText().contains("Warning treated as error")));
+  }
+
+  // ── CLI tests: SANYmain0() ────────────────────────────────────────────────
+
+  /**
+   * {@code -suppressMessages 4802} silences the warning; SANY exits cleanly
+   * even with {@code -error-codes}.
+   */
+  @Test
+  public void testCLISuppressMessagesSilencesWarning() throws SANYExitException {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    SANY.SANYmain0(new String[]{"-suppressMessages", "4802", "-error-codes", TEST_SPEC_PATH});
+    out.assertNoSubstring("field name");
+  }
+
+  /**
+   * {@code -messagesAsErrors 4802} causes a {@link SANYExitException} with
+   * code {@link SanyExitCode#SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE} and
+   * prints "Warning treated as error".
+   */
+  @Test
+  public void testCLIMessagesAsErrorsCausesFailure() {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    try {
+      SANY.SANYmain0(new String[]{"-messagesAsErrors", "4802", "-error-codes", TEST_SPEC_PATH});
+      Assert.fail("Expected SANYExitException for elevated warning");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(
+          SanyExitCode.SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE,
+          e.getEnumeratedExitCode());
+    }
+    out.assertSubstring("Warning treated as error");
+  }
+
+  /**
+   * A comma-separated list of codes works; both codes must be valid SANY
+   * codes (4800 and 4802).
+   */
+  @Test
+  public void testCLIMultipleCodesSuppressed() throws SANYExitException {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    SANY.SANYmain0(new String[]{"-suppressMessages", "4800,4802", "-error-codes", TEST_SPEC_PATH});
+    out.assertNoSubstring("field name");
+  }
+
+  /**
+   * An unknown code in {@code -suppressMessages} causes an error exit and
+   * reports "unknown message code".
+   */
+  @Test
+  public void testCLIUnknownCodeInSuppressMessages() {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    try {
+      SANY.SANYmain0(new String[]{"-suppressMessages", "9999", TEST_SPEC_PATH});
+      Assert.fail("Expected SANYExitException for unknown code");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+    }
+    out.assertSubstring("unknown message code");
+  }
+
+  /**
+   * An unknown code in {@code -messagesAsErrors} causes an error exit and
+   * reports "unknown message code".
+   */
+  @Test
+  public void testCLIUnknownCodeInMessagesAsErrors() {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    try {
+      SANY.SANYmain0(new String[]{"-messagesAsErrors", "9999", TEST_SPEC_PATH});
+      Assert.fail("Expected SANYExitException for unknown code");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+    }
+    out.assertSubstring("unknown message code");
+  }
+
+  /**
+   * {@code -suppressMessages} with no following argument reports an error.
+   */
+  @Test
+  public void testCLISuppressMessagesMissingArgument() {
+    try {
+      SANY.SANYmain0(new String[]{"-suppressMessages"});
+      Assert.fail("Expected SANYExitException when argument is missing");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+    }
+  }
+
+  /**
+   * {@code -messagesAsErrors} with no following argument reports an error.
+   */
+  @Test
+  public void testCLIMessagesAsErrorsMissingArgument() {
+    try {
+      SANY.SANYmain0(new String[]{"-messagesAsErrors"});
+      Assert.fail("Expected SANYExitException when argument is missing");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+    }
+  }
+
+  /**
+   * Passing the same code to both -suppressMessages and -messagesAsErrors
+   * causes an error exit and reports "overlap for codes".
+   */
+  @Test
+  public void testCLIOverlapBetweenSuppressMessagesAndMessagesAsErrors() throws SANYExitException {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    try {
+      SANY.SANYmain0(new String[]{"-suppressMessages", "4800", "-messagesAsErrors", "4800", TEST_SPEC_PATH});
+      Assert.fail("Expected SANYExitException for overlap");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+    }
+    out.assertSubstring("codes were set to both -suppressMessages and -messagesAsErrors");
+  }
+
+  /**
+   * Passing an error-level code (4200 = SYMBOL_UNDEFINED) to
+   * {@code -suppressMessages} is rejected with an error and a message
+   * indicating the code is not suppressable.
+   */
+  @Test
+  public void testCLIErrorLevelCodeInSuppressMessages() {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.err = out;
+    try {
+      SANY.SANYmain0(new String[]{"-suppressMessages", "4200", TEST_SPEC_PATH});
+      Assert.fail("Expected SANYExitException for non-suppressable code");
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+    }
+    out.assertSubstring("cannot be suppressed");
+  }
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest1.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest1.java
@@ -37,7 +37,8 @@ public class ETest1 extends SuiteETestCase {
 	
 	@Test
 	public void testSpec() {
-		assertSubstring("*** Errors: 1\n\n" + "line 18, col 12 to line 18, col 17 of module etest1\n\n"
-				+ "The operator Foo requires 1 arguments.");
+		assertSubstring("*** Errors: 1\n");
+		assertSubstring("line 18, col 12 to line 18, col 17 of module etest1\n");
+		assertSubstring("The operator Foo requires 1 arguments.");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest16.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest16.java
@@ -37,9 +37,10 @@ public class ETest16 extends SuiteETestCase {
 
 	@Test
 	public void testSpec() {
-		assertSubstring("*** Errors: 2\n\n" + "line 5, col 27 to line 5, col 27 of module etest16\n\n"
-				+ "Non-unique fields in constructor.\n\n\n"
-				+ "line 7, col 27 to line 7, col 27 of module etest16\n\n"
-				+ "Non-unique fields in constructor.");
+		assertSubstring("*** Errors: 2\n");
+		assertSubstring("line 5, col 27 to line 5, col 27 of module etest16\n");
+		assertSubstring("Non-unique fields in constructor.\n");
+		assertSubstring("line 7, col 27 to line 7, col 27 of module etest16\n");
+		assertSubstring("Non-unique fields in constructor.");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest2.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest2.java
@@ -41,8 +41,8 @@ public class ETest2 extends SuiteETestCase {
 	@Test
 	public void testSpec() {
 		assertFalse(recorder.recorded(EC.GENERAL));
-		assertSubstring("*** Errors: 1\n\n"
-				+ "line 18, col 12 to line 18, col 14 of module etest2\n\n"
-				+ "The operator Foo requires 2 arguments.");
+		assertSubstring("*** Errors: 1\n");
+		assertSubstring("line 18, col 12 to line 18, col 14 of module etest2\n");
+		assertSubstring("The operator Foo requires 2 arguments.");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest5.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/ETest5.java
@@ -41,8 +41,8 @@ public class ETest5 extends SuiteETestCase {
 	@Test
 	public void testSpec() {
 		assertFalse(recorder.recorded(EC.GENERAL));
-		assertSubstring("*** Errors: 1\n\n"
-				+ "line 13, col 17 to line 13, col 20 of module etest5\n\n"
-				+ "Unknown operator: `Init'.");
+		assertSubstring("*** Errors: 1\n");
+		assertSubstring("line 13, col 17 to line 13, col 20 of module etest5\n");
+		assertSubstring("Unknown operator: `Init'.");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test210.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test210.java
@@ -43,58 +43,48 @@ public class Test210 extends SuiteETestCase {
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertSubstring("Semantic errors:\n" + 
 				"\n" + 
-				"*** Errors: 9\n" + 
-				"\n" + 
+				"*** Errors: 9\n");
+		assertSubstring(
 				"line 33, col 16 to line 33, col 19 of module test210\n" + 
 				"\n" + 
 				"Accessing subexpression labeled `laby' of ASSUME/PROVE clause within the scope of a declaration\n" + 
-				" from outside that declaration's scope.\n" + 
-				"\n" + 
-				"\n" + 
+				" from outside that declaration's scope.\n");
+		assertSubstring(
 				"line 35, col 16 to line 35, col 16 of module test210\n" + 
 				"\n" + 
 				"Accessing ASSUME/PROVE clause within the scope of a declaration\n" + 
-				" from outside that declaration's scope.\n" + 
-				"\n" + 
-				"\n" + 
+				" from outside that declaration's scope.\n");
+		assertSubstring(
 				"line 42, col 41 to line 42, col 55 of module test210\n" + 
 				"\n" + 
-				"Label not allowed within scope of declaration in nested ASSUME/PROVE.\n" + 
-				"\n" + 
-				"\n" + 
+				"Label not allowed within scope of declaration in nested ASSUME/PROVE.\n");
+		assertSubstring(
 				"line 43, col 30 to line 43, col 44 of module test210\n" + 
 				"\n" + 
-				"Label not allowed within scope of declaration in nested ASSUME/PROVE.\n" + 
-				"\n" + 
-				"\n" + 
+				"Label not allowed within scope of declaration in nested ASSUME/PROVE.\n");
+		assertSubstring(
 				"line 55, col 16 to line 55, col 16 of module test210\n" + 
 				"\n" + 
-				"Accessing non-existent subexpression of a SUFFICES\n" + 
-				"\n" + 
-				"\n" + 
+				"Accessing non-existent subexpression of a SUFFICES\n");
+		assertSubstring(
 				"line 62, col 15 to line 62, col 18 of module test210\n" + 
 				"\n" + 
 				"Accessing subexpression labeled `laby' of ASSUME/PROVE clause within the scope of a declaration\n" + 
-				" from outside that declaration's scope.\n" + 
-				"\n" + 
-				"\n" + 
+				" from outside that declaration's scope.\n");
+		assertSubstring(
 				"line 63, col 15 to line 63, col 18 of module test210\n" + 
 				"\n" + 
 				"Accessing subexpression labeled `labi' of ASSUME/PROVE clause within the scope of a declaration\n" + 
-				" from outside that declaration's scope.\n" + 
-				"\n" + 
-				"\n" + 
+				" from outside that declaration's scope.\n");
+		assertSubstring(
 				"line 64, col 15 to line 64, col 18 of module test210\n" + 
 				"\n" + 
 				"Accessing subexpression labeled `labu' of ASSUME/PROVE clause within the scope of a declaration\n" + 
-				" from outside that declaration's scope.\n" + 
-				"\n" + 
-				"\n" + 
+				" from outside that declaration's scope.\n");
+		assertSubstring(
 				"line 65, col 15 to line 65, col 15 of module test210\n" + 
 				"\n" + 
 				"Accessing ASSUME/PROVE clause within the scope of a declaration\n" + 
-				" from outside that declaration's scope.\n" + 
-				"\n" + 
-				"\n");
+				" from outside that declaration's scope.\n");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test212.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test212.java
@@ -43,44 +43,36 @@ public class Test212 extends SuiteETestCase {
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertSubstring("Semantic errors:\n" + 
 				"\n" + 
-				"*** Errors: 6\n" + 
-				"\n" + 
+				"*** Errors: 6\n");
+		assertSubstring(
 				"line 27, col 1 to line 27, col 62 of module test212\n" + 
 				"\n" + 
 				"Error in instantiating module 'test212a':\n" + 
-				" A non-Leibniz operator substituted for 'Op2'.\n" + 
-				"\n" + 
-				"\n" + 
+				" A non-Leibniz operator substituted for 'Op2'.\n");
+		assertSubstring(
 				"line 28, col 1 to line 28, col 62 of module test212\n" + 
 				"\n" + 
 				"Error in instantiating module 'test212a':\n" + 
-				" A non-Leibniz operator substituted for 'Op'.\n" + 
-				"\n" + 
-				"\n" + 
+				" A non-Leibniz operator substituted for 'Op'.\n");
+		assertSubstring(
 				"line 29, col 1 to line 29, col 62 of module test212\n" + 
 				"\n" + 
 				"Error in instantiating module 'test212a':\n" + 
-				" A non-Leibniz operator substituted for 'Op'.\n" + 
-				"\n" + 
-				"\n" + 
+				" A non-Leibniz operator substituted for 'Op'.\n");
+		assertSubstring(
 				"line 30, col 1 to line 30, col 64 of module test212\n" + 
 				"\n" + 
 				"Error in instantiating module 'test212a':\n" + 
-				" A non-Leibniz operator substituted for 'Op2'.\n" + 
-				"\n" + 
-				"\n" + 
+				" A non-Leibniz operator substituted for 'Op2'.\n");
+		assertSubstring(
 				"line 31, col 1 to line 31, col 63 of module test212\n" + 
 				"\n" + 
 				"Error in instantiating module 'test212a':\n" + 
-				" A non-Leibniz operator substituted for 'Op2'.\n" + 
-				"\n" + 
-				"\n" + 
+				" A non-Leibniz operator substituted for 'Op2'.\n");
+		assertSubstring(
 				"line 32, col 1 to line 32, col 63 of module test212\n" + 
 				"\n" + 
 				"Error in instantiating module 'test212a':\n" + 
-				" A non-Leibniz operator substituted for 'Op2'.\n" + 
-				"\n" + 
-				"\n" + 
-				"");
+				" A non-Leibniz operator substituted for 'Op2'.\n");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test213.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test213.java
@@ -43,37 +43,30 @@ public class Test213 extends SuiteETestCase {
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertSubstring("Semantic errors:\n" + 
 				"\n" + 
-				"*** Errors: 5\n" + 
-				"\n" + 
+				"*** Errors: 5\n");
+		assertSubstring(
 				"line 13, col 1 to line 13, col 52 of module test213\n" + 
 				"\n" + 
 				"Level error in instantiating module 'test213b':\n" + 
 				"The level of the expression or operator substituted for 'C' \n" + 
-				"must be at most 2.\n" + 
-				"\n" + 
-				"\n" + 
+				"must be at most 2.\n");
+		assertSubstring(
 				"line 14, col 1 to line 14, col 52 of module test213\n" + 
 				"\n" + 
 				"Level error in instantiating module 'test213b':\n" + 
 				"The level of the expression or operator substituted for 'D' \n" + 
-				"must be at most 2.\n" + 
-				"\n" + 
-				"\n" + 
+				"must be at most 2.\n");
+		assertSubstring(
 				"line 29, col 8 to line 29, col 15 of module test213\n" + 
 				"\n" + 
-				"Non-constant CASE for temporal goal.\n" + 
-				"\n" + 
-				"\n" + 
+				"Non-constant CASE for temporal goal.\n");
+		assertSubstring(
 				"line 31, col 8 to line 31, col 15 of module test213\n" + 
 				"\n" + 
-				"Non-constant TAKE, WITNESS, or HAVE for temporal goal.\n" + 
-				"\n" + 
-				"\n" + 
+				"Non-constant TAKE, WITNESS, or HAVE for temporal goal.\n");
+		assertSubstring(
 				"line 33, col 8 to line 33, col 22 of module test213\n" + 
 				"\n" + 
-				"Non-constant TAKE, WITNESS, or HAVE for temporal goal.\n" + 
-				"\n" + 
-				"\n" + 
-				"");
+				"Non-constant TAKE, WITNESS, or HAVE for temporal goal.\n");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test214.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test214.java
@@ -43,13 +43,11 @@ public class Test214 extends SuiteETestCase {
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertSubstring("Semantic errors:\n" + 
 				"\n" + 
-				"*** Errors: 1\n" + 
-				"\n" + 
+				"*** Errors: 1\n");
+		assertSubstring(
 				"line 10, col 11 to line 10, col 14 of module test214\n" + 
 				"\n" + 
 				"The only expression allowed as a fact in a HIDE is \n" + 
-				"the name of a theorem, assumption, or step.\n" + 
-				"\n" + 
-				"\n");
+				"the name of a theorem, assumption, or step.\n");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test215.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test215.java
@@ -43,47 +43,38 @@ public class Test215 extends SuiteETestCase {
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertSubstring("Semantic errors:\n" + 
 				"\n" + 
-				"*** Errors: 8\n" + 
-				"\n" + 
+				"*** Errors: 8\n");
+		assertSubstring(
 				"line 8, col 6 to line 8, col 14 of module test215\n" + 
 				"\n" + 
-				"Action used where only temporal formula or state predicate allowed.\n" + 
-				"\n" + 
-				"\n" + 
+				"Action used where only temporal formula or state predicate allowed.\n");
+		assertSubstring(
 				"line 9, col 6 to line 9, col 14 of module test215\n" + 
 				"\n" + 
-				"Action used where only temporal formula or state predicate allowed.\n" + 
-				"\n" + 
-				"\n" + 
+				"Action used where only temporal formula or state predicate allowed.\n");
+		assertSubstring(
 				"line 12, col 6 to line 12, col 16 of module test215\n" + 
 				"\n" + 
-				"Action used where only temporal formula or state predicate allowed.\n" + 
-				"\n" + 
-				"\n" + 
+				"Action used where only temporal formula or state predicate allowed.\n");
+		assertSubstring(
 				"line 13, col 6 to line 13, col 16 of module test215\n" + 
 				"\n" + 
-				"Action used where only temporal formula or state predicate allowed.\n" + 
-				"\n" + 
-				"\n" + 
+				"Action used where only temporal formula or state predicate allowed.\n");
+		assertSubstring(
 				"line 16, col 6 to line 16, col 11 of module test215\n" + 
 				"\n" + 
-				"<> followed by action not of form <<A>>_v.\n" + 
-				"\n" + 
-				"\n" + 
+				"<> followed by action not of form <<A>>_v.\n");
+		assertSubstring(
 				"line 20, col 8 to line 20, col 13 of module test215\n" + 
 				"\n" + 
-				"[] followed by action not of form [A]_v.\n" + 
-				"\n" + 
-				"\n" + 
+				"[] followed by action not of form [A]_v.\n");
+		assertSubstring(
 				"line 23, col 25 to line 23, col 26 of module test215\n" + 
 				"\n" + 
-				"Action-level bound of quantified temporal formula.\n" + 
-				"\n" + 
-				"\n" + 
+				"Action-level bound of quantified temporal formula.\n");
+		assertSubstring(
 				"line 26, col 26 to line 26, col 27 of module test215\n" + 
 				"\n" + 
-				"Action-level bound of quantified temporal formula.\n" + 
-				"\n" + 
-				"\n");
+				"Action-level bound of quantified temporal formula.\n");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test217.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/suite/Test217.java
@@ -43,19 +43,16 @@ public class Test217 extends SuiteETestCase {
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertSubstring("Semantic errors:\n" + 
 				"\n" + 
-				"*** Errors: 2\n" + 
-				"\n" + 
+				"*** Errors: 2\n");
+		assertSubstring(
 				"line 12, col 11 to line 12, col 19 of module test217\n" + 
 				"\n" + 
 				"Level error in applying operator I!Foo:\n" + 
-				"The level of argument 1 exceeds the maximum level allowed by the operator.\n" + 
-				"\n" + 
-				"\n" + 
+				"The level of argument 1 exceeds the maximum level allowed by the operator.\n");
+		assertSubstring(
 				"line 13, col 9 to line 13, col 19 of module test217\n" + 
 				"\n" + 
 				"Level error in applying operator I!Foo:\n" + 
-				"The level of argument 1 exceeds the maximum level allowed by the operator.\n" + 
-				"\n" + 
-				"\n");
+				"The level of argument 1 exceeds the maximum level allowed by the operator.\n");
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/util/TestPrintStream.java
+++ b/tlatools/org.lamport.tlatools/test/util/TestPrintStream.java
@@ -65,7 +65,7 @@ public class TestPrintStream extends PrintStream {
 				return;
 			}
 		}
-		fail("Substring not found");
+		fail("Substring `" + substring + "' not found");
 	}
 
 	public void assertRegex(String regex) {
@@ -81,7 +81,7 @@ public class TestPrintStream extends PrintStream {
 	public void assertNoSubstring(String substring) {
 		for (String string : strings) {
 			if (string.contains(substring)) {
-				fail("Substring was found");
+				fail("Substring `" + substring + "' was found");
 			}
 		}
 	}


### PR DESCRIPTION
Add -suppressMessages and -warningsAsErrors CLI flags to SANY (phase 1 of #1186).
    
Support of the fine-grained warning control in SANY:

-suppressMessages comma-separated integer codes; silences those messages entirely (not
  printed, not a failure).
-warningsAsErrors comma-separated integer warning codes; when any such warning is
  triggered SANY exits with the semantic-analysis failure code.

Both flags validate each supplied code against ErrorCode.fromStandardValue() and reject
unknown codes with a descriptive error. -warningsAsErrors additionally rejects
non-warning-level codes.

This also
- resolves the long-standing TODO comment in frontEndSemanticAnalysis() to split
  errors and warnings into appropriate log levels.
- fixes a bug where linting warnings were accumulated in spec.semanticErrors
  during frontEndLinting() but never printed to the SanyOutput, so they were
  invisible to callers using the API path.