### PR TITLE
Add optional CLI wrapper for tla2tools.jar

### DIFF
--- a/general/cli/README.md
+++ b/general/cli/README.md
@@ -1,0 +1,44 @@
+# TLA+ CLI Wrappers
+
+This directory contains a lightweight command-line wrapper for the TLA+ tools
+provided in `tla2tools.jar`.
+
+## Overview
+
+The TLA+ tools are typically invoked via Java class names, for example:
+
+```bash
+  java -cp tla2tools.jar tlc2.TLC
+```
+
+This wrapper provides a more convenient interface:
+
+```bash
+tla <command> [args]
+```
+
+Available commands:
+- `tlc` Run the model checker
+- `sany` Parse a TLA+ specification
+- `repl` Start the TLA+ REPL
+- `pcal` Translate PlusCal to TLA+
+- `tla2tex` Export TLA+ to LaTeX
+
+Examples:
+```bash
+tla tlc Spec.tla
+tla sany Spec.tla
+```
+
+## Requirements
+
+- Java 11+
+- `tla2tools.jar`, available from the official releases of the
+  TLA+ project
+
+## Setup
+
+Download `tla2tools.jar` from the official releases and set the environment variable:
+
+```sh
+export TLA_JAR=/path/to/tla2tools.jar

--- a/general/cli/tla
+++ b/general/cli/tla
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JAVA="${JAVA_HOME:+$JAVA_HOME/bin/}java"
+JAR="${TLA_JAR:-}"
+
+if [ -z "$JAR" ]; then
+  echo "Error: tla2tools.jar not found." >&2
+  echo "Please set TLA_JAR to the path of tla2tools.jar." >&2
+  exit 1
+fi
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+  tlc)
+    exec "$JAVA" -cp "$JAR" tlc2.TLC "$@"
+    ;;
+  sany)
+    exec "$JAVA" -cp "$JAR" tla2sany.SANY "$@"
+    ;;
+  repl)
+    exec "$JAVA" -cp "$JAR" tlc2.REPL "$@"
+    ;;
+  pcal)
+    exec "$JAVA" -cp "$JAR" pcal.trans "$@"
+    ;;
+  tla2tex)
+    exec "$JAVA" -cp "$JAR" tla2tex.TLA "$@"
+    ;;
+  ""|help|-h|--help)
+    cat <<EOF
+TLA+ CLI
+
+Usage:
+  tla <command> [args]
+
+Commands:
+  tlc       Run model checker
+  sany      Parse spec
+  repl      Start REPL
+  pcal      Translate PlusCal
+  tla2tex   Export to LaTeX
+
+Environment:
+  TLA_JAR   Path to tla2tools.jar
+EOF
+    ;;
+  *)
+    echo "Unknown command: $cmd" >&2
+    exit 1
+    ;;
+esac

--- a/general/cli/tla
+++ b/general/cli/tla
@@ -10,9 +10,70 @@ if [ -z "$JAR" ]; then
   exit 1
 fi
 
-cmd="${1:-}"
-shift || true
+print_help() {
+  cat <<EOF
+TLA+ CLI
 
+Usage:
+  tla <command> [args]
+
+Commands:
+  tlc       Run model checker
+  sany      Parse spec
+  repl      Start REPL
+  pcal      Translate PlusCal
+  tla2tex   Export to LaTeX
+
+Global options:
+  -h, --help     Show this help
+  --version      Show version
+
+Environment:
+  TLA_JAR   Path to tla2tools.jar
+EOF
+}
+
+print_version() {
+  echo "tla CLI version 1.0"
+}
+
+# No args → show help
+if [ $# -eq 0 ]; then
+  print_help
+  exit 0
+fi
+
+cmd="$1"
+
+# Handle global flags BEFORE shifting
+case "$cmd" in
+  -h|--help|help)
+    print_help
+    exit 0
+    ;;
+  --version)
+    print_version
+    exit 0
+    ;;
+esac
+
+# Only shift if it's a real subcommand
+case "$cmd" in
+  tlc|sany|repl|pcal|tla2tex)
+    shift
+    ;;
+  *)
+    # If it's a flag, stay quiet (important for tab completion)
+    if [[ "$cmd" == -* ]]; then
+      exit 0
+    fi
+
+    echo "Unknown command: $cmd" >&2
+    exit 1
+    ;;
+esac
+
+# Dispatch
 case "$cmd" in
   tlc)
     exec "$JAVA" -cp "$JAR" tlc2.TLC "$@"
@@ -28,27 +89,5 @@ case "$cmd" in
     ;;
   tla2tex)
     exec "$JAVA" -cp "$JAR" tla2tex.TLA "$@"
-    ;;
-  ""|help|-h|--help)
-    cat <<EOF
-TLA+ CLI
-
-Usage:
-  tla <command> [args]
-
-Commands:
-  tlc       Run model checker
-  sany      Parse spec
-  repl      Start REPL
-  pcal      Translate PlusCal
-  tla2tex   Export to LaTeX
-
-Environment:
-  TLA_JAR   Path to tla2tools.jar
-EOF
-    ;;
-  *)
-    echo "Unknown command: $cmd" >&2
-    exit 1
     ;;
 esac


### PR DESCRIPTION
This PR adds a minimal CLI wrapper (`tla`) for invoking the TLA+ tools.

Currently, users invoke tools via Java class names, for example:
  java -cp tla2tools.jar tlc2.TLC

This change introduces an optional unified entrypoint:

  tla tlc Spec.tla
  tla sany Spec.tla
  tla repl

The script delegates directly to existing Java entry points in
tla2tools.jar and does not introduce any new functionality.

Key properties:
- no changes to core tools or build system
- no assumptions about repository layout or build artifacts
- requires users to provide tla2tools.jar (e.g., via TLA_JAR)
- placed under general/cli to remain separate from core code

This is intended as a small usability improvement and does not affect
existing workflows.

As a secondary benefit, having a stable CLI entrypoint also makes it easier
to package the tla2tools via external package managers (e.g., Homebrew),
without requiring changes to the core repository. 
A brew formulae for the toolbox does already exists but not for tla2tools.