### PR TITLE
XML Exporter: UserDefinedOpKind original op reference

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/OpDefNode.java
@@ -1503,25 +1503,28 @@ public class OpDefNode extends OpDefOrDeclNode
         ret = doc.createElement("UserDefinedOpKind");
         ret.appendChild(appendText(doc,"uniquename",getName().toString()));
         ret.appendChild(appendText(doc,"arity",Integer.toString(getArity())));
-		if (getPreComments().length > 0) {
-			ret.appendChild(appendCDATA(doc, "pre-comments", Arrays.stream(getPreComments()).filter(Objects::nonNull)
-					// Do not trim to preserve indentation of comments.
-					.map(String::stripTrailing).filter(s -> !s.isEmpty())
-					// Use "\n" rather than System.lineSeparator(): XML 1.0 §2.11
-					// normalizes line endings to LF, so \r\n would not survive a
-					// round-trip through a conformant XML parser.
-					.collect(Collectors.joining("\n"))));
-		}
+        ret.appendChild(appendElement(doc, "originalOperator", this.getSource().export(doc, context, filter)));
+        ret.appendChild(appendElement(doc, "originallyDefinedInModule", this.getOriginallyDefinedInModuleNode().export(doc, context, filter)));
         ret.appendChild(appendElement(doc,"body",body.export(doc,context, filter)));
+        final Element arguments = doc.createElement("params");
+        ret.appendChild(arguments);
         if (params != null) {
-          Element arguments = doc.createElement("params");
           for (int i=0; i<params.length; i++) {
             Element lp = doc.createElement("leibnizparam");
             lp.appendChild(params[i].export(doc,context, filter));
             if (isLeibnizArg != null && isLeibnizArg[i]) lp.appendChild(doc.createElement("leibniz"));
             arguments.appendChild(lp);
           }
-          ret.appendChild(arguments);
+        }
+
+        if (getPreComments().length > 0) {
+          ret.appendChild(appendCDATA(doc, "pre-comments", Arrays.stream(getPreComments()).filter(Objects::nonNull)
+              // Do not trim to preserve indentation of comments.
+              .map(String::stripTrailing).filter(s -> !s.isEmpty())
+              // Use "\n" rather than System.lineSeparator(): XML 1.0 §2.11
+              // normalizes line endings to LF, so \r\n would not survive a
+              // round-trip through a conformant XML parser.
+              .collect(Collectors.joining("\n"))));
         }
 
         if (inRecursive) {

--- a/tlatools/org.lamport.tlatools/src/tla2sany/xml/sany.xsd
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/xml/sany.xsd
@@ -1036,14 +1036,40 @@
             </xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element minOccurs="0" ref="pre-comments">
+        <xs:element name="originalOperator">
           <xs:annotation>
             <xs:documentation>
-              Any comments occurring before the operator. For example,
-              (* Text *) op == expr will have "(* Text *)" here, or "Text" if
-              certain XML Exporter settings are used.
+              When one module imports another using EXTENDS or INSTANCE, the
+              imported module's operators are all duplicated and inlined in
+              the importing module. This field contains a reference to the
+              operator node as it was originally defined. Note that operators
+              can be inlined multiple times, but this will always point to
+              the actual original operator; thus users do not need to resolve
+              a chain of references to find the original. If this operator is
+              itself an original operator not inlined from somewhere else, it
+              will reference its own UID here.
             </xs:documentation>
           </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="UserDefinedOpKindRef"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="originallyDefinedInModule">
+          <xs:annotation>
+            <xs:documentation>
+              A reference to the module in which this operator was originally
+              defined. This might be different from the module in which this
+              specific UserDefinedOpKind node is found, if the operator was
+              imported using EXTENDS or INSTANCE.
+            </xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element ref="ModuleNodeRef"/>
+            </xs:sequence>
+          </xs:complexType>
         </xs:element>
         <xs:element name="body">
           <xs:annotation>
@@ -1055,7 +1081,7 @@
             <xs:group ref="ExprNode"/>
           </xs:complexType>
         </xs:element>
-        <xs:element minOccurs="0" name="params">
+        <xs:element name="params">
           <xs:annotation>
             <xs:documentation>
               A list of parameters accepted by the operator. Note that these
@@ -1068,6 +1094,15 @@
                 <xs:element minOccurs="0" maxOccurs="unbounded" ref="leibnizparam"/>
             </xs:sequence>
           </xs:complexType>
+        </xs:element>
+        <xs:element minOccurs="0" ref="pre-comments">
+          <xs:annotation>
+            <xs:documentation>
+              Any comments occurring before the operator. For example,
+              (* Text *) op == expr will have "(* Text *)" here, or "Text" if
+              certain XML Exporter settings are used.
+            </xs:documentation>
+          </xs:annotation>
         </xs:element>
         <xs:element minOccurs="0" ref="recursive">
           <xs:annotation>


### PR DESCRIPTION
These changes modify the UserDefinedOpKind export format in several ways:
1. Add originalOperator and originallyDefinedInModule reference fields
2. Move optional pre-comments field below fixed fields to facilitate ease of parsing XML children
3. Fix dual-representation issue with parameters field where an operator with no parameters could be represented both by a missing parameters field and a parameters field with zero children; now a parameterless operator will have a parameters field with zero children

[Refactor][Feature][XMLExporter]

Ref #1313