### PR TITLE
Prevent disk pool writers from exiting on empty wakes

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskByteArrayQueue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskByteArrayQueue.java
@@ -249,9 +249,7 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 
 	public void finishAll() {
 		super.finishAll();
-		synchronized (this.writer) {
-			this.writer.notifyAll();
-		}
+		this.writer.setFinished();
 		synchronized (this.reader) {
 			this.reader.setFinished();
 			this.reader.notifyAll();
@@ -310,12 +308,14 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 	    private byte[][] buf;     
 	    private File poolFile;           // the file to be written
 	    private final ByteArrayPoolReader reader;  // the consumer if not null
+	    private boolean finished;
 	    
 	  public ByteArrayPoolWriter(int bufSize, ByteArrayPoolReader reader) {
 		  super("RawTLCStatePoolWriter");
 	    this.buf = new byte[bufSize][];
 	    this.poolFile = null;
 	    this.reader = reader;
+	    this.finished = false;
 	  }
 	  
 	  /*
@@ -381,6 +381,11 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 	    }
 	  }
 
+	  public final synchronized void setFinished() {
+	    this.finished = true;
+	    this.notifyAll();
+	  }
+
 	  /**
 	   * Write "buf" to "poolFile". The objects in the queue are written
 	   * using Java's object serialization facilities.
@@ -390,11 +395,10 @@ public class DiskByteArrayQueue extends ByteArrayQueue {
 	      synchronized(this) {
 		while (true) {
 		  while (this.poolFile == null) {
-		    this.wait();
-		    // we are done without ever receiving a pool file
-		    if(this.poolFile == null) {
-		    	return;
+		    if (this.finished) {
+		      return;
 		    }
+		    this.wait();
 		  }
 		  final BufferedDataOutputStream vos = new BufferedDataOutputStream(this.poolFile);
 		  for (int i = 0; i < this.buf.length; i++) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskStateQueue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/tool/queue/DiskStateQueue.java
@@ -231,9 +231,7 @@ public class DiskStateQueue extends StateQueue {
 
 	public void finishAll() {
 		super.finishAll();
-		synchronized (this.writer) {
-			this.writer.notifyAll();
-		}
+		this.writer.setFinished();
 		synchronized (this.reader) {
 			this.reader.setFinished();
 			this.reader.notifyAll();

--- a/tlatools/org.lamport.tlatools/src/tlc2/util/StatePoolWriter.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/util/StatePoolWriter.java
@@ -21,6 +21,7 @@ public class StatePoolWriter extends Thread {
     private TLCState[] buf;     
     private File poolFile;           // the file to be written
     private StatePoolReader reader;  // the consumer if not null
+    private boolean finished;
 
     
   public StatePoolWriter(int bufSize) {
@@ -32,6 +33,7 @@ public class StatePoolWriter extends Thread {
     this.buf = new TLCState[bufSize];
     this.poolFile = null;
     this.reader = reader;
+    this.finished = false;
   }
 
   /*
@@ -96,6 +98,11 @@ public class StatePoolWriter extends Thread {
     }
   }
 
+  public final synchronized void setFinished() {
+    this.finished = true;
+    this.notifyAll();
+  }
+
   /**
    * Write "buf" to "poolFile". The objects in the queue are written
    * using Java's object serialization facilities.
@@ -105,11 +112,10 @@ public class StatePoolWriter extends Thread {
       synchronized(this) {
 	while (true) {
 	  while (this.poolFile == null) {
-	    this.wait();
-	    // we are done without ever receiving a pool file
-	    if(this.poolFile == null) {
-	    	return;
+	    if (this.finished) {
+	      return;
 	    }
+	    this.wait();
 	  }
 	  ValueOutputStream vos = new ValueOutputStream(this.poolFile);
 	  for (int i = 0; i < this.buf.length; i++) {

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/queue/DiskPoolWriterTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/queue/DiskPoolWriterTest.java
@@ -11,6 +11,8 @@ import java.nio.file.Files;
 import org.junit.After;
 import org.junit.Test;
 
+import util.FileUtil;
+
 public class DiskPoolWriterTest {
 
 	private static final long TIMEOUT_MILLIS = 5000L;
@@ -24,13 +26,7 @@ public class DiskPoolWriterTest {
 			this.queue.finishAll();
 		}
 		if (this.diskDirectory != null) {
-			final File[] files = this.diskDirectory.listFiles();
-			if (files != null) {
-				for (File file : files) {
-					file.delete();
-				}
-			}
-			this.diskDirectory.delete();
+			FileUtil.deleteDir(this.diskDirectory, true);
 		}
 	}
 

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/queue/DiskPoolWriterTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/queue/DiskPoolWriterTest.java
@@ -1,0 +1,89 @@
+package tlc2.tool.queue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class DiskPoolWriterTest {
+
+	private static final long TIMEOUT_MILLIS = 5000L;
+
+	private File diskDirectory;
+	private IStateQueue queue;
+
+	@After
+	public void tearDown() {
+		if (this.queue != null) {
+			this.queue.finishAll();
+		}
+		if (this.diskDirectory != null) {
+			final File[] files = this.diskDirectory.listFiles();
+			if (files != null) {
+				for (File file : files) {
+					file.delete();
+				}
+			}
+			this.diskDirectory.delete();
+		}
+	}
+
+	@Test
+	public void testStatePoolWriterIgnoresEmptyWakeAndStopsOnFinish() throws Exception {
+		this.diskDirectory = Files.createTempDirectory("DiskPoolWriterTest").toFile();
+		final DiskStateQueue stateQueue = new DiskStateQueue(this.diskDirectory.getAbsolutePath());
+		this.queue = stateQueue;
+
+		assertIgnoresEmptyWake(stateQueue.writer);
+		assertStopsOnFinish(stateQueue.writer);
+	}
+
+	@Test
+	public void testByteArrayPoolWriterIgnoresEmptyWakeAndStopsOnFinish() throws Exception {
+		this.diskDirectory = Files.createTempDirectory("DiskPoolWriterTest").toFile();
+		final DiskByteArrayQueue byteArrayQueue = new DiskByteArrayQueue(this.diskDirectory.getAbsolutePath());
+		this.queue = byteArrayQueue;
+
+		final Field writerField = DiskByteArrayQueue.class.getDeclaredField("writer");
+		writerField.setAccessible(true);
+		final Thread writer = (Thread) writerField.get(byteArrayQueue);
+
+		assertIgnoresEmptyWake(writer);
+		assertStopsOnFinish(writer);
+	}
+
+	private void assertIgnoresEmptyWake(Thread writer) throws InterruptedException {
+		awaitState(writer, Thread.State.WAITING);
+		synchronized (writer) {
+			writer.notifyAll();
+			final long deadline = System.currentTimeMillis() + TIMEOUT_MILLIS;
+			while (writer.getState() == Thread.State.WAITING && System.currentTimeMillis() < deadline) {
+				Thread.sleep(10L);
+			}
+			assertTrue("writer did not observe the notification", writer.getState() != Thread.State.WAITING);
+		}
+		awaitState(writer, Thread.State.WAITING);
+		assertTrue("writer exited after an empty wake", writer.isAlive());
+	}
+
+	private void assertStopsOnFinish(Thread writer) throws InterruptedException {
+		this.queue.finishAll();
+		writer.join(TIMEOUT_MILLIS);
+		assertFalse("writer did not stop when the queue finished", writer.isAlive());
+	}
+
+	private static void awaitState(Thread thread, Thread.State expected) throws InterruptedException {
+		final long deadline = System.currentTimeMillis() + TIMEOUT_MILLIS;
+		while (thread.isAlive() && thread.getState() != expected && System.currentTimeMillis() < deadline) {
+			Thread.sleep(10L);
+		}
+		assertTrue("writer exited while waiting for state " + expected, thread.isAlive());
+		assertEquals("writer did not enter state " + expected, expected, thread.getState());
+	}
+}


### PR DESCRIPTION
Fixes #1403.

## Root cause

`StatePoolWriter` treated every wake with no pending pool file as a shutdown request. Java permits `Object.wait()` to wake spuriously, so the writer could exit during an active model-checking run. A later disk spill would then block forever in `ensureWritten()`. The raw-byte disk queue contained the same pattern.

The previous empty notification also doubled as the intentional shutdown mechanism in `finishAll()`, so merely removing the premature return would leave the daemon writers running after queue shutdown.

## Changes

- give both disk pool writers an explicit, persistent finished state
- make empty or spurious wakes return to waiting unless shutdown was requested
- have both disk queues explicitly finish their writer instead of sending an ambiguous empty notification
- add regression tests covering empty wakes and orderly shutdown for both writer implementations

## Impact

This prevents rare, permanent TLC hangs in large disk-backed state-space explorations while preserving writer shutdown behavior. The failure was observed in a real TLC 1.8.0 run after more than five days and 402 billion generated states. A locally patched writer allowed checkpoint recovery to drain the queue and complete without a model error.

## Validation

- reproduced the failure on `master` at `0894c34` (`writer_alive_after_empty_wake=false`)
- `ant -f customBuild.xml info compile compile-test test-set -Dtest.testcases="tlc2/tool/queue/DiskPoolWriterTest.java"`
- `ant -f customBuild.xml info compile compile-test test` with Temurin Java 11 (full suite, 3m26s)
- `ant -f customBuild.xml dist` with Temurin Java 11
