### PR TITLE
Fix formatter AST verification failure for nested conjunction-list infix operands

### DIFF
--- a/tlatools/org.lamport.tlatools/src/formatter/constructs/impl/InfixExprConstruct.java
+++ b/tlatools/org.lamport.tlatools/src/formatter/constructs/impl/InfixExprConstruct.java
@@ -39,12 +39,10 @@ public class InfixExprConstruct implements TlaConstruct {
         Doc operator = context.buildChild(opNode);
         Doc rightOperand = context.buildChild(node.zero()[2]);
 
-        int leftKind = leftNode.getKind();
-        boolean leftIsConjDisjList = leftKind == NodeKind.CONJ_LIST.getId()
-                || leftKind == NodeKind.DISJ_LIST.getId();
+        boolean leftContainsConjDisjList = containsConjDisjList(leftNode);
 
-        if (leftIsConjDisjList) {
-            // Left is a bulleted list: put operator+right on a new line.
+        if (leftContainsConjDisjList) {
+            // Left contains a bulleted list: put operator+right on a new line.
             // Do NOT use .align() -- alignment would place operator+right at the same
             // column as the list items, causing SANY to absorb it into the list.
             return leftOperand
@@ -56,5 +54,32 @@ public class InfixExprConstruct implements TlaConstruct {
                         .appendSpace(operator)
                         .appendLineOrSpace(rightOperand).indent(indentSize)
         );
+    }
+
+    private static boolean containsConjDisjList(TreeNode node) {
+        if (node == null) {
+            return false;
+        }
+        int kind = node.getKind();
+        if (kind == NodeKind.CONJ_LIST.getId() || kind == NodeKind.DISJ_LIST.getId()) {
+            return true;
+        }
+        TreeNode[] zero = node.zero();
+        if (zero != null) {
+            for (TreeNode child : zero) {
+                if (containsConjDisjList(child)) {
+                    return true;
+                }
+            }
+        }
+        TreeNode[] one = node.one();
+        if (one != null) {
+            for (TreeNode child : one) {
+                if (containsConjDisjList(child)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/tlatools/org.lamport.tlatools/test/formatter/InfixConjAlignmentTest.java
+++ b/tlatools/org.lamport.tlatools/test/formatter/InfixConjAlignmentTest.java
@@ -106,6 +106,24 @@ public class InfixConjAlignmentTest {
         assertAstPreserved(spec);
     }
 
+    /**
+     * An infix /\ whose left subtree already contains a conjunction list must
+     * keep a following operand separate from that list. The quantified expression
+     * is a compact operand that reliably triggers the old wrapping issue.
+     */
+    @Test
+    public void testInfixConjWithNestedConjListKeepsFollowingOperandSeparate() throws Exception {
+        var spec = "----- MODULE test -----\n" +
+                "CONSTANTS S, A, B, C, D, E, F\n" +
+                "Test == /\\ A\n" +
+                "        /\\ B\n" +
+                "/\\ C\n" +
+                "/\\ \\E e \\in S:\n" +
+                "    /\\ D = e /\\ E = F\n" +
+                "====";
+        assertAstPreserved(spec, 40);
+    }
+
     @Test
     public void testNestedInfixDisjWithQuantifier() throws Exception {
         var spec = "----- MODULE test -----\n" +


### PR DESCRIPTION
Fixes #1395.

## Summary

This fixes a formatter AST verification failure for a nested conjunction-list layout. In the failing case, the formatter produced syntactically valid TLA+ text, but SANY reparsed that text into a different AST shape, so the formatter's round-trip verification failed.

The change is intentionally small: when formatting an infix expression, the formatter now uses the existing conservative newline layout whenever the left subtree contains an `N_ConjList` or `N_DisjList`, not only when the direct left child is one of those list nodes.

This PR also adds a focused regression test for the nested layout case.

## Context

Although #1395 is observed through the VS Code extension, the extension delegates document formatting to the formatter bundled in `tla2tools.jar`. The VS Code document formatter writes the current document to a temporary `.tla` file and runs `formatter.Main -v ERROR` through Java. The error reported in VS Code therefore comes from the formatter's AST verification step in this repository.

The relevant shape in the translated #1395 reproduction is this nested `/\` expression:

```tla
InsertExistingDocDuringClone == /\ syncing = TRUE
/\ ~CloneComplete

/\ \E d \in Document:
    /\ Len(remoteCollSeq) > 0
    /\ cursor <= Len(remoteCollSeq)
    /\ remoteCollSeq[cursor] = d /\ localColl[d] # Nil
```

The first conjunct starts a conjunction list, the following `/\ ~CloneComplete` forms the nested left operand, and the next `/\ \E d \in Document:` is the following operand that must stay outside that existing list structure.

## Implementation

Before this PR, `InfixExprConstruct` already had a conservative newline guard for the direct case where the left operand is itself a conjunction or disjunction list:
https://github.com/tlaplus/tlaplus/blob/4ba7d8811289fb8e95dac4d5e554c05216ba3100/tlatools/org.lamport.tlatools/src/formatter/constructs/impl/InfixExprConstruct.java#L42-L52


This PR keeps that newline behavior and broadens only the predicate that selects it:

```java
boolean leftContainsConjDisjList = containsConjDisjList(leftNode);

if (leftContainsConjDisjList) {
    return leftOperand
            .appendLine(operator.appendSpace(rightOperand));
}
```

So the formatter now applies the same layout when the conjunction or disjunction list is nested inside the left operand.

The concrete changes are:

- Recursively checks the left subtree of an infix expression for `N_ConjList` or `N_DisjList`.
- Reuses the existing conservative newline behavior when such a list appears in the left subtree.
- Adds a small formatter regression test that keeps a following `/\` operand separate from a nested conjunction-list left subtree.

## Why this fixes the failure

Before this fix, formatting the full translated reproduction with AST verification skipped produced this shape:

```tla
InsertExistingDocDuringClone ==
  /\ syncing = TRUE
    /\ ~CloneComplete /\
    \E d \in Document: /\ Len(remoteCollSeq) > 0
                       /\ cursor <= Len(remoteCollSeq)
                       /\ remoteCollSeq[cursor] = d /\ localColl[d] # Nil
```

That output is still syntactically valid TLA+, but it changes the layout around the nested left operand: `~CloneComplete /\` is emitted at the end of one line, and the quantified expression starts on the next line near the existing list items.

The original input has this local AST shape at the failing point:

```text
N_InfixExpr
  left: N_InfixExpr
    left: N_ConjList
      item: syncing = TRUE
    op: /\
    right: ~CloneComplete
  op: /\
  right: N_BoundedQuant
```

For a normal infix expression, this part of the parse tree has three `zero[]` children: the left operand, the operator, and the right operand. The original AST has that shape at this point. After the before-fix output is reparsed, the corresponding path no longer has the same three-child infix structure. The verifier observes an `N_InfixExpr` with one `zero[]` child instead:

```text
N_InfixExpr
  zero[] length: 1
```

That is what the AST verifier reports:

```text
AST verification failed after formatting.
AST verification failed:
  Node zero[] length mismatch: expected 3 but found 1. Node: N_InfixExpr
```

After this fix, the following `/\` operand stays separate from the nested left subtree:

```tla
InsertExistingDocDuringClone == /\ syncing = TRUE
  /\ ~CloneComplete
  /\ \E d \in Document: /\ Len(remoteCollSeq) > 0
                        /\ cursor <= Len(remoteCollSeq)
                        /\ remoteCollSeq[cursor] = d /\ localColl[d] # Nil
```

The AST verifier then sees the same local infix-expression shape before and after formatting.

## Testing

Manually compiled the formatter sources and ran:

```text
formatter.InfixConjAlignmentTest
formatter.AstVerificationTest
formatter.constructs.impl.OperatorConstructTest
formatter.constructs.impl.InfixExprConstructTest
```

Result:

```text
OK (29 tests)
```

Also ran the full translated reproduction from #1395 through:

```text
formatter.Main -v ERROR
```

The fixed formatter no longer fails with:

```text
AST verification failed after formatting
```

Supplemental fork-only validation runs:

- Before fix, based on `origin/master`, the full translated #1395 reproduction fails as expected: https://github.com/Stool233/tlaplus/actions/runs/28328433474
- After fix, based on this PR commit, the formatter-specific tests and full translated #1395 reproduction pass: https://github.com/Stool233/tlaplus/actions/runs/28332725282

These are supplemental fork-only runs for the #1395 formatter reproduction; upstream PR checks remain authoritative.
