### PR TITLE
Simulation trace length statistics are incorrect

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/ExplorationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/ExplorationWorker.java
@@ -41,9 +41,9 @@ public class ExplorationWorker extends SimulationWorker {
 
 	public ExplorationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue, long seed,
 			int maxTraceDepth, long maxTraceNum, String traceActions, boolean checkDeadlock, String traceFile,
-			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces, AtomicLong m2AndMean) {
+			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces) {
 		super(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, traceActions, checkDeadlock, traceFile,
-				liveCheck, numOfGenStates, numOfGenTraces, m2AndMean);
+				liveCheck, numOfGenStates, numOfGenTraces);
 	}
 
 	@Override

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/RLActionSimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/RLActionSimulationWorker.java
@@ -35,9 +35,9 @@ public class RLActionSimulationWorker extends RLSimulationWorker {
 
 	public RLActionSimulationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue, long seed,
 			int maxTraceDepth, long maxTraceNum, String traceActions, boolean checkDeadlock, String traceFile,
-			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces, AtomicLong m2AndMean) {
+			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces) {
 		super(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, traceActions, checkDeadlock, traceFile, liveCheck,
-				numOfGenStates, numOfGenTraces, m2AndMean);
+				numOfGenStates, numOfGenTraces);
 	}
 	
 	@Override

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/RLSimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/RLSimulationWorker.java
@@ -54,14 +54,14 @@ public class RLSimulationWorker extends SimulationWorker {
 	public RLSimulationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue, long seed,
 			int maxTraceDepth, long maxTraceNum, boolean checkDeadlock, String traceFile, ILiveCheck liveCheck) {
 		this(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, null, checkDeadlock, traceFile, liveCheck,
-				new LongAdder(), new AtomicLong(), new AtomicLong());
+				new LongAdder(), new AtomicLong());
 	}
 	
 	public RLSimulationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue, long seed,
 			int maxTraceDepth, long maxTraceNum, String traceActions, boolean checkDeadlock, String traceFile,
-			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces, AtomicLong m2AndMean) {
+			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces) {
 		super(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, traceActions, checkDeadlock, traceFile, liveCheck,
-				numOfGenStates, numOfGenTraces, m2AndMean);
+				numOfGenStates, numOfGenTraces);
 		
 		for (final Action a : tool.getActions()) {
 			q.put(a, new HashMap<>());

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/SimulationWorker.java
@@ -234,21 +234,26 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 		private final LongAdder numOfGenStates;
 		private final AtomicLong numOfGenTraces;
 		
-		private final AtomicLong welfordM2AndMean;
+		// Per-worker local Welford state for computing trace length statistics.
+		// Each worker maintains its own n, mean, and M2; these are combined at
+		// reporting time using Welford's parallel/partitioned algorithm.
+		// This avoids the concurrency bug where the shared AtomicLong approach
+		// diverged from numOfGenTraces at high worker counts (e.g. 128 cores).
+		// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
+		private volatile long localN;
+		private volatile double localMean;
+		private volatile double localM2;
 		
 		// Adjacency Matrix with link weights.
 		final long[][] actionStats;
 
 		public SimulationWorkerStatistics(final String traceActions, final LongAdder numOfGenStates,
-				final AtomicLong numOfGenTraces, final AtomicLong m2AndMean) {
+				final AtomicLong numOfGenTraces) {
 			this.traceActions = traceActions;
 			
 			// Cheap (constant): Aggregated statistics about the number of generated states and traces.
 			this.numOfGenStates = numOfGenStates;
 			this.numOfGenTraces = numOfGenTraces;
-			
-			// Cheap (constant): Aggregated statistics about the average length, SD, ... about the traces.
-			this.welfordM2AndMean = m2AndMean;
 
 			// Moderate (quadratic in the number of actions): 
 			if (traceActions != null) {
@@ -280,23 +285,35 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 			//no-op
 		}
 
-		public void collectPostTrace(final TLCState s) {
+		public synchronized void collectPostTrace(final TLCState s) {
 			// Take the minimum of maxTraceDepth and getLevel here because - historically -
 			// the for loop above would add the chosen next-state from loop N in loop N+1.
 			// Thus, the final state that is generated before traceCnt = maxTraceDepth,
 			// wasn't getting added to the stateVec (check git history) whose length was
-			// passed to welfordM2AndMean.
-			welfordM2AndMean.accumulateAndGet(Math.min(maxTraceDepth, s.getLevel()), (acc, tl) -> {
-				// Welford's online algorithm (m2 and mean stuffed into high and low of the
-				// atomiclong because welfordM2AndMean is updated concurrently by multiple workers).
-				// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
-				int mean = (int) (acc & 0x00000000FFFFFFFFL);
-				long m2 = acc >>> 32;
-				final long delta = tl - mean;
-				mean += delta / Math.max(numOfGenTraces.longValue(), 1); // max(..., 1) to prevent div-by-zero
-				m2 += delta * (tl - mean);
-				return m2 << 32 | (mean & 0xFFFFFFFFL);
-			});
+			// passed to the Welford update.
+			final long tl = Math.min(maxTraceDepth, s.getLevel());
+			// Welford's online algorithm (single-threaded, per-worker).
+			// https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
+			localN++;
+			final double delta = tl - localMean;
+			localMean += delta / localN;
+			final double delta2 = tl - localMean;
+			localM2 += delta * delta2;
+		}
+		
+		/** Returns the number of traces this worker has incorporated into its Welford state. */
+		public long getLocalN() {
+			return localN;
+		}
+		
+		/** Returns this worker's local running mean of trace lengths. */
+		public double getLocalMean() {
+			return localMean;
+		}
+		
+		/** Returns this worker's local M2 (sum of squared deviations from the mean). */
+		public double getLocalM2() {
+			return localM2;
 		}
 		
 		//*************************** Reporting **************************//
@@ -356,8 +373,8 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 		 * fingerprinting of values and states is really expensive.
 		 */
 		public ExtendedSimulationWorkerStatistics(String traceActions, LongAdder numOfGenStates,
-				AtomicLong numOfGenTraces, AtomicLong m2AndMean) {
-			super(traceActions, numOfGenStates, numOfGenTraces, m2AndMean);
+				AtomicLong numOfGenTraces) {
+			super(traceActions, numOfGenStates, numOfGenTraces);
 			
 			// Prob: Cheap (constant) in space.
 			// Naive: Expensive (linear) in space, i.e., number of states.
@@ -434,12 +451,12 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 			long seed, int maxTraceDepth, long maxTraceNum, boolean checkDeadlock, String traceFile,
 			ILiveCheck liveCheck) {
 		this(id, tool, resultQueue, seed, maxTraceDepth, maxTraceNum, null, checkDeadlock, traceFile, liveCheck,
-				new LongAdder(), new AtomicLong(), new AtomicLong());
+				new LongAdder(), new AtomicLong());
 	}
 
 	public SimulationWorker(int id, ITool tool, BlockingQueue<SimulationWorkerResult> resultQueue,
 			long seed, int maxTraceDepth, long maxTraceNum, String traceActions, boolean checkDeadlock, String traceFile,
-			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces, AtomicLong m2AndMean) {
+			ILiveCheck liveCheck, LongAdder numOfGenStates, AtomicLong numOfGenTraces) {
 		super(id);
 		this.localRng = new RandomGenerator(seed);
 		this.tool = tool;
@@ -450,8 +467,23 @@ public class SimulationWorker extends IdThread implements INextStateFunctor {
 		this.traceFile = traceFile;
 		this.liveCheck = liveCheck;
 		this.statistics = Simulator.EXTENDED_STATISTICS
-				? new ExtendedSimulationWorkerStatistics(traceActions, numOfGenStates, numOfGenTraces, m2AndMean)
-				: new SimulationWorkerStatistics(traceActions, numOfGenStates, numOfGenTraces, m2AndMean);
+				? new ExtendedSimulationWorkerStatistics(traceActions, numOfGenStates, numOfGenTraces)
+				: new SimulationWorkerStatistics(traceActions, numOfGenStates, numOfGenTraces);
+	}
+
+	/** Returns the number of traces this worker has incorporated into its Welford state. */
+	public long getLocalN() {
+		return statistics.getLocalN();
+	}
+
+	/** Returns this worker's local running mean of trace lengths. */
+	public double getLocalMean() {
+		return statistics.getLocalMean();
+	}
+
+	/** Returns this worker's local M2 (sum of squared deviations from the mean). */
+	public double getLocalM2() {
+		return statistics.getLocalM2();
 	}
 	
 	/**

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/Simulator.java
@@ -131,19 +131,19 @@ public class Simulator {
 			if (tool.isDebugger()) {
 				this.workers.add(new ExplorationWorker(i, t, this.workerResultQueue, this.rng.nextLong(),
 						this.traceDepth, this.traceNum, this.traceActions, this.checkDeadlock, this.traceFile,
-						liveCheck, this.numOfGenStates, this.numOfGenTraces, this.welfordM2AndMean));
+						liveCheck, this.numOfGenStates, this.numOfGenTraces));
 			} else if (Boolean.getBoolean(Simulator.class.getName() + ".rl")) {
 				this.workers.add(new RLSimulationWorker(i, t, this.workerResultQueue, this.rng.nextLong(),
 						this.traceDepth, this.traceNum, this.traceActions, this.checkDeadlock, this.traceFile,
-						liveCheck, this.numOfGenStates, this.numOfGenTraces, this.welfordM2AndMean));
+						liveCheck, this.numOfGenStates, this.numOfGenTraces));
 			} else if (Boolean.getBoolean(Simulator.class.getName() + ".rlaction")) {
 				this.workers.add(new RLActionSimulationWorker(i, t, this.workerResultQueue, this.rng.nextLong(),
 						this.traceDepth, this.traceNum, this.traceActions, this.checkDeadlock, this.traceFile,
-						liveCheck, this.numOfGenStates, this.numOfGenTraces, this.welfordM2AndMean));
+						liveCheck, this.numOfGenStates, this.numOfGenTraces));
 			} else {
 				this.workers.add(new SimulationWorker(i, t, this.workerResultQueue, this.rng.nextLong(),
 						this.traceDepth, this.traceNum, this.traceActions, this.checkDeadlock, this.traceFile,
-						liveCheck, this.numOfGenStates, this.numOfGenTraces, this.welfordM2AndMean));
+						liveCheck, this.numOfGenStates, this.numOfGenTraces));
 			}
 		}
 	
@@ -175,7 +175,6 @@ public class Simulator {
 	// concurrently, so we use a LongAdder to reduce potential contention.
 	private final LongAdder numOfGenStates = new LongAdder();
 	private final AtomicLong numOfGenTraces = new AtomicLong();
-	private final AtomicLong welfordM2AndMean = new AtomicLong();
 
 	// private Action[] actionTrace; // SZ: never read locally
 	private final String traceFile;
@@ -604,7 +603,48 @@ public class Simulator {
 	public final ITool getTool() {
 	    return this.tool;	
 	}
-	
+
+	/**
+	 * Combines per-worker Welford state into aggregate statistics using the
+	 * parallel/partitioned Welford algorithm.
+	 *
+	 * @return double[3] where [0]=aggregate mean, [1]=aggregate M2, [2]=aggregate N.
+	 * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm">
+	 *      Welford's parallel algorithm</a>
+	 */
+	protected double[] computeAggregateTraceStats() {
+		double aggMean = 0;
+		double aggM2 = 0;
+		long aggN = 0;
+
+		for (SimulationWorker w : this.workers) {
+			final long wN;
+			final double wMean;
+			final double wM2;
+			synchronized (w.statistics) {
+				wN = w.statistics.getLocalN();
+				if (wN == 0) {
+					continue;
+				}
+				wMean = w.statistics.getLocalMean();
+				wM2 = w.statistics.getLocalM2();
+			}
+
+			if (aggN == 0) {
+				aggN = wN;
+				aggMean = wMean;
+				aggM2 = wM2;
+			} else {
+				// Welford's parallel/partitioned combine:
+				final long newN = aggN + wN;
+				final double delta = wMean - aggMean;
+				aggM2 = aggM2 + wM2 + delta * delta * ((double) aggN * wN / newN);
+				aggMean = aggMean + delta * ((double) wN / newN);
+				aggN = newN;
+			}
+		}
+		return new double[] { aggMean, aggM2, aggN };
+	}
 	/**
 	 * Reports progress information
 	 */
@@ -623,16 +663,15 @@ public class Simulator {
 						ready.countDown();
 						this.wait(TLCGlobals.progressInterval);
 					}
-					final long genTrace = numOfGenTraces.longValue();
-					final long m2AndMean = welfordM2AndMean.get();
-					final long mean = m2AndMean & 0x00000000FFFFFFFFL; // could be int.
-					final long m2 = m2AndMean >>> 32;
+					final double[] stats = computeAggregateTraceStats();
+					final long aggN = (long) stats[2];
+					final double variance = aggN > 1 ? stats[1] / (aggN - 1) : 0; // sample variance
 					MP.printMessage(EC.TLC_PROGRESS_SIMU, 
 							String.valueOf(numOfGenStates.longValue()),
-							String.valueOf(genTrace),
-							String.valueOf(mean),
-							String.valueOf(Math.round(m2 / (genTrace + 1d))), // Var(X),  +1 to prevent div-by-zero.
-							String.valueOf(Math.round(Math.sqrt(m2 / (genTrace + 1d))))); // SD, +1 to prevent div-by-zero.
+							String.valueOf(aggN),
+							String.valueOf(Math.round(stats[0])),
+							String.valueOf(Math.round(variance)), // Var(X)
+							String.valueOf(Math.round(Math.sqrt(variance)))); // SD
 					if (count > 1) {
 						count--;
 					} else {
@@ -902,14 +941,14 @@ public class Simulator {
 		n[8] = TLCGetSet.SPEC_ACTIONS;
 		v[8] = getWorkerStatistics().getActions();
 		
-		final long m2AndMean = welfordM2AndMean.get();
-		final long mean = m2AndMean & 0x00000000FFFFFFFFL; // could be int.
+		final double[] stats = computeAggregateTraceStats();
 		n[9] = TLCGetSet.LEVEL_MEAN;
-		v[9] = IntValue.narrowToIntValue(mean);
+		v[9] = IntValue.narrowToIntValue(Math.round(stats[0]));
 
-		final long m2 = m2AndMean >>> 32;
+		final long aggN = (long) stats[2];
+		final double variance = aggN > 1 ? stats[1] / (aggN - 1) : 0;
 		n[10] = TLCGetSet.LEVEL_VARIANCE;
-		v[10] = IntValue.narrowToIntValue(Math.round(m2 / (genTrace + 1d)));// Var(X),  +1 to prevent div-by-zero.
+		v[10] = IntValue.narrowToIntValue(Math.round(variance));
 
 		return new RecordValue(n, v, false);
 	}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/SimulationWorkerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/SimulationWorkerTest.java
@@ -14,7 +14,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState0() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		final StateVec trace = sw.getTrace(null);
 		assertEquals(0, trace.size());
@@ -22,7 +22,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState1() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		TLCState a = new EqualityDummyTLCState(0, 0);
 
@@ -36,7 +36,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState2() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		TLCState a = new EqualityDummyTLCState(0, 0);
 		TLCState b = new EqualityDummyTLCState(0, 0, a);
@@ -51,7 +51,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState3() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		TLCState a = new EqualityDummyTLCState(0, 0);
 		TLCState b = new EqualityDummyTLCState(0, 0, a);
@@ -67,7 +67,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState4() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		TLCState a = new EqualityDummyTLCState(0, 0);
 		TLCState b = new EqualityDummyTLCState(0, 0, a);
@@ -87,7 +87,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState5() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		TLCState a = new EqualityDummyTLCState(0, 0);
 		TLCState b = new EqualityDummyTLCState(0, 0, a);
@@ -111,7 +111,7 @@ public class SimulationWorkerTest {
 
 	@Test
 	public void testGetTraceTLCState6() {
-		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null, null);
+		SimulationWorker sw = new SimulationWorker(0, null, null, 0, 0, 0, null, false, null, null, null, null);
 
 		TLCState a = new EqualityDummyTLCState(0, 0);
 		TLCState b = new EqualityDummyTLCState(0, 0, a);

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/SimulatorTraceStatsTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/SimulatorTraceStatsTest.java
@@ -1,0 +1,104 @@
+package tlc2.tool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import tlc2.util.FP64;
+import tlc2.util.RandomGenerator;
+import util.SimpleFilenameToStream;
+import util.TLAConstants;
+import util.ToolIO;
+
+/**
+ * Regression test for multi-worker trace length statistics.
+ *
+ * Runs simulation with multiple workers at a fixed trace depth and verifies
+ * that {@link Simulator#computeAggregateTraceStats()} produces the expected
+ * mean and variance via Welford's parallel/partitioned algorithm.
+ *
+ * With a fixed depth and no invariant violations, every trace hits the depth
+ * limit, so the expected mean equals the depth and the expected variance is
+ * zero.
+ */
+public class SimulatorTraceStatsTest {
+
+	private static final String BASE_DIR = System.getProperty("basedir",
+			System.getProperty("user.dir", "."));
+	private static final String TEST_MODEL = "test-model" + File.separator;
+	private static final String BASE_PATH = System.getProperty("basepath",
+			BASE_DIR + File.separator + TEST_MODEL);
+
+	private RandomGenerator rng;
+
+	@Before
+	public void setUp() throws Exception {
+		rng = new RandomGenerator(0);
+		ToolIO.setUserDir(BASE_PATH + File.separator + "simulation"
+				+ File.separator + "BasicMultiTrace");
+		FP64.Init();
+	}
+
+	@Test
+	public void testMultiWorkerTraceStats() {
+		final int numWorkers = 4;
+		final int traceDepth = 5;
+		final long traceNum = 50;
+
+		try {
+			final Simulator simulator = new Simulator("BasicMultiTrace",
+					TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, null, false,
+					traceDepth, traceNum, rng, 0,
+					new SimpleFilenameToStream(), numWorkers);
+			simulator.simulate();
+
+			// After simulation, verify the aggregated trace statistics.
+			final double[] stats = simulator.computeAggregateTraceStats();
+			final double aggMean = stats[0];
+			final double aggM2 = stats[1];
+			final long aggN = (long) stats[2];
+
+			// Each worker generates traceNum traces, all of length traceDepth.
+			assertEquals("aggregate N", numWorkers * traceNum, aggN);
+			assertEquals("aggregate mean", traceDepth, aggMean, 0.001);
+			// All traces have the same length, so M2 (and variance) must be zero.
+			assertEquals("aggregate M2", 0.0, aggM2, 0.001);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testSingleWorkerTraceStats() {
+		final int numWorkers = 1;
+		final int traceDepth = 5;
+		final long traceNum = 50;
+
+		try {
+			final Simulator simulator = new Simulator("BasicMultiTrace",
+					TLAConstants.Files.MODEL_CHECK_FILE_BASENAME, null, false,
+					traceDepth, traceNum, rng, 0,
+					new SimpleFilenameToStream(), numWorkers);
+			simulator.simulate();
+
+			final double[] stats = simulator.computeAggregateTraceStats();
+			final double aggMean = stats[0];
+			final double aggM2 = stats[1];
+			final long aggN = (long) stats[2];
+
+			assertEquals("aggregate N", traceNum, aggN);
+			assertEquals("aggregate mean", traceDepth, aggMean, 0.001);
+			assertEquals("aggregate M2", 0.0, aggM2, 0.001);
+
+		} catch (Exception e) {
+			e.printStackTrace();
+			fail(e.getMessage());
+		}
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/simulation/SimulationWorkerTest.java
@@ -443,18 +443,20 @@ public class SimulationWorkerTest extends CommonTestCase {
 		// Have the worker generate a specified number of traces of a fixed length.
 		LongAdder numOfGenStates = new LongAdder();
 		AtomicLong numOfGenTraces = new AtomicLong();
-		AtomicLong m2AndMean = new AtomicLong();
 		int traceDepth = 5;
 		long traceNum = 5;
 		SimulationWorker worker = new SimulationWorker(0, tool, resultQueue, 0, traceDepth, traceNum, null, false,
-				null, liveCheck, numOfGenStates, numOfGenTraces, m2AndMean);
+				null, liveCheck, numOfGenStates, numOfGenTraces);
 
 		worker.start(initStates);
 		worker.join();
 		assertFalse(worker.isAlive());
 		assertEquals(70, numOfGenStates.longValue());
 		assertEquals(5, numOfGenTraces.longValue());
-		// With traces all length 5, mean is 5 and m2 is 0, hence m2AndMean = 5
-		assertEquals(5, m2AndMean.get());
+		// With traces all length 5, mean is 5 and M2 is 0 (no variance).
+		// Original test checked: assertEquals(5, m2AndMean.get()) which encoded mean=5, M2=0.
+		assertEquals(5.0, worker.getLocalMean(), 0.001);
+		assertEquals(0.0, worker.getLocalM2(), 0.001);
+		assertEquals(5, worker.getLocalN());
 	}
 }


### PR DESCRIPTION
`SimulationWorker.collectPostTrace()` produced incorrect mean and variance when running with any number of workers > 1.

The root cause was a race condition where the CAS lambda reads `numOfGenTraces`. With N concurrent workers, this counter runs ~N times ahead of the actual number of Welford updates, systematically deflating the mean and introducing phantom variance. CAS retries exacerbate this by re-reading the ever-growing counter.

Replace the shared `AtomicLong` with per-worker local state. At reporting time, `Simulator.computeAggregateTraceStats()` merges all workers using Welford's parallel/partitioned algorithm.