### PR TITLE
TLCRuntime returns x86 on non-x86 architecture such as arm.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/REPL.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/REPL.java
@@ -268,7 +268,7 @@ public class REPL {
 		udc.put("osArch", System.getProperty("os.arch"));
 		udc.put("jvmVendor", System.getProperty("java.vendor"));
 		udc.put("jvmVersion", System.getProperty("java.version"));
-		udc.put("jvmArch", tlcRuntime.getArchitecture().name());
+		udc.put("jvmArch", tlcRuntime.getArchitecture().toString());
 		udc.put("jvmHeapMem", Long.toString(heapMemory));
 		udc.put("jvmOffHeapMem", Long.toString(offHeapMemory));
 		udc.put("toolbox", Boolean.toString(TLCGlobals.tool));

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -1419,7 +1419,7 @@ public class TLC {
 		result.put("osArch", System.getProperty("os.arch"));
 		result.put("jvmVendor", System.getProperty("java.vendor"));
 		result.put("jvmVersion", System.getProperty("java.version"));
-		result.put("jvmArch", tlcRuntime.getArchitecture().name());
+		result.put("jvmArch", tlcRuntime.getArchitecture().toString());
 		result.put("jvmHeapMem", Long.toString(heapMemory));
 		result.put("jvmOffHeapMem", Long.toString(offHeapMemory));
 		result.put("jvmPid", pid == -1 ? "" : String.valueOf(pid));
@@ -1454,7 +1454,7 @@ public class TLC {
 		result.put("osArch", System.getProperty("os.arch"));
 		result.put("jvmVendor", System.getProperty("java.vendor"));
 		result.put("jvmVersion", System.getProperty("java.version"));
-		result.put("jvmArch", tlcRuntime.getArchitecture().name());
+		result.put("jvmArch", tlcRuntime.getArchitecture().toString());
 		result.put("jvmHeapMem", Long.toString(heapMemory));
 		result.put("jvmOffHeapMem", Long.toString(offHeapMemory));
 		result.put("seed", Long.toString(RandomEnumerableValues.getSeed()));

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/FPSetFactory.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/FPSetFactory.java
@@ -54,7 +54,7 @@ public abstract class FPSetFactory {
 	}
 
 	private static boolean supports32Bits(final Class<? extends FPSet> clazz) {
-		if (TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.x86
+		if (TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.BIT_32
 				&& OffHeapDiskFPSet.class.isAssignableFrom(clazz)) {
 			return false;
 		}

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/fp/LongArray.java
@@ -94,7 +94,7 @@ public final class LongArray {
 	 *         cannot be loaded (on some JVM implementations, this isn't possible).
 	 */
 	public static boolean isSupported() {
-		if (TLCRuntime.ARCH.x86_64 != TLCRuntime.getInstance().getArchitecture()) {
+		if (TLCRuntime.ARCH.BIT_64 != TLCRuntime.getInstance().getArchitecture()) {
 			return false;
 		}
 		try {

--- a/tlatools/org.lamport.tlatools/src/util/TLCRuntime.java
+++ b/tlatools/org.lamport.tlatools/src/util/TLCRuntime.java
@@ -147,24 +147,35 @@ public class TLCRuntime {
 	}
 
 	public enum ARCH {
-		x86,
-		x86_64;
+		BIT_32("32bit"),
+		BIT_64("64bit");
+
+		private final String label;
+
+		ARCH(String label) {
+			this.label = label;
+		}
+
+		@Override
+		public String toString() {
+			return label;
+		}
 	}
 	
 	public ARCH getArchitecture() {
 		if (System.getProperty("sun.arch.data.model") != null
 				&& System.getProperty("sun.arch.data.model").equals("64")) {
-			return ARCH.x86_64;
+			return ARCH.BIT_64;
 		}
 		if (System.getProperty("com.ibm.vm.bitmode") != null 
 				&& System.getProperty("com.ibm.vm.bitmode").equals("64")) {
-			return ARCH.x86_64;
+			return ARCH.BIT_64;
 		}
 		if (System.getProperty("java.vm.version") != null 
 				&& System.getProperty("java.vm.version").contains("_64")) {
-			return ARCH.x86_64;
+			return ARCH.BIT_64;
 		}
-		return ARCH.x86;
+		return ARCH.BIT_32;
 	}
 
 	// See java.lang.ProcessHandle.current().pid() or -1 when Java version -lt 9.

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/FPSetFactoryTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/FPSetFactoryTest.java
@@ -64,7 +64,7 @@ public class FPSetFactoryTest {
 
 	@Test
 	public void testGetFPSetOffHeap() throws RemoteException {
-		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.x86_64);
+		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.BIT_64);
 		System.setProperty(FPSetFactory.IMPL_PROPERTY, OffHeapDiskFPSet.class.getName());
 		final FPSetConfiguration fpSetConfiguration = new FPSetConfiguration();
 		doTestGetFPSet(OffHeapDiskFPSet.class, fpSetConfiguration);
@@ -150,7 +150,7 @@ public class FPSetFactoryTest {
 	
 	@Test
 	public void testGetFPSetOffHeapMultiFPSet() throws RemoteException {
-		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.x86_64);
+		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.BIT_64);
 		System.setProperty(FPSetFactory.IMPL_PROPERTY, OffHeapDiskFPSet.class.getName());
 		final FPSetConfiguration fpSetConfiguration = new FPSetConfiguration();
 		fpSetConfiguration.setFpBits(1);
@@ -188,7 +188,7 @@ public class FPSetFactoryTest {
 	
 	@Test
 	public void testGetFPSetOffHeapMultiFPSetWithMem() throws RemoteException {
-		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.x86_64);
+		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.BIT_64);
 		System.setProperty(FPSetFactory.IMPL_PROPERTY, OffHeapDiskFPSet.class.getName());
 		final FPSetConfiguration fpSetConfiguration = new FPSetConfiguration();
 		fpSetConfiguration.setMemory(MEMORY);

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/LongArrayTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/LongArrayTest.java
@@ -45,7 +45,7 @@ public class LongArrayTest {
 	
 	@Before
 	public void setup() {
-		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.x86_64);
+		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.BIT_64);
 	}
 
 	@Test

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/OffHeapDiskFPSetTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/fp/OffHeapDiskFPSetTest.java
@@ -66,7 +66,7 @@ public class OffHeapDiskFPSetTest {
 	
 	@Before
 	public void setup() {
-		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.x86_64);
+		Assume.assumeTrue(TLCRuntime.getInstance().getArchitecture() == TLCRuntime.ARCH.BIT_64);
 	}
 
 //	@Test


### PR DESCRIPTION
Updated the architecture enumeration from x86/x86_64 to BIT_32/BIT_64. Adjusted related code in REPL, TLC, and various test files to reflect this change.

Fixes Github issue #997
https://github.com/tlaplus/tlaplus/issues/997

[Refactor][TLC]