### PR TITLE
SANY: Only lint after semantic analysis and level checking

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -192,22 +192,22 @@ public class SANY {
       frontEndParse(spec, out, settings);
     
       // **** Semantic analysis and level checking
-      if (settings.doSemanticAnalysis) 
-            {frontEndSemanticAnalysis(spec, out, settings);} ;
+      if (settings.doSemanticAnalysis) {
+        frontEndSemanticAnalysis(spec, out, settings);
 
-      // **** Linting
-      if (settings.doLinting) {
-        final int warnsBefore = spec.semanticErrors.getWarningDetails().size();
-        frontEndLinting(spec, out);
-        // Print linting warnings, respecting suppressed/elevated codes.
-        final List<ErrorDetails> allWarnings = spec.semanticErrors.getWarningDetails();
-        final List<ErrorDetails> lintingWarnings = allWarnings.subList(warnsBefore, allWarnings.size());
-        final boolean errorElevated = reportMessages(out, filterVisibleMessages(lintingWarnings, settings), settings);
-        if (errorElevated) {
-          spec.errorLevel = SanyExitCode.SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE.code();
+        // **** Linting
+        if (settings.doLevelChecking && SanyExitCode.OK == SanyExitCode.fromCode(spec.getErrorLevel()) && settings.doLinting) {
+          final int warnsBefore = spec.semanticErrors.getWarningDetails().size();
+          frontEndLinting(spec, out);
+          // Print linting warnings, respecting suppressed/elevated codes.
+          final List<ErrorDetails> allWarnings = spec.semanticErrors.getWarningDetails();
+          final List<ErrorDetails> lintingWarnings = allWarnings.subList(warnsBefore, allWarnings.size());
+          final boolean errorElevated = reportMessages(out, filterVisibleMessages(lintingWarnings, settings), settings);
+          if (errorElevated) {
+            spec.errorLevel = SanyExitCode.SEMANTIC_ANALYSIS_OR_LEVEL_CHECKING_FAILURE.code();
+          }
         }
       }
-
     }
     catch (ParseException pe) {
       return SanyExitCode.ERROR;

--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SanySettings.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SanySettings.java
@@ -59,8 +59,9 @@ public final class SanySettings {
 
   /**
    * This setting controls whether, after running semantic analysis & level
-   * checking, SANY runs linting. This will cause a failure if semantic
-   * analysis was disabled.
+   * checking, SANY runs linting. If either {@link SanySettings#doSemanticAnalysis}
+   * or {@link SanySettings#doLevelChecking} are false, SANY will skip linting
+   * regardless of this setting.
    */
   public final boolean doLinting;
 


### PR DESCRIPTION
Fixes crash if linter is run after skipping semantic analysis

Before these changes, SANY would crash if semantic analysis was skipped but linting was run anyway. Now SANY only runs the linter if semantic analysis completed successfully. In addition, SANY requires level-checking to have been run before running the linter, in anticipation of possible future linter messages that might require use of level information; it also just makes sense to have the most "optional" analysis level only run after all the strictly required analysis levels have run.

[Enhancement][Bug][SANY]