### PR TITLE
TLC reports error with trace, but no message about what went wrong

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Worker.java
@@ -184,7 +184,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 		// originate, and c) there is no global exception handling.
 		try {
 			this.tlc.liveCheck.addNextState(tlc.tool.noDebug(), curState, curStateFP, liveNextStates);
-		} catch (EvalException | TLCRuntimeException origExp) {
+		} catch (EvalException | TLCRuntimeException | FingerprintException origExp) {
 			synchronized (this.tlc) {
 				if (this.tlc.printedLivenessErrorStack) {
 					// Another worker beat us to printing an error trace.
@@ -206,7 +206,7 @@ public final class Worker extends IdThread implements IWorker, INextStateFunctor
 					// Regular evaluation with tlc.tool.getLiveness failed but CallStackTool
 					// succeeded. This should never happen!
 					Assert.fail(EC.GENERAL, origExp);
-				} catch (EvalException | TLCRuntimeException rerunExp) {
+				} catch (EvalException | TLCRuntimeException | FingerprintException rerunExp) {
 					// liveCheck#addNextState is not side-effect free. For example, the behavior
 					// (liveness) graph might have been changed and new GraphNodes been added. If
 					// that's the case, calling addNextStates with the same parameters again causes

--- a/tlatools/org.lamport.tlatools/test-model/Github763.tla
+++ b/tlatools/org.lamport.tlatools/test-model/Github763.tla
@@ -1,0 +1,16 @@
+---- MODULE Github763 ----
+
+CONSTANT MV
+VARIABLE x
+Init == x = {}
+Grow == x' = [val |-> 1]
+Next == Grow \/ UNCHANGED x
+Spec == Init /\ [][Next]_x /\ WF_<<x>>(Grow)
+Live == []<>(x /= MV)
+
+====
+---- CONFIG Github763 ----
+SPECIFICATION Spec
+CONSTANT MV = MV
+PROPERTY Live
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/Github763Test.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/liveness/Github763Test.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool.liveness;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+
+public class Github763Test extends ModelCheckerTestCase {
+
+	public Github763Test() {
+		super("Github763", new String[] { "-config", "Github763.tla" }, EC.ExitStatus.ERROR);
+	}
+
+	@Override
+	protected boolean runWithDebugger() {
+		return false;
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true;
+	}
+
+	@Override
+	protected boolean doCoverage() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDump() {
+		return false;
+	}
+
+	@Override
+	protected boolean doDumpTrace() {
+		return false;
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		// Assert the error trace is printed.
+		assertFalse(recorder.getRecords(EC.TLC_STATE_PRINT2).isEmpty());
+
+		// Assert the error message is printed (regression: was previously missing).
+		assertTrue(recorder.recordedWithStringValues(EC.GENERAL,
+				"TLC threw an unexpected exception.\n" + "This was probably caused by an error in the spec or model.\n"
+						+ "See the User Output or TLC Console for clues to what happened.\n"
+						+ "The exception was a java.lang.RuntimeException\n"
+						+ ": Attempted to check equality of the set {} with the value:\n" + "[val |-> 1]"));
+
+		// Assert the nested expression (call stack) is printed.
+		assertTrue(recorder.recorded(EC.TLC_NESTED_EXPRESSION));
+	}
+}


### PR DESCRIPTION
Commit 1004befc introduced support for re-running liveness checking with CallStackTool to improve error diagnostics (the irony). However, CallStackTool can throw a FingerprintException because it carries source information that FastTool does not. The calling code in Worker did not catch FingerprintException, which caused TLC to report an error trace without the corresponding error message. Catch FingerprintException and report the appropriate error message.

Fixes Github issue #763
https://github.com/tlaplus/tlaplus/issues/763

[Bug][TLC]