### PR TITLE
fix: compute permutation on VIEW for fingerprint

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMut.java
@@ -166,110 +166,112 @@ public final class TLCStateMut extends TLCState implements Serializable {
    *
    * Since the values in this state can be shared by multiple threads
    * via the state queue. They have to be normalized before adding to
-   * the state queue.  We do that here.
+   * the state queue. We do that here.
    */
-	public final long fingerPrint() {
-		int sz = this.values.length;
+  public final long fingerPrint() {
+    int sz = this.values.length;
+    for (int i = 0; i < sz; i++) {
+      this.values[i].deepNormalize();
+    }
 
-		// TLC supports symmetry reduction. Symmetry reduction works by defining classes
-		// of symmetrically equivalent states for which TLC only checks a
-		// single representative of the equivalence class (orbit). E.g. in a two
-		// process mutual exclusion problem, the process ids are - most of the time -
-		// not relevant with regards to mutual exclusion: We don't care if process A or
-		// B is in the critical section as long as only a single process is in CS. Thus
-		// two states are symmetric that only differ in the process id variable value.
-		// Symmetry can also be observed graphically in the state graph s.t. subgraphs
-		// are isomorphic (Graph Isomorphism). Instead of enumerating the complete state
-		// graph, TLC enumerates one of the isomorphic subgraphs whose state correspond
-		// to the representatives. With respect to the corresponding Kripke structure M,
-		// the resulting Kripke M' is called the "quotient structure" (see "Exploiting
-		// Symmetry in Temporal Logic Model Checking" by Clarke et al).
-		// 
-		// The definition of equivalence classes (orbits) is provided manually by the
-		// user at startup by defining 1 to n symmetry sets. Thus TLC has to find
-		// representative at runtime only which happens below. Given any state s, TLC
-		// evaluates rep(s) to find the lexicographically smallest state ss = rep(s)
-		// with regards to the variable values. The state ss is then fingerprint instead
-		// of s.
-		//
-		// Evaluating rep(s) - to reduce s to ss - requires to apply all permutations in
-		// the group this.perms (derived from the user-defined orbit). This is known as
-		// the constructive orbit problem and is NP-hard. The loop has O(|perms| * |this.values|)
-		// with |prems| = |symmetry set 1|! * |symmetry set 2|! * ... * |symmetry set n|. 
-        //		
-		// minVals is what is used to calculate/generate the fingerprint below.
-		// If this state is not the lexicographically smallest state ss, its current
-		// minVals will be replaced temporarily with the values of ss for the
-		// calculation of the fingerprint.
-		IValue[] minVals = this.values;
-		if (perms != null) {
-			IValue[] vals = new IValue[sz];
-			// The following for loop converges to the smallest state ss under symmetry by
-			// looping over all permutations applying each. If the outcome turns out to be
-			// lexicographically smaller than the currently smallest, it replaces the
-			// current smallest. Once all permutations (perms) have been processed, we know
-			// we have found the smallest state.
-			NEXT_PERM: for (int i = 0; i < perms.length; i++) {
-				int cmp = 0;
-				// For each value in values succinctly permute the current value
-				// and compare it to its corresponding minValue in minVals.
-				for (int j = 0; j < sz; j++) {
-					vals[j] = this.values[j].permute(perms[i]);
-					if (cmp == 0) {
-						// Only compare unless an earlier compare has found a
-						// difference already (if a difference has been found
-						// earlier, still permute the remaining values of the
-						// state to fully permute all state values).
-						cmp = vals[j].compareTo(minVals[j]);
-						if (cmp > 0) {
-							// When cmp evaluates to >0, all subsequent
-							// applications of perms[i] for the remaining values
-							// won't make the resulting vals[] smaller than
-							// minVals. Thus, exit preemptively from the loop
-							// over vals. This works because perms is the cross
-							// product of all symmetry sets.
-							continue NEXT_PERM;
-						}
-					}
-				}
-				// cmp < 0 means the current state is part of a symmetry
-				// permutation set/group and not the "smallest" one.
-				if (cmp < 0) {
-					if (minVals == this.values) {
-						minVals = vals;
-						vals = new IValue[sz];
-					} else {
-						IValue[] temp = minVals;
-						minVals = vals;
-						vals = temp;
-					}
-				}
-			}
-		}
-		// Fingerprint the state:
-		long fp = FP64.New();
-		if (viewMap == null) {
-			for (int i = 0; i < sz; i++) {
-				fp = minVals[i].fingerPrint(fp);
-			}
-			if (this.values != minVals) {
-				for (int i = 0; i < sz; i++) {
-					this.values[i].deepNormalize();
-				}
-			}
-		} else {
-			for (int i = 0; i < sz; i++) {
-				this.values[i].deepNormalize();
-			}
-			TLCStateMut state = this;
-			if (minVals != this.values) {
-				state = new TLCStateMut(minVals);
-			}
-			IValue val = mytool.eval(viewMap, Context.Empty, state);
-			fp = val.fingerPrint(fp);
-		}
-		return fp;
-	}
+    // TLC supports symmetry reduction. Symmetry reduction works by defining classes
+    // of symmetrically equivalent states for which TLC only checks a
+    // single representative of the equivalence class (orbit). E.g. in a two
+    // process mutual exclusion problem, the process ids are - most of the time -
+    // not relevant with regards to mutual exclusion: We don't care if process A or
+    // B is in the critical section as long as only a single process is in CS. Thus
+    // two states are symmetric that only differ in the process id variable value.
+    // Symmetry can also be observed graphically in the state graph s.t. subgraphs
+    // are isomorphic (Graph Isomorphism). Instead of enumerating the complete state
+    // graph, TLC enumerates one of the isomorphic subgraphs whose state correspond
+    // to the representatives. With respect to the corresponding Kripke structure M,
+    // the resulting Kripke M' is called the "quotient structure" (see "Exploiting
+    // Symmetry in Temporal Logic Model Checking" by Clarke et al).
+    //
+    // The definition of equivalence classes (orbits) is provided manually by the
+    // user at startup by defining 1 to n symmetry sets. Thus TLC has to find
+    // representative at runtime only which happens below. Given any state s, TLC
+    // evaluates rep(s) to find the lexicographically smallest state ss = rep(s)
+    // with regards to the variable values. The state ss is then fingerprint instead
+    // of s.
+    //
+    // Evaluating rep(s) - to reduce s to ss - requires to apply all permutations in
+    // the group this.perms (derived from the user-defined orbit). This is known as
+    // the constructive orbit problem and is NP-hard. The loop has O(|perms| *
+    // |this.values|)
+    // with |prems| = |symmetry set 1|! * |symmetry set 2|! * ... * |symmetry set
+    // n|.
+    //
+    // minVals is what is used to calculate/generate the fingerprint below.
+    // If this state is not the lexicographically smallest state ss, its current
+    // minVals will be replaced temporarily with the values of ss for the
+    // calculation of the fingerprint.
+    IValue[] values;
+    if (viewMap == null) {
+      values = this.values;
+    } else {
+      // If viewMap is non-null, we have to evaluate the view function first,
+      // so that the symmetry reduction is applied to the view of the state, not the
+      // state itself as the lexicographical order for the view is not necessarily the
+      // same as for the state.
+      IValue view = mytool.eval(viewMap, Context.Empty, this);
+      values = new IValue[] { view };
+      sz = 1;
+    }
+
+    IValue[] minVals = values;
+
+    if (perms != null) {
+      IValue[] vals = new IValue[sz];
+      // The following for loop converges to the smallest state ss under symmetry by
+      // looping over all permutations applying each. If the outcome turns out to be
+      // lexicographically smaller than the currently smallest, it replaces the
+      // current smallest. Once all permutations (perms) have been processed, we know
+      // we have found the smallest state.
+      NEXT_PERM: for (int i = 0; i < perms.length; i++) {
+        int cmp = 0;
+        // For each value in values succinctly permute the current value
+        // and compare it to its corresponding minValue in minVals.
+        for (int j = 0; j < sz; j++) {
+          vals[j] = values[j].permute(perms[i]);
+          if (cmp == 0) {
+            // Only compare unless an earlier compare has found a
+            // difference already (if a difference has been found
+            // earlier, still permute the remaining values of the
+            // state to fully permute all state values).
+            cmp = vals[j].compareTo(minVals[j]);
+            if (cmp > 0) {
+              // When cmp evaluates to >0, all subsequent
+              // applications of perms[i] for the remaining values
+              // won't make the resulting vals[] smaller than
+              // minVals. Thus, exit preemptively from the loop
+              // over vals. This works because perms is the cross
+              // product of all symmetry sets.
+              continue NEXT_PERM;
+            }
+          }
+        }
+        // cmp < 0 means the current state is part of a symmetry
+        // permutation set/group and not the "smallest" one.
+        if (cmp < 0) {
+          if (minVals == values) {
+            minVals = vals;
+            vals = new IValue[sz];
+          } else {
+            IValue[] temp = minVals;
+            minVals = vals;
+            vals = temp;
+          }
+        }
+      }
+    }
+    // Fingerprint the state:
+    long fp = FP64.New();
+    for (int i = 0; i < sz; i++) {
+      fp = minVals[i].fingerPrint(fp);
+    }
+    return fp;
+  }
 
   public final boolean allAssigned() {
     int len = this.values.length;    

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/TLCStateMutExt.java
@@ -179,108 +179,111 @@ public final class TLCStateMutExt extends TLCState implements Serializable {
 		return fingerPrint(mytool);
 	}
 
-    @Override
-	public final long fingerPrint(final ITool tool) {
-			int sz = this.values.length;
+	@Override
+    public final long fingerPrint(final ITool tool) {
+        int sz = this.values.length;
+        for (int i = 0; i < sz; i++) {
+            this.values[i].deepNormalize();
+        }
+
 		// TLC supports symmetry reduction. Symmetry reduction works by defining classes
-		// of symmetrically equivalent states for which TLC only checks a
-		// single representative of the equivalence class (orbit). E.g. in a two
-		// process mutual exclusion problem, the process ids are - most of the time -
-		// not relevant with regards to mutual exclusion: We don't care if process A or
-		// B is in the critical section as long as only a single process is in CS. Thus
-		// two states are symmetric that only differ in the process id variable value.
-		// Symmetry can also be observed graphically in the state graph s.t. subgraphs
-		// are isomorphic (Graph Isomorphism). Instead of enumerating the complete state
-		// graph, TLC enumerates one of the isomorphic subgraphs whose state correspond
-		// to the representatives. With respect to the corresponding Kripke structure M,
-		// the resulting Kripke M' is called the "quotient structure" (see "Exploiting
-		// Symmetry in Temporal Logic Model Checking" by Clarke et al).
-		// 
-		// The definition of equivalence classes (orbits) is provided manually by the
-		// user at startup by defining 1 to n symmetry sets. Thus TLC has to find
-		// representative at runtime only which happens below. Given any state s, TLC
-		// evaluates rep(s) to find the lexicographically smallest state ss = rep(s)
-		// with regards to the variable values. The state ss is then fingerprint instead
-		// of s.
-		//
-		// Evaluating rep(s) - to reduce s to ss - requires to apply all permutations in
-		// the group this.perms (derived from the user-defined orbit). This is known as
-		// the constructive orbit problem and is NP-hard. The loop has O(|perms| * |this.values|)
-		// with |prems| = |symmetry set 1|! * |symmetry set 2|! * ... * |symmetry set n|. 
-        //		
-		// minVals is what is used to calculate/generate the fingerprint below.
-		// If this state is not the lexicographically smallest state ss, its current
-		// minVals will be replaced temporarily with the values of ss for the
-		// calculation of the fingerprint.
-		IValue[] minVals = this.values;
+        // of symmetrically equivalent states for which TLC only checks a
+        // single representative of the equivalence class (orbit). E.g. in a two
+        // process mutual exclusion problem, the process ids are - most of the time -
+        // not relevant with regards to mutual exclusion: We don't care if process A or
+        // B is in the critical section as long as only a single process is in CS. Thus
+        // two states are symmetric that only differ in the process id variable value.
+        // Symmetry can also be observed graphically in the state graph s.t. subgraphs
+        // are isomorphic (Graph Isomorphism). Instead of enumerating the complete state
+        // graph, TLC enumerates one of the isomorphic subgraphs whose state correspond
+        // to the representatives. With respect to the corresponding Kripke structure M,
+        // the resulting Kripke M' is called the "quotient structure" (see "Exploiting
+        // Symmetry in Temporal Logic Model Checking" by Clarke et al).
+        //
+        // The definition of equivalence classes (orbits) is provided manually by the
+        // user at startup by defining 1 to n symmetry sets. Thus TLC has to find
+        // representative at runtime only which happens below. Given any state s, TLC
+        // evaluates rep(s) to find the lexicographically smallest state ss = rep(s)
+        // with regards to the variable values. The state ss is then fingerprint instead
+        // of s.
+        //
+        // Evaluating rep(s) - to reduce s to ss - requires to apply all permutations in
+        // the group this.perms (derived from the user-defined orbit). This is known as
+        // the constructive orbit problem and is NP-hard. The loop has O(|perms| *
+        // |this.values|)
+        // with |prems| = |symmetry set 1|! * |symmetry set 2|! * ... * |symmetry set
+        // n|.
+        //
+        // minVals is what is used to calculate/generate the fingerprint below.
+        // If this state is not the lexicographically smallest state ss, its current
+        // minVals will be replaced temporarily with the values of ss for the
+        // calculation of the fingerprint.
+        IValue[] values;
+        if (viewMap == null) {
+            values = this.values;
+        } else {
+            // If viewMap is non-null, we have to evaluate the view function first,
+            // so that the symmetry reduction is applied to the view of the state, not the
+            // state itself as the lexicographical order for the view is not necessarily the
+            // same as for the state.
+            IValue view = tool.eval(viewMap, Context.Empty, this);
+            values = new IValue[] { view };
+            sz = 1;
+        }
+
+        IValue[] minVals = values;
+
 		if (perms != null) {
-			IValue[] vals = new IValue[sz];
-			// The following for loop converges to the smallest state ss under symmetry by
-			// looping over all permutations applying each. If the outcome turns out to be
-			// lexicographically smaller than the currently smallest, it replaces the
-			// current smallest. Once all permutations (perms) have been processed, we know
-			// we have found the smallest state.
-			NEXT_PERM: for (int i = 0; i < perms.length; i++) {
-				int cmp = 0;
-				// For each value in values succinctly permute the current value
-				// and compare it to its corresponding minValue in minVals.
-				for (int j = 0; j < sz; j++) {
-					vals[j] = this.values[j].permute(perms[i]);
-					if (cmp == 0) {
-						// Only compare unless an earlier compare has found a
-						// difference already (if a difference has been found
-						// earlier, still permute the remaining values of the
-						// state to fully permute all state values).
-						cmp = vals[j].compareTo(minVals[j]);
-						if (cmp > 0) {
-							// When cmp evaluates to >0, all subsequent
-							// applications of perms[i] for the remaining values
-							// won't make the resulting vals[] smaller than
-							// minVals. Thus, exit preemptively from the loop
-							// over vals. This works because perms is the cross
-							// product of all symmetry sets.
-							continue NEXT_PERM;
-						}
-					}
-				}
-				// cmp < 0 means the current state is part of a symmetry
-				// permutation set/group and not the "smallest" one.
-				if (cmp < 0) {
-					if (minVals == this.values) {
-						minVals = vals;
-						vals = new IValue[sz];
-					} else {
-						IValue[] temp = minVals;
-						minVals = vals;
-						vals = temp;
-					}
-				}
-			}
-		}
-		// Fingerprint the state:
-		long fp = FP64.New();
-		if (viewMap == null) {
-			for (int i = 0; i < sz; i++) {
-				fp = minVals[i].fingerPrint(fp);
-			}
-			if (this.values != minVals) {
-				for (int i = 0; i < sz; i++) {
-					this.values[i].deepNormalize();
-				}
-			}
-		} else {
-			for (int i = 0; i < sz; i++) {
-				this.values[i].deepNormalize();
-			}
-			TLCStateMutExt state = this;
-			if (minVals != this.values) {
-				state = new TLCStateMutExt(minVals);
-			}
-			IValue val = tool.eval(viewMap, Context.Empty, state);
-			fp = val.fingerPrint(fp);
-		}
-		return fp;
-	}
+            IValue[] vals = new IValue[sz];
+            // The following for loop converges to the smallest state ss under symmetry by
+            // looping over all permutations applying each. If the outcome turns out to be
+            // lexicographically smaller than the currently smallest, it replaces the
+            // current smallest. Once all permutations (perms) have been processed, we know
+            // we have found the smallest state.
+            NEXT_PERM: for (int i = 0; i < perms.length; i++) {
+                int cmp = 0;
+                // For each value in values succinctly permute the current value
+                // and compare it to its corresponding minValue in minVals.
+                for (int j = 0; j < sz; j++) {
+                    vals[j] = values[j].permute(perms[i]);
+                    if (cmp == 0) {
+                        // Only compare unless an earlier compare has found a
+                        // difference already (if a difference has been found
+                        // earlier, still permute the remaining values of the
+                        // state to fully permute all state values).
+                        cmp = vals[j].compareTo(minVals[j]);
+                        if (cmp > 0) {
+                            // When cmp evaluates to >0, all subsequent
+                            // applications of perms[i] for the remaining values
+                            // won't make the resulting vals[] smaller than
+                            // minVals. Thus, exit preemptively from the loop
+                            // over vals. This works because perms is the cross
+                            // product of all symmetry sets.
+                            continue NEXT_PERM;
+                        }
+                    }
+                }
+                // cmp < 0 means the current state is part of a symmetry
+                // permutation set/group and not the "smallest" one.
+                if (cmp < 0) {
+                    if (minVals == values) {
+                        minVals = vals;
+                        vals = new IValue[sz];
+                    } else {
+                        IValue[] temp = minVals;
+                        minVals = vals;
+                        vals = temp;
+                    }
+                }
+            }
+        }
+        // Fingerprint the state:
+        long fp = FP64.New();
+        for (int i = 0; i < sz; i++) {
+            fp = minVals[i].fingerPrint(fp);
+        }
+        return fp;
+    }
 
   public final boolean allAssigned() {
     int len = this.values.length;    


### PR DESCRIPTION
This PR attempts to fix #1368 and #206 by computing the view upfront and then applying symmetry sets to it.

Tests are passing, and trying it with both the simple TLA+ spec in #1368 and with the original #206 one seems to report the expected number of states.

I wanted to add both specs to the test cases, but I am not sure how to check the expected number of states generated. Probably adding a new test case in Java? Is it overkill? Please give me some guidance here.