### PR TITLE
Add VIEW to `-loadTrace` to handle non-shortest counterexamples.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_JsonTrace.tla
@@ -3,6 +3,7 @@ LOCAL INSTANCE TLC
 LOCAL INSTANCE TLCExt
 LOCAL INSTANCE Json
 LOCAL INSTANCE Sequences
+LOCAL INSTANCE Naturals
 
 CONSTANT _JsonTraceFile
 
@@ -22,9 +23,22 @@ CONSTANT _JsonTraceInputFile   \* Used by -loadTrace json
 LOCAL _TLCState(level) ==
 	Trace[level]
 
+LOCAL _JsonTraceDump == JsonDeserialize(_JsonTraceInputFile)
+
+\* A liveness counterexample's action graph contains a closing edge that
+\* completes the lasso. In a forward path s1->s2->...->sn every edge
+\* satisfies target[1] > source[1]; the closing edge is the unique edge
+\* where target[1] <= source[1] (back-to-state: <, stuttering: =).
+LOCAL _JsonTraceLassoTarget ==
+    LET actions == _JsonTraceDump["counterexample"]["action"]
+    IN IF \E i \in DOMAIN actions : actions[i][3][1] <= actions[i][1][1]
+       THEN LET i == CHOOSE i \in DOMAIN actions :
+                        actions[i][3][1] <= actions[i][1][1]
+            IN actions[i][3][1]
+       ELSE 0
+
 LOCAL _JsonTraceConstraint ==
     LET level == TLCGet("level")
-        dump  == JsonDeserialize(_JsonTraceInputFile)
         \* DOMAIN trace is meaningful only because we serialize TLA+ sets as JSON arrays. JSON has
         \* no set type---only the world's favorite least-common-denominator of strings, numbers,
         \* and nested lists---so on the wire every set is an ordered sequence. If that encoding
@@ -32,12 +46,12 @@ LOCAL _JsonTraceConstraint ==
         \* would stop matching what we dump.
         \* Rebuilding vars likewise assumes the array order matches TLC's normalized set order from
         \* when the trace was written; the format does not pin down a stronger invariant.
-        trace == dump["counterexample"]["state"]
+        trace == _JsonTraceDump["counterexample"]["state"]
         \* JSON deserializes sets as tuples, so convert back to a set
-        vars  == {dump["vars"][i] : i \in DOMAIN dump["vars"]}
+        vars  == {_JsonTraceDump["vars"][i] : i \in DOMAIN _JsonTraceDump["vars"]}
 	\* For liveness properties, TLC trace dumps stop at the state *before* the
 	\* lasso is closed. When replaying such a trace, TLC may request a state with
-	\*   level = Len(dump) + 1,
+	\*   level = Len(trace) + 1,
 	\* which does not exist in the dump. In that case, the constraint
 	\* is intentionally vacuously satisfied.
 	\* Since the names of the spec's variables are not known, Trace[level] is
@@ -50,5 +64,16 @@ LOCAL _JsonTraceConstraint ==
             \* to rename, add, or remove variables.
             \A v \in vars \cap (DOMAIN _TLCState(level)):
                     _TLCState(level)[v] = trace[level][2][v]
+
+\* VIEW for trace replay. Includes TLCGet("level") to prevent premature
+\* state collapsing within the trace. For liveness traces, the level
+\* beyond the trace is mapped to the lasso target so the cycle can close.
+LOCAL _JsonTraceView ==
+    LET level       == TLCGet("level")
+        traceLen    == Len(_JsonTraceDump["counterexample"]["state"])
+        lassoTarget == _JsonTraceLassoTarget
+    IN IF level <= traceLen
+       THEN << level, _TLCState(level) >>
+       ELSE << lassoTarget, _TLCState(level) >>
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTrace.tla
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/StandardModules/_TLCTrace.tla
@@ -2,6 +2,7 @@
 LOCAL INSTANCE TLC
 LOCAL INSTANCE TLCExt
 LOCAL INSTANCE Sequences
+LOCAL INSTANCE Naturals
 
 \* This operator has a Java module override (tlc2.module._TLCTrace#ioDeserialize).
 LOCAL _TLCTraceDeserialize(absoluteFilename) ==
@@ -41,6 +42,16 @@ LOCAL _TLCTraceFileDeserialized ==
 LOCAL _TLCState(level) ==
 	Trace[level]
 
+\* A liveness counterexample's action graph contains a closing edge that
+\* completes the lasso. In a forward path s1->s2->...->sn every edge
+\* satisfies target[1] > source[1]; the closing edge is the unique edge
+\* where target[1] <= source[1] (back-to-state: <, stuttering: =).
+LOCAL _TLCTraceLassoTarget ==
+    LET actions == _TLCTraceFileDeserialized["counterexample"]["action"]
+    IN IF \E e \in actions : e[3][1] <= e[1][1]
+       THEN (CHOOSE e \in actions : e[3][1] <= e[1][1])[3][1]
+       ELSE 0
+
 LOCAL _TLCTraceConstraint ==
     LET level == TLCGet("level")
         dump  == _TLCTraceFileDeserialized
@@ -62,5 +73,16 @@ LOCAL _TLCTraceConstraint ==
                 \* variables.
                 \A v \in vars \cap DOMAIN _TLCState(level):
                         _TLCState(level)[v] = pair[2][v]
+
+\* VIEW for trace replay. Includes TLCGet("level") to prevent premature
+\* state collapsing within the trace. For liveness traces, the level
+\* beyond the trace is mapped to the lasso target so the cycle can close.
+LOCAL _TLCTraceView ==
+    LET level       == TLCGet("level")
+        trace       == _TLCTraceFileDeserialized["counterexample"]["state"]
+        lassoTarget == _TLCTraceLassoTarget
+    IN IF \E pair \in trace : pair[1] = level
+       THEN << level, _TLCState(level) >>
+       ELSE << lassoTarget, _TLCState(level) >>
 
 =============================================================================

--- a/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/modanalyzer/SpecObj.java
@@ -1088,6 +1088,11 @@ public class SpecObj
 		return new ArrayList<>();
 	}
 
+	public OpDefNode getView() {
+		// overridden by sub-classes.
+		return null;
+	}
+
 	public void processConstantDefns(final Defns defns) {
 		// overridden by sub-classes.
 	}

--- a/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/TLC.java
@@ -49,6 +49,7 @@ import tlc2.tool.impl.ParameterizedSpecObj.Constraint;
 import tlc2.tool.impl.ParameterizedSpecObj.InvariantTemplate;
 import tlc2.tool.impl.ParameterizedSpecObj.PostCondition;
 import tlc2.tool.impl.ParameterizedSpecObj.RuntimeInvariantTemplate;
+import tlc2.tool.impl.ParameterizedSpecObj.View;
 import tlc2.tool.impl.Tool;
 import tlc2.tool.management.ModelCheckerMXWrapper;
 import tlc2.tool.management.TLCStandardMBean;
@@ -746,12 +747,14 @@ public class TLC {
 								.computeIfAbsent(ParameterizedSpecObj.CONSTRAINTS, k -> new ArrayList<Constraint>());
 						computeIfAbsent.add(
 								new Constraint("_TLCTrace", "_TLCTraceConstraint", "_TLCTraceInputFile", args[index++]));
+						params.putIfAbsent(ParameterizedSpecObj.VIEW, new View("_TLCTrace", "_TLCTraceView"));
 					} else if ("json".equalsIgnoreCase(fmt)) {
 						@SuppressWarnings("unchecked")
 						final List<Constraint> computeIfAbsent = (List<Constraint>) params
 								.computeIfAbsent(ParameterizedSpecObj.CONSTRAINTS, k -> new ArrayList<Constraint>());
 						computeIfAbsent.add(
 								new Constraint("_JsonTrace", "_JsonTraceConstraint", "_JsonTraceInputFile", args[index++]));
+						params.putIfAbsent(ParameterizedSpecObj.VIEW, new View("_JsonTrace", "_JsonTraceView"));
 					} else {
 						printErrorMsg("Error: Unknown format " + fmt + " given to -loadTrace.");
 						return false;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ParameterizedSpecObj.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/ParameterizedSpecObj.java
@@ -59,6 +59,7 @@ public class ParameterizedSpecObj extends SpecObj {
 	public static final String CONSTRAINTS = "CONSTRAINT";
 	public static final String POST_CONDITIONS = "POST_CONDITIONS";
 	public static final String INVARIANT = "INVARIANT";
+	public static final String VIEW = "VIEW";
 
 	private final Spec spec;
 	private final Map<String, Object> params;
@@ -114,6 +115,12 @@ public class ParameterizedSpecObj extends SpecObj {
 				rootModule.getRelatives().addExtendee(c.module);
 			}
 		}
+		if (firstCall && params.containsKey(VIEW)) {
+			final ModulePointer rootModule = pu.getRootModule();
+
+			final View view = (View) params.get(VIEW);
+			rootModule.getRelatives().addExtendee(view.module);
+		}
 		return pu;
 	}
 
@@ -154,6 +161,12 @@ public class ParameterizedSpecObj extends SpecObj {
 			for (final String module : inv.getModules()) {
 				processConstantsForModule(mt, module, new HashMap<>(), defns);
 			}
+		}
+
+		// Process constants for VIEW
+		if (params.containsKey(VIEW)) {
+			final View view = (View) params.get(VIEW);
+			processConstantsForModule(mt, view.module, view.constDefs, defns);
 		}
 
 		super.processConstantDefns(defns);
@@ -265,6 +278,27 @@ public class ParameterizedSpecObj extends SpecObj {
 		return res;
 	}
 
+	public static class View {
+
+		private final String module;
+		private final String operator;
+		private final Map<String, String> constDefs;
+
+		public View(final String module, final String operator) {
+			this(module, operator, new HashMap<>());
+		}
+
+		public View(final String module, final String operator, final String def, final String constDef) {
+			this(module, operator, Map.of(def, constDef));
+		}
+
+		public View(final String module, final String operator, Map<String, String> constDefs) {
+			this.module = module;
+			this.operator = operator;
+			this.constDefs = constDefs;
+		}
+	}
+
 	public static class Constraint {
 
 		private final String module;
@@ -280,6 +314,21 @@ public class ParameterizedSpecObj extends SpecObj {
 			this.operator = operator;
 			this.constDefs = constDefs;
 		}
+	}
+
+	@Override
+	public OpDefNode getView() {
+		if (!params.containsKey(VIEW)) {
+			return null;
+		}
+		final View view = (View) params.get(VIEW);
+		final ExternalModuleTable mt = getExternalModuleTable();
+		final ModuleNode moduleNode = mt.getModuleNode(view.module);
+		Assert.check(moduleNode != null, EC.GENERAL, "Could not find module: " + view.module);
+		final OpDefNode opDef = moduleNode.getOpDef(view.operator);
+		Assert.check(opDef != null, EC.GENERAL,
+				"Could not find operator: " + view.operator + " in module: " + view.module);
+		return opDef;
 	}
 
 	@Override

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Spec.java
@@ -243,8 +243,17 @@ abstract class Spec
     public final SemanticNode getViewSpec()
     {
         String name = this.config.getView();
-        if (name.length() == 0)
-            return null;
+        if (name.length() == 0) {
+            final OpDefNode paramView = specProcessor.getSpecObj().getView();
+            if (paramView == null) {
+                return null;
+            }
+            if (paramView.getArity() != 0) {
+                Assert.fail(EC.TLC_CONFIG_ID_REQUIRES_NO_ARG,
+                        new String[] { "view function", paramView.getName().toString() });
+            }
+            return paramView.getBody();
+        }
 
         Object view = this.defns.get(name);
         if (view == null)


### PR DESCRIPTION
  When TLC runs with multiple workers, `-dumpTrace` is not guaranteed to  produce the shortest counterexample. A subsequent `-loadTrace` may therefore encounter a trace where two distinct positions have identical variable values. Without a VIEW, TLC's fingerprint-based deduplication collapses these positions into a single state, causing it to skip the remainder of the trace.

The VIEW `<< TLCGet("level"), _TLCState(level) >>` makes each trace position fingerprint-unique by including the level, so the full trace is replayed regardless of repeated variable values.

Related: https://github.com/tlaplus/Examples/pull/204