### PR TITLE
Document `_POSSIBLE` and name the unwitnessed predicate

### DIFF
--- a/docs/possible-conditions.md
+++ b/docs/possible-conditions.md
@@ -1,0 +1,73 @@
+# Possibility Conditions with TLC's `_POSSIBLE`
+
+## Why check that something *can* happen
+
+When TLC reports that all invariants and properties hold, the result may be misleading if the model omits intended behaviors. A specification that permits only stuttering steps, an action whose enabling condition is too strong, or a model whose constant assignments are too small can cause TLC to explore too little while reporting no error. Always be suspicious of success.
+
+The traditional remedy is to add `INVARIANT ~P` temporarily and check that it *fails*, which proves that a state satisfying `P` is reachable. Doing this by hand is tedious, easy to forget, and impossible to keep in the configuration file, since it makes a passing run fail. `_POSSIBLE` lets you keep the check in the configuration file:
+
+```tla
+SPECIFICATION Spec
+INVARIANT TypeOK
+_POSSIBLE
+    LeaderElected
+    BufferFull
+    ReconfigurationCommitted
+```
+
+Each listed definition is a possibility condition, which TLC's messages call a `_POSSIBLE` predicate: a zero-arity state predicate or action; constant and temporal formulas are rejected. A state predicate is witnessed by a state satisfying it, an action by a step satisfying it. TLC fails the run unless every listed condition has a witness.
+
+## An unwitnessed possibility condition
+
+If TLC sent you here, it printed a record of witness counts followed by an error:
+
+```
+[BufferFull |-> 217, LeaderElected |-> 0]
+Error: The _POSSIBLE predicate LeaderElected at line 42, col 21 to line 42, col 38 of module MySpec was never witnessed.
+Others may be unwitnessed too; only witnessed predicates appear with a
+non-zero count in the record printed above.
+See https://explain.tlapl.us/possible-conditions for additional details.
+```
+
+Here no state satisfies `LeaderElected`, or no step does if it is an action. TLC names one unwitnessed condition and stops there; which one is unspecified. Any number of the others can be unwitnessed too, and only the record identifies them all.
+
+`_POSSIBLE` is provisional (hence the leading underscore) and may be renamed or removed in a future release.
+
+## Witness counts
+
+TLC counts witnesses rather than recording a Boolean value. The `_Possible` module exposes the counts as `_Counts`, a record mapping the name of each condition TLC evaluated to the number of evaluations that yielded TRUE, summed over all workers. A `POSTCONDITION` can therefore assert exact counts:
+
+```tla
+EXTENDS _Possible
+
+\* Guarded: applying _Counts outside its domain is an error, not FALSE.
+Count(name) == IF name \in DOMAIN _Counts THEN _Counts[name] ELSE 0
+
+CountsPostCondition ==
+    /\ Count("BufferFull") > 0
+    /\ Count("ReconfigurationCommitted") = 42
+```
+
+Interpret the counts only in terms of TLC's exploration. A count records how many evaluations yielded TRUE, so it depends on which states and steps the exploration strategy visits: the reachable state graph in model-checking mode, the sampled behaviors in simulation mode. A condition's share of the counts does not estimate the probability that the corresponding state or step occurs in the real system; that would require a sampling distribution validated against the system, which TLC does not provide in the general case.
+
+On a long run, watching the counts grow tells you far more about progress than the distinct-state count does. The `_Possible` module defines `_PrintCounts` for that purpose; use it with `_PERIODIC`, and TLC prints the counts every time it reports progress:
+
+```tla
+_PERIODIC _PrintCounts
+```
+
+## Limitations
+
+- `_POSSIBLE` asserts that **some** reachable state or step is a witness. It does not assert that every behavior, or every behavior starting from a given state, contains one.
+- A state or step excluded by a `CONSTRAINT` or `ACTION_CONSTRAINT` lies outside the model and so never witnesses a condition. A condition can be reported as unwitnessed although an excluded state or step satisfies it.
+- The record of witness counts lists only the conditions TLC evaluated, so read a missing name as a zero count. A state predicate goes unevaluated when TLC evaluates no state, an action when it evaluates no step, as when a `CONSTRAINT` excludes every state. The error names it regardless, taking the name from the `_POSSIBLE` list rather than from the record.
+- An unwitnessed condition fails the run before a `POSTCONDITION` is evaluated, so one reading `_Counts` runs only when every condition is witnessed.
+- In simulation mode, an unwitnessed condition may only mean that the sampled behaviors missed it. Treat simulation counts as evidence, not proof.
+- Possibility conditions are not preserved by refinement. A refinement need not exhibit every behavior of the specification it refines.
+- Possibility conditions are not liveness properties. They say that a situation *can* occur, not that it *must*.
+
+## How to use possibility conditions
+
+**To justify a reduced model.** Every state-space reduction (smaller constants, a `CONSTRAINT`, a `VIEW`, or a coarser abstraction) trades coverage for tractability, and each one risks producing a model that verifies quickly because it no longer does anything interesting. Write down the situations that make the model worth checking before you start reducing it, encode them as possibility conditions, and then shrink the configuration. If a witness stops being reached, the reduction went too far, and you find out mechanically instead of by intuition.
+
+**As regression tests on the specification.** Because an unwitnessed condition fails the run, a checked-in set of them catches a later edit that leaves an action never enabled or strengthens its enabling condition, instead of letting it silently shrink the set of behaviors.

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/_Possible.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/_Possible.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import tla2sany.semantic.LevelConstants;
 import tlc2.TLCGlobals;
 import tlc2.overrides.TLAPlusOperator;
 import tlc2.tool.AbstractChecker;
@@ -45,7 +46,10 @@ public class _Possible implements ValueConstants {
 
 	private static final UniqueString KEY = UniqueString.uniqueStringOf("s:_possible");
 
-	@TLAPlusOperator(identifier = "_Counts", module = "_Possible", warn = false)
+	// minLevel keeps _Counts out of TLC's constant folding: its value only exists
+	// once a checker runs, so folding it at startup would bake in an empty record
+	// and turn a POSTCONDITION reading it into a rejected constant-level one.
+	@TLAPlusOperator(identifier = "_Counts", module = "_Possible", warn = false, minLevel = LevelConstants.VariableLevel)
 	public static Value counts() {
 		final List<IValue> perWorker;
 		if (TLCGlobals.mainChecker != null) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/EC.java
@@ -74,6 +74,7 @@ public interface EC
     public static final int TLC_ASSUMPTION_EVALUATION_ERROR = 2105;
     public static final int TLC_POSTCONDITION_FALSE = 2404;
     public static final int TLC_POSTCONDITION_EVALUATION_ERROR = 2405;
+    public static final int TLC_POSSIBLE_UNWITNESSED = 2780;
     public static final int TLC_STATE_NOT_COMPLETELY_SPECIFIED_INITIAL = 2106;
 
     public static final int TLC_INVARIANT_VIOLATED_INITIAL = 2107;
@@ -422,6 +423,7 @@ public interface EC
 	        case TLC_ASSUMPTION_EVALUATION_ERROR:
 	        case TLC_POSTCONDITION_FALSE:
 	        case TLC_POSTCONDITION_EVALUATION_ERROR:
+	        case TLC_POSSIBLE_UNWITNESSED:
 	            return VIOLATION_ASSUMPTION;
 	        
 	        case TLC_VALUE_ASSERT_FAILED:

--- a/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/output/MP.java
@@ -577,6 +577,12 @@ public class MP
         case EC.TLC_POSTCONDITION_FALSE:
             b.append("Postcondition %1% at %2% is false.");
             break;
+        case EC.TLC_POSSIBLE_UNWITNESSED:
+            b.append("The _POSSIBLE predicate %1% at %2% was never witnessed.\n"
+                    + "Others may be unwitnessed too; only witnessed predicates appear with a\n"
+                    + "non-zero count in the record printed above.\n"
+                    + "See https://explain.tlapl.us/possible-conditions for additional details.");
+            break;
         case EC.TLC_POSTCONDITION_EVALUATION_ERROR:
             b.append("Evaluating postcondition %1% at %2% failed.\n%3%");
             break;

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/impl/Tool.java
@@ -44,6 +44,7 @@ import tlc2.tool.IContextEnumerator;
 import tlc2.tool.INextStateFunctor;
 import tlc2.tool.IStateFunctor;
 import tlc2.tool.ITool;
+import tlc2.tool.PossibleAction;
 import tlc2.tool.StateVec;
 import tlc2.tool.TLCState;
 import tlc2.tool.TLCStateFun;
@@ -3687,7 +3688,13 @@ public abstract class Tool
 				// Cast is safe: postconditions are constant-level operator bodies (OpDefNode.getBody()),
 			    // which are always ExprNode instances.
 			    if (!isValid((ExprNode) pc.pred, ctxt)) {
-					return MP.printError(EC.TLC_POSTCONDITION_FALSE,
+					// A PossibleAction checks a single predicate and reports the user's name
+					// and location for it, so this names an unwitnessed predicate even when
+					// the record of counts that _CheckName printed omits it entirely.  Since
+					// the loop returns here, only the first unwitnessed predicate is named.
+					final int errorCode = pc instanceof PossibleAction ? EC.TLC_POSSIBLE_UNWITNESSED
+							: EC.TLC_POSTCONDITION_FALSE;
+					return MP.printError(errorCode,
 							new String[] { pc.getNameOfDefault(), pc.getPred().toString() });
 				}
 			} catch (Exception e) {

--- a/tlatools/org.lamport.tlatools/test-model/PossibleCountsTest.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/PossibleCountsTest.cfg
@@ -1,0 +1,3 @@
+SPECIFICATION Spec
+_POSSIBLE AtOne WrapAround
+POSTCONDITION CountsPostCondition

--- a/tlatools/org.lamport.tlatools/test-model/PossibleCountsTest.tla
+++ b/tlatools/org.lamport.tlatools/test-model/PossibleCountsTest.tla
@@ -1,0 +1,27 @@
+---- MODULE PossibleCountsTest ----
+EXTENDS Naturals, _Possible
+VARIABLE x
+
+Init == x = 0
+
+Next == x' = (x + 1) % 3
+
+AtOne == x = 1
+
+WrapAround == x = 2 /\ x' = 0
+
+Spec == Init /\ [][Next]_x
+
+Count(name) == IF name \in DOMAIN _Counts THEN _Counts[name] ELSE 0
+
+\* This postcondition mentions no variable, so _Counts alone determines its
+\* level.  TLC rejects a constant postcondition, and it folds a constant
+\* definition away at startup, when the counts are still empty.  Both make this
+\* postcondition a regression test for the level that the _Counts override
+\* declares.
+CountsPostCondition ==
+    /\ DOMAIN _Counts = {"AtOne", "WrapAround"}
+    /\ Count("AtOne") = 1
+    /\ Count("WrapAround") = 1
+    /\ Count("NotAPossibilityCondition") = 0
+====

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleCountsTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleCountsTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved.
+ *
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+/**
+ * Checks a POSTCONDITION that reads _Counts and nothing else, the way a spec
+ * asserts exact witness counts.
+ * <p>
+ * Such a postcondition only works because the Java override of _Counts declares
+ * a variable level. With the default level of zero, the override would report a
+ * lower level than the TLA+ definition it replaces, which is variable-level
+ * through TLCGet. TLC would then reject the postcondition below as a constant,
+ * and would evaluate _Counts once at startup while folding constant
+ * definitions, baking in the empty record that exists before any checker runs.
+ *
+ * @see tlc2.module._Possible#counts()
+ * @see tlc2.tool.impl.SymbolNodeValueLookupProvider#getLevelBoundAppl
+ */
+public class PossibleCountsTest extends ModelCheckerTestCase {
+
+	public PossibleCountsTest() {
+		super("PossibleCountsTest");
+	}
+
+	@Test
+	public void testSpec() {
+		// Fails if _Counts leaves the postcondition constant-level. Asserted
+		// first because TLC then rejects the configuration and records neither
+		// TLC_FINISHED nor a postcondition result.
+		assertFalse(recorder.recorded(EC.TLC_CONFIG_ID_MUST_NOT_BE_CONSTANT));
+
+		// Fails if _Counts is folded to the empty record at startup.
+		assertFalse(recorder.recorded(EC.TLC_POSTCONDITION_FALSE));
+		assertFalse(recorder.recorded(EC.TLC_POSTCONDITION_EVALUATION_ERROR));
+
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.GENERAL));
+		assertFalse(recorder.recorded(EC.TLC_POSSIBLE_UNWITNESSED));
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailActionTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailActionTest.java
@@ -35,8 +35,8 @@ import tlc2.tool.liveness.ModelCheckerTestCase;
 
 /**
  * Exercises the _POSSIBLE feature with a single action-level predicate that is
- * never witnessed by any transition. The failure must be reported as a
- * postcondition violation naming the user's predicate.
+ * never witnessed by any transition. The failure must be reported as an
+ * unwitnessed possibility condition naming the user's predicate.
  */
 public class PossibleFailActionTest extends ModelCheckerTestCase {
 
@@ -48,8 +48,8 @@ public class PossibleFailActionTest extends ModelCheckerTestCase {
 	@Test
 	public void testSpec() {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
-		assertTrue(recorder.recorded(EC.TLC_POSTCONDITION_FALSE));
+		assertTrue(recorder.recorded(EC.TLC_POSSIBLE_UNWITNESSED));
 		// The error message must identify the user's original predicate name.
-		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSTCONDITION_FALSE, "BigJump", 0));
+		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSSIBLE_UNWITNESSED, "BigJump", 0));
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailMixedTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailMixedTest.java
@@ -35,20 +35,26 @@ import tlc2.tool.liveness.ModelCheckerTestCase;
 
 /**
  * Exercises the _POSSIBLE feature with several predicates where only some are
- * never witnessed. This pins down the current error-reporting behavior so
- * regressions surface if it changes:
- * <ul>
- * <li>The failure is reported as {@link EC#TLC_POSTCONDITION_FALSE}.</li>
- * <li>The error identifies the first failing predicate in config order (here
- * {@code Unreachable}, a state-level predicate), not a shared placeholder like
- * {@code _Possible}.</li>
- * </ul>
+ * never witnessed ({@code Unreachable} and {@code BigJump}). The failure must
+ * be reported as {@link EC#TLC_POSSIBLE_UNWITNESSED} and must name one of the
+ * unwitnessed predicates rather than a shared placeholder like
+ * {@code _Possible}.
  *
  * <p>
- * Note: {@link tlc2.tool.impl.Tool#checkPostConditionWithContext} returns on
- * the first failure, so later failing predicates (e.g. {@code BigJump}) are not
- * individually listed in the error output. If that behavior ever changes to
- * enumerate all failing possibles, this test needs to be updated accordingly.
+ * Which one TLC names is not a guarantee of the feature: _POSSIBLE leaves it
+ * unspecified, because
+ * {@link tlc2.tool.impl.Tool#checkPostConditionWithContext} reports the first
+ * predicate whose check fails and the order in which the checks run is an
+ * implementation detail. The assertion below pins down today's outcome
+ * ({@code Unreachable}) so that a change becomes visible rather than silent; it
+ * is not a contract, so reordering the checks may legitimately require updating
+ * the expected name here.
+ * </p>
+ *
+ * <p>
+ * Only one predicate is named either way. The record of witness counts printed
+ * before the error is what identifies every unwitnessed predicate, including
+ * {@code BigJump}.
  * </p>
  */
 public class PossibleFailMixedTest extends ModelCheckerTestCase {
@@ -60,10 +66,9 @@ public class PossibleFailMixedTest extends ModelCheckerTestCase {
 	@Test
 	public void testSpec() {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
-		assertTrue(recorder.recorded(EC.TLC_POSTCONDITION_FALSE));
-		// Predicates are evaluated in the order they appear in the config
-		// (AtOne, AllDone, WrapAround, Unreachable, BigJump). The first three
-		// are witnessed, so the first failure is Unreachable.
-		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSTCONDITION_FALSE, "Unreachable", 0));
+		assertTrue(recorder.recorded(EC.TLC_POSSIBLE_UNWITNESSED));
+		// Unreachable and BigJump are both unwitnessed; TLC currently names the
+		// former. See the class comment: this pins down behavior, not a contract.
+		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSSIBLE_UNWITNESSED, "Unreachable", 0));
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailNoTransTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailNoTransTest.java
@@ -43,7 +43,10 @@ public class PossibleFailNoTransTest extends ModelCheckerTestCase {
 	@Test
 	public void testSpec() {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
-		assertTrue(recorder.recorded(EC.TLC_POSTCONDITION_FALSE));
-		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSTCONDITION_FALSE, "BigJump", 0));
+		assertTrue(recorder.recorded(EC.TLC_POSSIBLE_UNWITNESSED));
+		// BigJump is an action, but SpecOnlyInit permits no transitions, so no
+		// transition can witness it. The name comes from the PossibleAction rather
+		// than from the record of witness counts, so the error names it either way.
+		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSSIBLE_UNWITNESSED, "BigJump", 0));
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailStateTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleFailStateTest.java
@@ -35,8 +35,8 @@ import tlc2.tool.liveness.ModelCheckerTestCase;
 
 /**
  * Exercises the _POSSIBLE feature with a single state-level predicate that is
- * never witnessed by any reachable state. The failure must be reported as a
- * postcondition violation naming the user's predicate.
+ * never witnessed by any reachable state. The failure must be reported as an
+ * unwitnessed possibility condition naming the user's predicate.
  */
 public class PossibleFailStateTest extends ModelCheckerTestCase {
 
@@ -47,8 +47,8 @@ public class PossibleFailStateTest extends ModelCheckerTestCase {
 	@Test
 	public void testSpec() {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
-		assertTrue(recorder.recorded(EC.TLC_POSTCONDITION_FALSE));
+		assertTrue(recorder.recorded(EC.TLC_POSSIBLE_UNWITNESSED));
 		// The error message must identify the user's original predicate name.
-		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSTCONDITION_FALSE, "Unreachable", 0));
+		assertTrue(recorder.recordedWithStringValueAt(EC.TLC_POSSIBLE_UNWITNESSED, "Unreachable", 0));
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/PossibleTest.java
@@ -44,5 +44,6 @@ public class PossibleTest extends ModelCheckerTestCase {
 		assertTrue(recorder.recorded(EC.TLC_FINISHED));
 		assertFalse(recorder.recorded(EC.GENERAL));
 		assertFalse(recorder.recorded(EC.TLC_POSTCONDITION_FALSE));
+		assertFalse(recorder.recorded(EC.TLC_POSSIBLE_UNWITNESSED));
 	}
 }


### PR DESCRIPTION
`_POSSIBLE` was undocumented, and an unwitnessed possibility condition failed under the generic `TLC_POSTCONDITION_FALSE` without saying which predicate went unwitnessed.

- Add `EC.TLC_POSSIBLE_UNWITNESSED`, reported with the predicate's name and location. Which predicate is named when several are unwitnessed is unspecified.
- Declare `minLevel = VariableLevel` on the `_Counts` override, so a `POSTCONDITION` reading only `_Counts` is no longer folded to the empty record at startup.
- Document both statements in `current-tools.md` and add `docs/possible-conditions.md`, the page the new error links to.

Part of #860