### PR TITLE
SANY: add spec dir to include paths by default

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -205,10 +205,9 @@ jobs:
         # Skip Apalache-specific examples.
         find "$EXAMPLES_DIR/specifications" \
         -type f -iname "*.tla" -not -name "Einstein.tla" -and -not -name "IndInv_apa.tla" -and -not -name "*_TTrace_*.tla" -print0 |
-        xargs --verbose --null --no-run-if-empty --max-procs=$(nproc) --replace={TLA_FILE} sh -c \
-        'TLA_DIR=$(dirname "{TLA_FILE}") && \
-        java -ea -cp "'"$DIST_DIR/tla2tools.jar"'":$TLA_DIR:"'"$DEPS_DIR/community/modules.jar:$DEPS_DIR/tlapm/library"'" \
-        tla2sany.SANY -error-codes "{TLA_FILE}"'
+        xargs --verbose --null --no-run-if-empty --max-procs=$(nproc) -I {TLA_FILE} \
+        java -ea -cp "$DIST_DIR/tla2tools.jar:$DEPS_DIR/community/modules.jar:$DEPS_DIR/tlapm/library" \
+        tla2sany.SANY -error-codes "{TLA_FILE}"
     - name: Run XMLExporter on tlaplus/examples modules
       run: |
         set -o pipefail

--- a/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/drivers/SANY.java
@@ -30,6 +30,7 @@ import tla2sany.semantic.Generator;
 import tla2sany.semantic.ModuleNode;
 import tla2sany.st.TreeNode;
 import util.FileUtil;
+import util.SimpleFilenameToStream;
 import util.ToolIO;
 import util.UniqueString;
 import util.UsageGenerator;
@@ -603,7 +604,7 @@ public class SANY {
     }
   }
 
-  public static void SANYmain0(String args[]) throws SANYExitException {
+  public static void SANYmain0(String[] args) throws SANYExitException {
     if (args.length == 0) {
       printUsage();
       throw new SANYExitException(SanyExitCode.ERROR, "No arguments provided");
@@ -729,7 +730,8 @@ public class SANY {
       // semantically analyze, and level check the spec started in
       // file Filename leaving the result (normally) in Specification
       // spec.
-      SpecObj spec = new SpecObj(args[i], null);
+      final SpecObj spec = new SpecObj(args[i], SimpleFilenameToStream.specDirAndTlaLibrary(args[i]));
+
       // check if file exists
       if (FileUtil.createNamedInputStream(args[i], spec.getResolver()) != null) 
       {

--- a/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
+++ b/tlatools/org.lamport.tlatools/src/util/SimpleFilenameToStream.java
@@ -11,7 +11,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -81,6 +83,37 @@ public class SimpleFilenameToStream implements FilenameToStream {
     standardLibraryResourceLocator = getInstallationBasePath();
   }
 
+  private SimpleFilenameToStream(final ResourceLocator locator) {
+    this.userFileResourceLocator = locator;
+    this.standardLibraryResourceLocator = getInstallationBasePath();
+  }
+
+  /**
+   * Search for specs in the following order:
+   *  1. The parent dir of the given spec file.
+   *  2. Paths in the TLA-Library Java system property.
+   *  3. The dir from which Java was run, or the current working dir.
+   */
+  public static SimpleFilenameToStream specDirAndTlaLibrary(final String specPath) {
+    final List<ResourceLocator> locators = new ArrayList<>();
+
+    // Make best-effort attempt at getting the spec path's parent directory
+    // and adding it to the list of include paths.
+    try {
+      final Path specParentDir = Path.of(specPath).getParent();
+      if (specParentDir != null) {
+        locators.add(searchFilesystemPaths(specParentDir));
+      }
+    } catch (InvalidPathException e) {
+      // Ignore this; if the path is really invalid, SANY will fail when it
+      // tries to load the spec, and will provide nice error reporting.
+    }
+
+    locators.add(searchTlaLibraryProperty());
+    locators.add(searchUserDirOrCWD());
+    return new SimpleFilenameToStream(new SequentialResourceLocator(locators));
+  }
+
   /**
    * Find the TLA+ standard modules.
    *
@@ -133,6 +166,29 @@ public class SimpleFilenameToStream implements FilenameToStream {
             .map(Path::of)
             .map(FilesystemResourceLocator::new)
             .collect(Collectors.toList()));
+  }
+
+  /**
+   * Create a locator that searches the given filesystem paths.
+   *
+   * @param paths an array of paths
+   * @return a locator that searches the given paths
+   */
+  private static ResourceLocator searchFilesystemPaths(Path... paths) {
+    return new SequentialResourceLocator(
+            Arrays.stream(paths)
+            .map(FilesystemResourceLocator::new)
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * Builds a {@link ResourceLocator} to look for paths specified in the
+   * -DTLA-Library Java system property.
+   */
+  private static ResourceLocator searchTlaLibraryProperty() {
+    final String property = System.getProperty(TLA_LIBRARY);
+    final String[] paths = parsePaths(property);
+    return searchFilesystemPaths(paths);
   }
 
   /**

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IncludeDirPrecedenceTest.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IncludeDirPrecedenceTest.java
@@ -1,0 +1,160 @@
+package tla2sany.drivers;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import tlc2.tool.CommonTestCase;
+import util.TestPrintStream;
+import util.ToolIO;
+
+/**
+ * Test the relative precedences of SANY's various methods of searching for
+ * an EXTENDed or INSTANCEd module.
+ */
+public class IncludeDirPrecedenceTest {
+
+  private static final Path SPEC_DIR = Paths.get(CommonTestCase.BASE_DIR).resolve("test/tla2sany/drivers/");
+  private static final Path SPEC_SUBDIR = SPEC_DIR.resolve("include/");
+  private static final Path SPEC_SUBDIR_OTHER = SPEC_DIR.resolve("other/");
+  private static final Path SPEC_PATH = SPEC_DIR.resolve("IncludeDirPrecedenceTest.tla");
+  private static final String EXTENDED_SPEC_NAME = "IncludeDirPrecedenceTestTarget.tla";
+  private static final Path EXTENDED_SPEC_PATH_SAME_DIR = SPEC_DIR.resolve(EXTENDED_SPEC_NAME);
+  private static final Path EXTENDED_SPEC_PATH_SUBDIR = SPEC_SUBDIR.resolve(EXTENDED_SPEC_NAME);
+  private static final Path PROPERTY_SPEC_PATH = SPEC_DIR.resolve("TlaLibraryPropertyTest.tla");
+  private static final Path EXTENDED_PROPERTY_SPEC_PATH = SPEC_SUBDIR.resolve("TlaLibraryPropertyTestTarget.tla");
+  private static final Path EXTENDED_PROPERTY_SPEC_PATH_OTHER = SPEC_SUBDIR_OTHER.resolve("TlaLibraryPropertyTestTarget.tla");
+  
+  private static void setOrClear(String key, String value) {
+		if (null == value) {
+		  System.clearProperty(key);
+		} else {
+		  System.setProperty(key, value);
+		}
+  }
+
+  /**
+   * Without any specified include dirs, SANY should find the module in the
+   * same directory as the base module.
+   */
+  @Test
+  public void testNoIncludeDir() throws SANYExitException {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+		SANY.SANYmain0(new String[] {SPEC_PATH.toString()});
+		out.assertContains(SPEC_PATH.toString());
+		out.assertContains(EXTENDED_SPEC_PATH_SAME_DIR.toString());
+		out.assertNoSubstring(EXTENDED_SPEC_PATH_SUBDIR.toString());
+  }
+  
+  /**
+   * Baseline test to ensure below tests are actually testing what we think:
+   * ensure SANY cannot find a spec in the include dir by default.
+   */
+  @Test
+  public void testCannotFindSpec() {
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    try {
+      SANY.SANYmain0(new String[] {PROPERTY_SPEC_PATH.toString()});
+      Assert.fail();
+    } catch (SANYExitException e) {
+      Assert.assertEquals(SanyExitCode.ERROR, e.getEnumeratedExitCode());
+      out.assertContains(PROPERTY_SPEC_PATH.toString());
+    }
+  }
+ 
+  /**
+   * Tests that SANY will resolve specs in the CWD. This resolves the error
+   * in the {@link IncludeDirPrecedenceTest#testCannotFindSpec()} test.
+   */
+  @Test
+  public void testUserDir() throws SANYExitException {
+    final String oldUserDir = ToolIO.getUserDir();
+    final String oldUserDirProp = System.getProperty("user.dir");
+
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    ToolIO.setUserDir(SPEC_SUBDIR.toString());
+    System.setProperty("user.dir", SPEC_SUBDIR.toString());
+
+		SANY.SANYmain0(new String[] {PROPERTY_SPEC_PATH.toString()});
+
+		out.assertContains(PROPERTY_SPEC_PATH.toString());
+		out.assertContains(EXTENDED_PROPERTY_SPEC_PATH.toString());
+
+		ToolIO.setUserDir(oldUserDir);
+		setOrClear("user.dir", oldUserDirProp);
+  }
+
+  /**
+   * SANY should find an imported module if it is on the TLA-Library system
+   * property list of search paths. This resolves the error in the
+   * {@link IncludeDirPrecedenceTest#testCannotFindSpec()} test.
+   */
+  @Test
+  public void testTlaLibraryProperty() throws SANYExitException {
+    final String oldProperty = System.getProperty("TLA-Library");
+
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    System.setProperty("TLA-Library", SPEC_SUBDIR.toString());
+
+		SANY.SANYmain0(new String[] {PROPERTY_SPEC_PATH.toString()});
+
+		out.assertContains(PROPERTY_SPEC_PATH.toString());
+		out.assertContains(EXTENDED_PROPERTY_SPEC_PATH.toString());
+		
+		setOrClear("TLA-Library", oldProperty);
+  }
+
+  /**
+   * Even when the TLA-Library property is defined, specs in the same dir as
+   * the base module take precedence over it.
+   */
+  @Test
+  public void testTlaLibraryPropertyOverruled() throws SANYExitException {
+    final String oldProperty = System.getProperty("TLA-Library");
+
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    System.setProperty("TLA-Library", SPEC_SUBDIR.toString());
+
+		SANY.SANYmain0(new String[] {SPEC_PATH.toString()});
+
+		out.assertContains(SPEC_PATH.toString());
+		out.assertContains(EXTENDED_SPEC_PATH_SAME_DIR.toString());
+		out.assertNoSubstring(EXTENDED_SPEC_PATH_SUBDIR.toString());
+
+		setOrClear("TLA-Library", oldProperty);
+  }
+
+  /**
+   * When running SANY from a particular directory, specs found in the
+   * TLA-Library property should take precedence over specs found in the CWD.
+   */
+  @Test
+  public void testUserDirOverruledByTlaLibraryProperty() throws SANYExitException {
+    final String oldTlaLibProp = System.getProperty("TLA-Library");
+    final String oldUserDir = ToolIO.getUserDir();
+    final String oldUserDirProp = System.getProperty("user.dir");
+
+    final TestPrintStream out = new TestPrintStream();
+    ToolIO.out = out;
+    System.setProperty("TLA-Library", SPEC_SUBDIR_OTHER.toString());
+    ToolIO.setUserDir(SPEC_SUBDIR.toString());
+    System.setProperty("user.dir", SPEC_SUBDIR.toString());
+
+		SANY.SANYmain0(new String[] {PROPERTY_SPEC_PATH.toString()});
+
+		out.assertContains(PROPERTY_SPEC_PATH.toString());
+		out.assertContains(EXTENDED_PROPERTY_SPEC_PATH_OTHER.toString());
+		out.assertNoSubstring(EXTENDED_SPEC_PATH_SUBDIR.toString());
+
+		setOrClear("user.dir", oldUserDirProp);
+		ToolIO.setUserDir(oldUserDir);
+		setOrClear("TLA-Library", oldTlaLibProp);
+  }
+}

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IncludeDirPrecedenceTest.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IncludeDirPrecedenceTest.tla
@@ -1,0 +1,3 @@
+---- MODULE IncludeDirPrecedenceTest ----
+EXTENDS IncludeDirPrecedenceTestTarget
+====

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IncludeDirPrecedenceTestTarget.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/IncludeDirPrecedenceTestTarget.tla
@@ -1,0 +1,3 @@
+---- MODULE IncludeDirPrecedenceTestTarget ----
+op == TRUE
+====

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/TlaLibraryPropertyTest.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/TlaLibraryPropertyTest.tla
@@ -1,0 +1,3 @@
+---- MODULE TlaLibraryPropertyTest ----
+EXTENDS TlaLibraryPropertyTestTarget
+====

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/include/IncludeDirPrecedenceTestTarget.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/include/IncludeDirPrecedenceTestTarget.tla
@@ -1,0 +1,3 @@
+---- MODULE IncludeDirPrecedenceTestTarget ----
+op == TRUE
+====

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/include/TlaLibraryPropertyTestTarget.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/include/TlaLibraryPropertyTestTarget.tla
@@ -1,0 +1,3 @@
+---- MODULE TlaLibraryPropertyTestTarget ----
+op == TRUE
+====

--- a/tlatools/org.lamport.tlatools/test/tla2sany/drivers/other/TlaLibraryPropertyTestTarget.tla
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/drivers/other/TlaLibraryPropertyTestTarget.tla
@@ -1,0 +1,3 @@
+---- MODULE TlaLibraryPropertyTestTarget ----
+op == TRUE
+====


### PR DESCRIPTION
Also update CI since dirname command no longer needed (this also functions as a test of this feature).

Added regression test ensuring `TLA-Library` system path is still honored. Unfortunately there is no way to set the classpath from within running Java code so I could not test that include method. Also made the resolution logic more similar to TLC, so SANY no longer behaves like #545 where it will prioritize specs from the current working directory over others. SANY's search order is now:

1. The root spec directory
2. The `TLA-Library` property
3. The current working directory

The classpath fits in there somewhere, but I'm not entirely sure where.

[SANY][Feature]

Closes #1372