### PR TITLE
Equality of function sets is unsound when a domain or co-domain is empty

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/module/AnySet.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/AnySet.java
@@ -41,6 +41,12 @@ public class AnySet extends UserObj
         return false;
     }
 
+    // isEmpty is deliberately not overridden, which makes TLC refuse to say
+    // whether ANY is empty.  TLA+ defines Any as CHOOSE x : TRUE, a fixed but
+    // unspecified value, so [Any -> {}] is { <<>> } if Any = {} and {}
+    // otherwise, and nothing decides which.  That member above accepts every
+    // value is a fiction of TLC's, because no set contains every value.
+
     @Override
     public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow)
     {

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Integers.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Integers.java
@@ -247,6 +247,15 @@ public class Integers extends UserObj implements ValueConstants
         return false;
     }
 
+    // THEOREM Int # {}
+    //
+    // The witness is 0 \in Int.
+    @Override
+    public final boolean isEmpty()
+    {
+        return false;
+    }
+
     @Override
     public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow)
     {

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Naturals.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Naturals.java
@@ -256,6 +256,15 @@ public class Naturals extends UserObj implements ValueConstants
         return false;
     }
 
+    // THEOREM Nat # {}
+    //
+    // The witness is 0 \in Nat.
+    @Override
+    public final boolean isEmpty()
+    {
+        return false;
+    }
+
     @Override
     public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow)
     {

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
@@ -417,6 +417,18 @@ public class Sequences extends UserObj implements ValueConstants
         return this.size != Integer.MAX_VALUE;
     }
 
+    // THEOREM ASSUME NEW S
+    //         PROVE  Seq(S) # {}
+    //
+    // The witness is <<>> \in Seq(S): the empty sequence is shorter than any
+    // bound this.size >= 0 and has no element that would have to be in
+    // this.range, i.e. member above returns true for it.
+    @Override
+    public final boolean isEmpty()
+    {
+        return this.size < 0;
+    }
+
     @Override
     public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow)
     {

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Sequences.java
@@ -411,10 +411,14 @@ public class Sequences extends UserObj implements ValueConstants
         return true;
     }
 
+    // THEOREM ESE_SeqEmptyFinite ==
+    //   ASSUME NEW S, S = {}
+    //   PROVE  IsFiniteSet(Seq(S))
     @Override
     public final boolean isFinite()
     {
-        return this.size != Integer.MAX_VALUE;
+        return this.size != Integer.MAX_VALUE
+                || (this.range.isFinite() && this.range.isEmpty());
     }
 
     // THEOREM ASSUME NEW S

--- a/tlatools/org.lamport.tlatools/src/tlc2/module/Strings.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/module/Strings.java
@@ -53,6 +53,15 @@ public class Strings extends UserObj
         return false;
     }
 
+    // THEOREM STRING # {}
+    //
+    // The witness is "" \in STRING.
+    @Override
+    public final boolean isEmpty()
+    {
+        return false;
+    }
+
     @Override
     public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow)
     {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -151,10 +151,39 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
 
   // THEOREM ASSUME NEW S, NEW T, IsFiniteSet(S), IsFiniteSet(T)
   //         PROVE  IsFiniteSet([S -> T])
+  //
+  // THEOREM ESE_UnitFinite ==
+  //   ASSUME NEW S, NEW T, S = {}
+  //   PROVE  IsFiniteSet([S -> T])
+  //
+  // THEOREM ESE_EmptyRangeFinite ==
+  //   ASSUME NEW S, NEW T, T = {}
+  //   PROVE  IsFiniteSet([S -> T])
+  //
+  // THEOREM ESE_SingletonRangeFinite ==
+  //   ASSUME NEW S, NEW T, NEW w, T = {w}
+  //   PROVE  IsFiniteSet([S -> T])
+  //
+  // The first theorem misses { <<>> } and {}: an empty domain or co-domain
+  // makes [S -> T] finite whatever the other argument is, so neither argument
+  // has to be finite. isEmpty is only asked of an argument that isFinite has
+  // answered for, because an empty set is finite, and asking one that TLC
+  // cannot enumerate, such as Nat \ {0}, would fail instead of answering.
   @Override
   public final boolean isFinite() {
     try {
-      return this.domain.isFinite() && this.range.isFinite();
+      final boolean finiteDomain = this.domain.isFinite();
+      if (finiteDomain && this.domain.isEmpty()) {
+        return true;
+      }
+      final boolean finiteRange = this.range.isFinite();
+      if (finiteRange && this.range.isEmpty()) {
+        return true;
+      }
+      if (finiteDomain && finiteRange) {
+        return true;
+      }
+      return finiteRange && this.range.size() == 1;
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -414,26 +414,29 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {
     try {
-      boolean unlazy = TLCGlobals.expand;
+      Value val = null;
       try {
-        if (unlazy) {
-          int dsz = this.domain.size();
-          int rsz = this.range.size();
-          long sz = 1;
-          for (int i = 0; i < dsz; i++) {
-            sz *= rsz;
-            if (sz < -2147483648 || sz > 2147483647) {
-              unlazy = false;
-              break;
+        if (TLCGlobals.expand) {
+          long sz;
+          if (this.domain.isEmpty()) {
+            sz = 1;
+          }
+          else {
+            final int dsz = this.domain.size();
+            final int rsz = this.range.size();
+            sz = 1;
+            for (int i = 0; i < dsz && sz <= 2147483647; i++) {
+              sz *= rsz;
             }
           }
-          unlazy = sz < TLCGlobals.enumBound;
+          if (sz < TLCGlobals.enumBound) {
+            val = this.toSetEnum();
+          }
         }
       }
-      catch (Throwable e) { if (swallow) unlazy = false; else throw e; }
+      catch (Throwable e) { if (!swallow) throw e; }
 
-      if (unlazy) {
-        Value val = this.toSetEnum();
+      if (val != null) {
         return val.toString(sb, offset, swallow);
       }
       else {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -56,10 +56,41 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
     }
   }
 
+  // THEOREM ESE_UnitDomain ==
+  //   ASSUME NEW S, NEW T, S = {}
+  //   PROVE  [S -> T] = { <<>> }
+  //
+  // THEOREM ESE_EmptyRange ==
+  //   ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  //   PROVE  [S -> T] = {}
+  //
+  // THEOREM ESE_DomainDecides ==
+  //   ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  //   PROVE  [S -> R] = [T -> R] <=> S = T
+  //
+  // THEOREM ESE_RangeDecides ==
+  //   ASSUME NEW S, NEW R, NEW Q, NEW w, w \in S
+  //   PROVE  [S -> R] = [S -> Q] <=> R = Q
+  //
+  // The witness w that the last two theorems need is what the two guards below
+  // rule out first: an empty domain makes [S -> T] the singleton { <<>> }
+  // whatever T is, and an empty co-domain makes it {} whatever the non-empty S
+  // is. Either set being one of the two therefore settles the equality on its
+  // own, and only the sets that are neither are left for the domains and the
+  // co-domains to decide.
   public final boolean equals(Object obj) {
     try {
       if (obj instanceof SetOfFcnsValue) {
         SetOfFcnsValue fcns = (SetOfFcnsValue)obj;
+
+        boolean isUnit1 = this.domain.isEmpty();
+        boolean isUnit2 = fcns.domain.isEmpty();
+        if (isUnit1 || isUnit2) { return isUnit1 == isUnit2; }
+
+        boolean isEmpty1 = this.range.isEmpty();
+        boolean isEmpty2 = fcns.range.isEmpty();
+        if (isEmpty1 || isEmpty2) { return isEmpty1 == isEmpty2; }
+
         return (this.domain.equals(fcns.domain) &&
           this.range.equals(fcns.range));
       }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -103,11 +103,11 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
     }
   }
 
-  // THEOREM \A S, T : \A f : f \in [S -> T] <=> /\ IsAFcn(f)
-  //                                             /\ DOMAIN f = S
-  //                                             /\ \A x \in S : f[x] \in T
-  //
-  // where IsAFcn(f) == f = [x \in DOMAIN f |-> f[x]].
+  // THEOREM ESE_FcnSetMember ==
+  //   ASSUME NEW S, NEW T, NEW f
+  //   PROVE  f \in [S -> T] <=> /\ f = [x \in DOMAIN f |-> f[x]]
+  //                             /\ DOMAIN f = S
+  //                             /\ \A x \in S : f[x] \in T
   //
   // The three conjuncts are toFcnRcd, the comparison of the domains, and the
   // loop over the function's values below.

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -237,9 +237,21 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   //
   // The loop below is that induction, i.e. one multiplication per element of the
   // domain, and not the closed form Cardinality(T)^Cardinality(S).
+  //
+  // THEOREM ASSUME NEW S, NEW T, NEW w, T = {w}
+  //         PROVE  Cardinality([S -> T]) = 1
   @Override
   public final int size() {
     try {
+      if (this.domain.isEmpty()) {
+        return 1;
+      }
+      if (this.range.isEmpty()) {
+        return 0;
+      }
+      if (this.range.size() == 1) {
+        return 1;
+      }
       int dsz = this.domain.size();
       int rsz = this.range.size();
       long sz = 1;
@@ -260,6 +272,12 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
 
 	@Override
 	protected boolean needBigInteger() {
+		if (this.domain.isEmpty() || this.range.isEmpty()) {
+			return false;
+		}
+		if (this.range.size() == 1) {
+			return false;
+		}
 		final int rsz = this.range.size();
 		final int dsz = this.domain.size();
 		long sz = 1;

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -91,17 +91,12 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
     }
   }
 
-  // THEOREM \A S, T : \A r : r \in [h: S, g: T] <=> /\ IsAFcn(r)
-  //                                                 /\ DOMAIN r = {"h", "g"}
-  //                                                 /\ r.h \in S
-  //                                                 /\ r.g \in T
-  //
-  // where IsAFcn(r) == r = [x \in DOMAIN r |-> r[x]].
-  //
-  // DOMAIN r = {"h", "g"} is why the comparison of the field names below is an
-  // equality and not a lookup: a record whose domain is a strict superset of
-  // {"h", "g"} is not an element of [h: S, g: T], even if r.h \in S and
-  // r.g \in T.
+  // THEOREM ESE_RcdSetMember ==
+  //   ASSUME NEW S, NEW T, NEW r
+  //   PROVE  r \in [n1 : S, n2 : T] <=> /\ r = [x \in DOMAIN r |-> r[x]]
+  //                                     /\ DOMAIN r = {"n1", "n2"}
+  //                                     /\ r.n1 \in S
+  //                                     /\ r.n2 \in T
   @Override
   public final boolean member(Value elem) {
     try {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -405,24 +405,28 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {
     try {
-      boolean unlazy = TLCGlobals.expand;
+      Value val = null;
       try {
-        if (unlazy) {
+        if (TLCGlobals.expand) {
           long sz = 1;
           for (int i = 0; i < this.values.length; i++) {
-            sz *= this.values[i].size();
-            if (sz < -2147483648 || sz > 2147483647) {
-              unlazy = false;
+            final int fsz = this.values[i].size();
+            if (fsz == 0) {
+              sz = 0;
               break;
             }
+            if (sz <= 2147483647) {
+              sz *= fsz;
+            }
           }
-          unlazy = sz < TLCGlobals.enumBound;
+          if (sz < TLCGlobals.enumBound) {
+            val = this.toSetEnum();
+          }
         }
       }
-      catch (Throwable e) { if (swallow) unlazy = false; else throw e; }
+      catch (Throwable e) { if (!swallow) throw e; }
 
-      if (unlazy) {
-        Value val = this.toSetEnum();
+      if (val != null) {
         return val.toString(sb, offset, swallow);
       }
       else {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -130,13 +130,30 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
     }
   }
 
+  // THEOREM ASSUME NEW S, NEW T, IsFiniteSet(S), IsFiniteSet(T)
+  //         PROVE  IsFiniteSet([n1 : S, n2 : T])
+  //
+  // THEOREM ESE_RcdSetEmptyFinite ==
+  //   ASSUME NEW S, NEW T, S = {} \/ T = {}
+  //   PROVE  IsFiniteSet([n1 : S, n2 : T])
+  //
+  // An empty field makes the record set {} whatever the other fields are, so
+  // the loop reads every field to find the empty one rather than stopping at
+  // the first field that is not finite. isEmpty is only asked of a field that
+  // isFinite has answered for, because an empty set is finite, and asking one
+  // that TLC cannot enumerate, such as Nat \ {0}, would fail instead.
   @Override
   public final boolean isFinite() {
     try {
+      boolean allFinite = true;
       for (int i = 0; i < this.values.length; i++) {
-        if (!this.values[i].isFinite()) return false;
+        if (this.values[i].isFinite()) {
+          if (this.values[i].isEmpty()) { return true; }
+        } else {
+          allFinite = false;
+        }
       }
-      return true;
+      return allFinite;
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -33,6 +33,7 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   /* Constructor */
   public SetOfRcdsValue(UniqueString[] names, Value[] values, boolean isNorm) {
 	  assert names.length == values.length; // see tlc2.tool.Tool.evalAppl(OpApplNode, Context, TLCState, TLCState, int) case for OPCODE_sor
+	  assert values.length > 0; // a record set spells out its fields and there is no syntax for none of them; [] parses as the box operator
     this.names = names;
     this.values = values;
     this.rcdSet = null;

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -201,6 +201,9 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   @Override
   public final int size() {
     try {
+      if (this.isEmpty()) {
+        return 0;
+      }
       long sz = 1;
       for (int i = 0; i < this.values.length; i++) {
         sz *= this.values[i].size();
@@ -219,6 +222,9 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
 
 	@Override
 	protected boolean needBigInteger() {
+		if (this.isEmpty()) {
+			return false;
+		}
 		long sz = 1;
 		for (int i = 0; i < values.length; i++) {
 			sz *= values[i].size();

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -35,6 +35,7 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
 
   /* Constructor */
   public SetOfTuplesValue(Value[] sets) {
+	  assert sets.length > 0; // \X takes two or more components, i.e. there is no nullary product; see tlc2.tool.Tool.evalAppl(OpApplNode, Context, TLCState, TLCState, int) case for OPCODE_cp
     this.sets = sets;
     this.tupleSet = null;
   }
@@ -43,6 +44,8 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
 	  this.cm = cm;
   }
 
+  // Unused and scheduled for removal: it builds a unary product, which no TLA+
+  // expression denotes. Tighten the assert above to "> 1" once it is gone.
   public SetOfTuplesValue(Value val) {
 	  this(new Value[1]);
     this.sets[0] = val;

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -100,17 +100,19 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
     }
   }
 
-  // THEOREM \A S, T : \A t : t \in S \X T <=> /\ IsAFcn(t)
-  //                                           /\ DOMAIN t = 1..2
-  //                                           /\ t[1] \in S
-  //                                           /\ t[2] \in T
-  //
-  // where IsAFcn(t) == t = [x \in DOMAIN t |-> t[x]].
+  // THEOREM ESE_TupleSetMember ==
+  //   ASSUME NEW S, NEW T, NEW t
+  //   PROVE  t \in S \X T <=> /\ t = [x \in DOMAIN t |-> t[x]]
+  //                           /\ DOMAIN t = 1..2
+  //                           /\ t[1] \in S
+  //                           /\ t[2] \in T
   //
   // DOMAIN t = 1..2 is why toTuple accepts a function whose domain is 1..n, i.e.
   // a product is a set of functions:
   //
-  // THEOREM \A S : S \X S = [1..2 -> S]
+  // THEOREM ESE_TupleSetIsFcnSet ==
+  //   ASSUME NEW S
+  //   PROVE  S \X S = [1..2 -> S]
   //
   // A function whose domain is an interval other than 1..2 is not an element of
   // S \X T, whence the comparison of the lengths below, whereas a value whose

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -383,24 +383,28 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
   @Override
   public final StringBuffer toString(StringBuffer sb, int offset, boolean swallow) {
     try {
-      boolean unlazy = TLCGlobals.expand;
+      Value val = null;
       try {
-        if (unlazy) {
+        if (TLCGlobals.expand) {
           long sz = 1;
           for (int i = 0; i < this.sets.length; i++) {
-            sz *= this.sets[i].size();
-            if (sz < -2147483648 || sz > 2147483647) {
-              unlazy = false;
+            final int csz = this.sets[i].size();
+            if (csz == 0) {
+              sz = 0;
               break;
             }
+            if (sz <= 2147483647) {
+              sz *= csz;
+            }
           }
-          unlazy = sz < TLCGlobals.enumBound;
+          if (sz < TLCGlobals.enumBound) {
+            val = this.toSetEnum();
+          }
         }
       }
-      catch (Throwable e) { if (swallow) unlazy = false; else throw e; }
+      catch (Throwable e) { if (!swallow) throw e; }
 
-      if (unlazy) {
-        Value val = this.toSetEnum();
+      if (val != null) {
         return val.toString(sb, offset, swallow);
       }
       else {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -158,15 +158,30 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
     }
   }
 
+  // THEOREM ASSUME NEW S, NEW T, IsFiniteSet(S), IsFiniteSet(T)
+  //         PROVE  IsFiniteSet(S \X T)
+  //
+  // THEOREM ESE_TupleSetEmptyFinite ==
+  //   ASSUME NEW S, NEW T, S = {} \/ T = {}
+  //   PROVE  IsFiniteSet(S \X T)
+  //
+  // An empty component makes the product {} whatever the others are, so the
+  // loop reads every component to find the empty one rather than stopping at
+  // the first component that is not finite. isEmpty is only asked of a
+  // component that isFinite has answered for, because an empty set is finite,
+  // and asking one that TLC cannot enumerate, such as Nat \ {0}, would fail.
   @Override
   public final boolean isFinite() {
     try {
+      boolean allFinite = true;
       for (int i = 0; i < this.sets.length; i++) {
-        if (!this.sets[i].isFinite()) {
-          return false;
+        if (this.sets[i].isFinite()) {
+          if (this.sets[i].isEmpty()) { return true; }
+        } else {
+          allFinite = false;
         }
       }
-      return true;
+      return allFinite;
     }
     catch (RuntimeException | OutOfMemoryError e) {
       if (hasSource()) { throw FingerprintException.getNewHead(this, e); }

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -229,6 +229,9 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
   @Override
   public final int size() {
     try {
+      if (this.isEmpty()) {
+        return 0;
+      }
       long sz = 1;
       for (int i = 0; i < this.sets.length; i++) {
         sz *= this.sets[i].size();

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserObj.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/UserObj.java
@@ -6,6 +6,7 @@
 package tlc2.value.impl;
 
 import tla2sany.semantic.ExprNode;
+import util.Assert;
 
 public abstract class UserObj {
 
@@ -16,6 +17,12 @@ public abstract class UserObj {
   public abstract boolean member(Value val);
 
   public abstract boolean isFinite();
+
+  /* True iff this object has no member.  */
+  public boolean isEmpty() {
+    Assert.fail("Shouldn't call isEmpty() on value " + this.toString());
+    return false;   // make compiler happy
+  }
   
   /* The String representation.    */
   public abstract StringBuffer toString(StringBuffer sb, int offset, boolean swallow);

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/Value.java
@@ -176,24 +176,50 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
             SetDiffValue diff = (SetDiffValue)this;
             return diff.elements().nextElement() == null;
           }
+        // THEOREM ESE_FcnSetEmpty ==
+        //   ASSUME NEW S, NEW T
+        //   PROVE  [S -> T] = {} <=> (S # {} /\ T = {})
+        //
+        // [{} -> T] is { <<>> } for every T, which is why the empty domain rules
+        // out the empty set instead of implying it.
         case SETOFFCNSVALUE:
           {
             SetOfFcnsValue fcns = (SetOfFcnsValue)this;
-            return fcns.elements().nextElement() == null;
+            return !fcns.domain.isEmpty() && fcns.range.isEmpty();
           }
+        // THEOREM ESE_RcdSetEmpty ==
+        //   ASSUME NEW S, NEW T
+        //   PROVE  [n1 : S, n2 : T] = {} <=> (S = {} \/ T = {})
         case SETOFRCDSVALUE:
           {
             SetOfRcdsValue srv = (SetOfRcdsValue)this;
-            return srv.elements().nextElement() == null;
+            for (int i = 0; i < srv.values.length; i++) {
+              if (srv.values[i].isEmpty()) { return true; }
+            }
+            // return false would still be correct even if TLA+ allowed constructing/
+            // an empty set of records, because such a set would be equal to { <<>> }.
+            return false;
           }
+        // THEOREM ESE_TupleSetEmpty ==
+        //   ASSUME NEW S, NEW T
+        //   PROVE  S \X T = {} <=> (S = {} \/ T = {})
         case SETOFTUPLESVALUE:
           {
             SetOfTuplesValue stv = (SetOfTuplesValue)this;
-            return stv.elements().nextElement() == null;
+            for (int i = 0; i < stv.sets.length; i++) {
+              if (stv.sets[i].isEmpty()) { return true; }
+            }
+            // return false would still be correct even if TLA+ allowed constructing/
+            // an empty product, because such a product would be equal to { <<>> }.
+            return false;
           }
+        // THEOREM ESE_SubsetNonEmpty ==
+        //   ASSUME NEW S
+        //   PROVE  SUBSET S # {}
+        //
+        // SUBSET S always contains {}.
         case SUBSETVALUE:
           {
-            // SUBSET S is never empty.  (It always contains {}.)
             return false;
           }
         case UNIONVALUE:
@@ -205,6 +231,13 @@ public abstract class Value implements ValueConstants, Serializable, IValue {
           {
             SetPredValue spv = (SetPredValue)this;
             return spv.elements().nextElement() == null;
+          }
+        // An overridden value such as Nat, Int, or Seq(S) cannot be enumerated,
+        // which is why the module that defines it has to answer this.
+        case USERVALUE:
+          {
+            UserValue uv = (UserValue)this;
+            return uv.userObj.isEmpty();
           }
         default:
           Assert.fail("Shouldn't call isEmpty() on value " + Values.ppr(this.toString()), getSource());

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.cfg
@@ -1,0 +1,2 @@
+\* EmptySetEqAssumeTest
+\* No behavior spec, because TLC checks the assumptions either way.

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -6,6 +6,10 @@
 \* TLA+ fact; the last five are proved and say so, i.e. they record a
 \* limitation.
 \*
+\* TLC does not yet answer every assumption below. The commented out ones are
+\* the finiteness assumptions it decides the wrong way, marked "wrong", and
+\* the commit that fixes TLC uncomments them.
+\*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 
@@ -184,6 +188,77 @@ ASSUME CardUnitTripleRange
 ASSUME CardEmptyInterval
 
 -----------------------------------------------------------------------------
+\* The finiteness of the same sets.
+
+ASSUME FinUnitEmptyRange
+ASSUME FinUnitInterval
+ASSUME FinUnitRcdField
+ASSUME FinUnitTuple
+ASSUME FinUnitFcnSet
+ASSUME FinUnitFcnSetRange
+
+\* ASSUME FinUnitNatRange           \* wrong
+\* ASSUME FinUnitStrRange           \* wrong
+\* ASSUME FinUnitFcnSetNat          \* wrong
+
+ASSUME FinEmptySingleton
+ASSUME FinEmptyInterval
+ASSUME FinEmptySubsetEmpty
+ASSUME FinEmptyRcdRange
+ASSUME FinEmptyTupleRange
+ASSUME FinEmptyFcnSetRange
+
+\* ASSUME FinEmptyNatDomain         \* wrong
+\* ASSUME FinEmptySeqDomain         \* wrong
+\* ASSUME FinEmptyDiffDomain        \* wrong
+\* ASSUME FinEmptyFcnSetNat         \* wrong
+
+ASSUME FinRcdEmptyField
+ASSUME FinRcdEmptyArity
+ASSUME FinRcdEmptyPosition
+ASSUME FinRcdEmptyFcnSet
+ASSUME FinRcdEmptyRcd
+ASSUME FinRcdEmptyTuple
+
+\* ASSUME FinRcdEmptyFieldNat       \* wrong
+\* ASSUME FinRcdEmptyNatField       \* wrong
+\* ASSUME FinRcdEmptyThenDiff       \* wrong
+\* ASSUME FinRcdDiffThenEmpty       \* wrong
+\* ASSUME FinRcdEmptyFcnSetNat      \* wrong
+
+ASSUME FinTupEmptyComponent
+ASSUME FinTupEmptyPosition
+ASSUME FinTupEmptyArity
+ASSUME FinTupEmptyFcnSet
+ASSUME FinTupEmptyRcd
+ASSUME FinTupEmptyTuple
+
+\* ASSUME FinTupEmptyNatSecond      \* wrong
+\* ASSUME FinTupEmptyNatFirst       \* wrong
+\* ASSUME FinTupDiffThenEmpty       \* wrong
+\* ASSUME FinTupEmptyFcnSetNat      \* wrong
+
+\* ASSUME FinSingletonNatDomain     \* wrong
+\* ASSUME FinSingletonIntDomain     \* wrong
+\* ASSUME FinSingletonStrDomain     \* wrong
+\* ASSUME FinSingletonDiffDomain    \* wrong
+\* ASSUME FinSingletonSeqDomain     \* wrong
+
+\* ASSUME FinSingletonInterval      \* wrong
+\* ASSUME FinSingletonRcdRange      \* wrong
+\* ASSUME FinSingletonTupleRange    \* wrong
+\* ASSUME FinSingletonSubset        \* wrong
+\* ASSUME FinSingletonFcnSet        \* wrong
+\* ASSUME FinSingletonNestedNat     \* wrong
+\* ASSUME FinSingletonAsDomain      \* wrong
+
+\* ASSUME FinSeqEmpty               \* wrong
+\* ASSUME FinSeqEmptyInterval       \* wrong
+\* ASSUME FinSeqEmptyRcd            \* wrong
+\* ASSUME FinSeqEmptyTuple          \* wrong
+\* ASSUME FinSeqEmptyFcnSet         \* wrong
+
+-----------------------------------------------------------------------------
 \* Sets that are neither empty nor {<<>>}, i.e. comparing the domains and the
 \* co-domains, the field sets, or the components is the only means left to
 \* decide these.
@@ -355,8 +430,20 @@ ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the do
 ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
                    { <<>> } = [[Nat -> {}] -> {"d2"}])
 
-\* The five assumptions of this section that record a limitation instead of an
-\* acceptable refusal. EmptySetEqCases_proofs.tla derives each of them from
+\* The finiteness of a set built from a value whose emptiness TLA+ leaves
+\* open, which TLA+ leaves open in turn: [1 -> 2] is { <<>> } if 1 = {} and
+\* {} if 2 = {}, both finite, and need not be finite otherwise. These carry
+\* the message of IntValue#isFinite rather than the isEmpty message of the
+\* five below.
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
+                   IsFiniteSet([1 -> 2]))
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
+                   IsFiniteSet([n1 : 1, n2 : {"d1"}]))
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
+                   IsFiniteSet(1 \X {"d1"}))
+
+\* Five assumptions that record a limitation instead of an acceptable
+\* refusal. EmptySetEqCases_proofs.tla derives each of them from
 \* ESE_FcnSetCongruence, ESE_RcdSetCongruence, or ESE_TupleSetCongruence, i.e.
 \* TLA+ determines all five to be TRUE. A set is a function of the arguments
 \* of its constructor, so a comparison of a set with itself holds whatever

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -5,12 +5,6 @@
 \* proof, because they state what TLC refuses to answer instead of a TLA+
 \* fact.
 \*
-\* TLC does not yet answer every comparison below. The commented out
-\* assumptions are the ones it gets wrong: it decides the ones marked "wrong"
-\* the wrong way, refuses the ones marked "refused" with an error, and raises
-\* an error other than the expected one for the ones marked "other error".
-\* The commits that make TLC answer them uncomment them.
-\*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 
@@ -18,96 +12,96 @@ EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 \* Sets of functions that denote {<<>>}, i.e. the empty domain decides.
 
 ASSUME UnitEmptyRangeEnum
-\* ASSUME UnitEmptyRangeSym         \* wrong
+ASSUME UnitEmptyRangeSym
 ASSUME UnitSingletonRangeEnum
-\* ASSUME UnitSingletonRangeSym     \* wrong
+ASSUME UnitSingletonRangeSym
 ASSUME UnitTripleRangeEnum
-\* ASSUME UnitTripleRangeSym        \* wrong
-\* ASSUME UnitNatRangeSym           \* refused
+ASSUME UnitTripleRangeSym
+ASSUME UnitNatRangeSym
 
 ASSUME UnitIntervalEnum
-\* ASSUME UnitIntervalSym           \* wrong
-\* ASSUME UnitIntervalNatSym        \* refused
+ASSUME UnitIntervalSym
+ASSUME UnitIntervalNatSym
 
 ASSUME UnitCapEnum
-\* ASSUME UnitCapSym                \* wrong
+ASSUME UnitCapSym
 ASSUME UnitCupEnum
-\* ASSUME UnitCupSym                \* wrong
+ASSUME UnitCupSym
 ASSUME UnitDiffEnum
-\* ASSUME UnitDiffSym               \* wrong
+ASSUME UnitDiffSym
 ASSUME UnitUnionEmptyEnum
-\* ASSUME UnitUnionEmptySym         \* wrong
+ASSUME UnitUnionEmptySym
 ASSUME UnitUnionOfEmptyEnum
-\* ASSUME UnitUnionOfEmptySym       \* wrong
+ASSUME UnitUnionOfEmptySym
 ASSUME UnitFilterEnum
-\* ASSUME UnitFilterSym             \* wrong
+ASSUME UnitFilterSym
 
 ASSUME UnitRcdFieldEnum
-\* ASSUME UnitRcdFieldSym           \* wrong
-\* ASSUME UnitRcdNatFieldSym        \* refused
-\* ASSUME UnitRcdFieldNatSym        \* wrong
+ASSUME UnitRcdFieldSym
+ASSUME UnitRcdNatFieldSym
+ASSUME UnitRcdFieldNatSym
 
 ASSUME UnitTupleEnum
-\* ASSUME UnitTupleSym              \* wrong
-\* ASSUME UnitTupleNatFirstSym      \* refused
-\* ASSUME UnitTupleNatSecondSym     \* wrong
-\* ASSUME UnitTupleStrFirstSym      \* refused
+ASSUME UnitTupleSym
+ASSUME UnitTupleNatFirstSym
+ASSUME UnitTupleNatSecondSym
+ASSUME UnitTupleStrFirstSym
 
-\* ASSUME UnitFcnSetSym             \* refused
-\* ASSUME UnitFcnSetNestedSym       \* refused
+ASSUME UnitFcnSetSym
+ASSUME UnitFcnSetNestedSym
 ASSUME UnitDiffNestedUnitEnum
 ASSUME UnitDiffNestedUnitSym
 
-\* ASSUME UnitRcdFcnSetSym          \* refused
-\* ASSUME UnitRcdRcdSym             \* wrong
-\* ASSUME UnitRcdTupleSym           \* wrong
-\* ASSUME UnitTupleFcnSetSym        \* refused
-\* ASSUME UnitTupleRcdSym           \* wrong
-\* ASSUME UnitTupleTupleSym         \* wrong
+ASSUME UnitRcdFcnSetSym
+ASSUME UnitRcdRcdSym
+ASSUME UnitRcdTupleSym
+ASSUME UnitTupleFcnSetSym
+ASSUME UnitTupleRcdSym
+ASSUME UnitTupleTupleSym
 
 -----------------------------------------------------------------------------
 \* Sets of functions that are empty, i.e. the empty co-domain decides.
 
 ASSUME EmptySingletonEnum
-\* ASSUME EmptySingletonSym         \* wrong
+ASSUME EmptySingletonSym
 ASSUME EmptyIntervalEnum
-\* ASSUME EmptyIntervalSym          \* wrong
+ASSUME EmptyIntervalSym
 
 ASSUME EmptyCapEnum
-\* ASSUME EmptyCapSym               \* wrong
+ASSUME EmptyCapSym
 ASSUME EmptyCupEnum
-\* ASSUME EmptyCupSym               \* wrong
+ASSUME EmptyCupSym
 ASSUME EmptyDiffEnum
-\* ASSUME EmptyDiffSym              \* wrong
+ASSUME EmptyDiffSym
 ASSUME EmptyUnionEnum
-\* ASSUME EmptyUnionSym             \* wrong
+ASSUME EmptyUnionSym
 ASSUME EmptyFilterEnum
-\* ASSUME EmptyFilterSym            \* wrong
+ASSUME EmptyFilterSym
 
 ASSUME EmptySubsetEmptyEnum
-\* ASSUME EmptySubsetEmptySym       \* refused
-\* ASSUME EmptySubsetNatSym         \* refused
+ASSUME EmptySubsetEmptySym
+ASSUME EmptySubsetNatSym
 
 ASSUME EmptyRcdEnum
-\* ASSUME EmptyRcdSym               \* refused
-\* ASSUME EmptyRcdNatSym            \* refused
+ASSUME EmptyRcdSym
+ASSUME EmptyRcdNatSym
 
 ASSUME EmptyTupleEnum
-\* ASSUME EmptyTupleSym             \* refused
-\* ASSUME EmptyTupleNatSym          \* refused
+ASSUME EmptyTupleSym
+ASSUME EmptyTupleNatSym
 
-\* ASSUME EmptyNatSym               \* refused
-\* ASSUME EmptyIntSym               \* refused
-\* ASSUME EmptySeqSym               \* refused
-\* ASSUME EmptyStrSym               \* refused
+ASSUME EmptyNatSym
+ASSUME EmptyIntSym
+ASSUME EmptySeqSym
+ASSUME EmptyStrSym
 
-\* ASSUME EmptyRcdRangeSym          \* wrong
-\* ASSUME EmptyTupleRangeSym        \* wrong
-\* ASSUME EmptyRcdFcnSetRangeSym    \* wrong
-\* ASSUME EmptyTupleFcnSetRangeSym  \* wrong
-\* ASSUME EmptyFcnSetRangeSym       \* wrong
+ASSUME EmptyRcdRangeSym
+ASSUME EmptyTupleRangeSym
+ASSUME EmptyRcdFcnSetRangeSym
+ASSUME EmptyTupleFcnSetRangeSym
+ASSUME EmptyFcnSetRangeSym
 
-\* ASSUME EmptyFcnSetSym            \* refused
+ASSUME EmptyFcnSetSym
 
 -----------------------------------------------------------------------------
 \* Sets of records that are empty, i.e. a single empty field decides.
@@ -313,10 +307,10 @@ ASSUME AssertError("Attempted to check equality of the set {<<>>} with the value
 \* rule that every value is in Any (tlc2.module.AnySet#member, which no set
 \* satisfies) as Any # {}. Refusing a reflexive comparison is acceptable for
 \* the same reason.
-\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
-\*                    [{"ref"} -> {}] = [Any -> {}])  \* other error
-\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
-\*                    [Any -> {}] = [Any -> {}])  \* other error
+ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+                   [{"ref"} -> {}] = [Any -> {}])
+ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+                   [Any -> {}] = [Any -> {}])
 ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
                    [ref : {}] = [n1 : Any, n2 : {}])
 ASSUME AssertError("Shouldn't call isEmpty() on value ANY",

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -6,10 +6,6 @@
 \* TLA+ fact; the last five are proved and say so, i.e. they record a
 \* limitation.
 \*
-\* TLC does not yet answer every assumption below. The commented out ones are
-\* the finiteness assumptions it decides the wrong way, marked "wrong", and
-\* the commit that fixes TLC uncomments them.
-\*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 
@@ -197,9 +193,9 @@ ASSUME FinUnitTuple
 ASSUME FinUnitFcnSet
 ASSUME FinUnitFcnSetRange
 
-\* ASSUME FinUnitNatRange           \* wrong
-\* ASSUME FinUnitStrRange           \* wrong
-\* ASSUME FinUnitFcnSetNat          \* wrong
+ASSUME FinUnitNatRange
+ASSUME FinUnitStrRange
+ASSUME FinUnitFcnSetNat
 
 ASSUME FinEmptySingleton
 ASSUME FinEmptyInterval
@@ -208,10 +204,10 @@ ASSUME FinEmptyRcdRange
 ASSUME FinEmptyTupleRange
 ASSUME FinEmptyFcnSetRange
 
-\* ASSUME FinEmptyNatDomain         \* wrong
-\* ASSUME FinEmptySeqDomain         \* wrong
-\* ASSUME FinEmptyDiffDomain        \* wrong
-\* ASSUME FinEmptyFcnSetNat         \* wrong
+ASSUME FinEmptyNatDomain
+ASSUME FinEmptySeqDomain
+ASSUME FinEmptyDiffDomain
+ASSUME FinEmptyFcnSetNat
 
 ASSUME FinRcdEmptyField
 ASSUME FinRcdEmptyArity
@@ -220,11 +216,11 @@ ASSUME FinRcdEmptyFcnSet
 ASSUME FinRcdEmptyRcd
 ASSUME FinRcdEmptyTuple
 
-\* ASSUME FinRcdEmptyFieldNat       \* wrong
-\* ASSUME FinRcdEmptyNatField       \* wrong
-\* ASSUME FinRcdEmptyThenDiff       \* wrong
-\* ASSUME FinRcdDiffThenEmpty       \* wrong
-\* ASSUME FinRcdEmptyFcnSetNat      \* wrong
+ASSUME FinRcdEmptyFieldNat
+ASSUME FinRcdEmptyNatField
+ASSUME FinRcdEmptyThenDiff
+ASSUME FinRcdDiffThenEmpty
+ASSUME FinRcdEmptyFcnSetNat
 
 ASSUME FinTupEmptyComponent
 ASSUME FinTupEmptyPosition
@@ -233,30 +229,30 @@ ASSUME FinTupEmptyFcnSet
 ASSUME FinTupEmptyRcd
 ASSUME FinTupEmptyTuple
 
-\* ASSUME FinTupEmptyNatSecond      \* wrong
-\* ASSUME FinTupEmptyNatFirst       \* wrong
-\* ASSUME FinTupDiffThenEmpty       \* wrong
-\* ASSUME FinTupEmptyFcnSetNat      \* wrong
+ASSUME FinTupEmptyNatSecond
+ASSUME FinTupEmptyNatFirst
+ASSUME FinTupDiffThenEmpty
+ASSUME FinTupEmptyFcnSetNat
 
-\* ASSUME FinSingletonNatDomain     \* wrong
-\* ASSUME FinSingletonIntDomain     \* wrong
-\* ASSUME FinSingletonStrDomain     \* wrong
-\* ASSUME FinSingletonDiffDomain    \* wrong
-\* ASSUME FinSingletonSeqDomain     \* wrong
+ASSUME FinSingletonNatDomain
+ASSUME FinSingletonIntDomain
+ASSUME FinSingletonStrDomain
+ASSUME FinSingletonDiffDomain
+ASSUME FinSingletonSeqDomain
 
-\* ASSUME FinSingletonInterval      \* wrong
-\* ASSUME FinSingletonRcdRange      \* wrong
-\* ASSUME FinSingletonTupleRange    \* wrong
-\* ASSUME FinSingletonSubset        \* wrong
-\* ASSUME FinSingletonFcnSet        \* wrong
-\* ASSUME FinSingletonNestedNat     \* wrong
-\* ASSUME FinSingletonAsDomain      \* wrong
+ASSUME FinSingletonInterval
+ASSUME FinSingletonRcdRange
+ASSUME FinSingletonTupleRange
+ASSUME FinSingletonSubset
+ASSUME FinSingletonFcnSet
+\* ASSUME FinSingletonNestedNat     \* refused
+ASSUME FinSingletonAsDomain
 
-\* ASSUME FinSeqEmpty               \* wrong
-\* ASSUME FinSeqEmptyInterval       \* wrong
-\* ASSUME FinSeqEmptyRcd            \* wrong
-\* ASSUME FinSeqEmptyTuple          \* wrong
-\* ASSUME FinSeqEmptyFcnSet         \* wrong
+ASSUME FinSeqEmpty
+ASSUME FinSeqEmptyInterval
+ASSUME FinSeqEmptyRcd
+ASSUME FinSeqEmptyTuple
+ASSUME FinSeqEmptyFcnSet
 
 -----------------------------------------------------------------------------
 \* Sets that are neither empty nor {<<>>}, i.e. comparing the domains and the
@@ -432,15 +428,24 @@ ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the do
 
 \* The finiteness of a set built from a value whose emptiness TLA+ leaves
 \* open, which TLA+ leaves open in turn: [1 -> 2] is { <<>> } if 1 = {} and
-\* {} if 2 = {}, both finite, and need not be finite otherwise. These carry
-\* the message of IntValue#isFinite rather than the isEmpty message of the
-\* five below.
+\* {} if 2 = {}, both finite, and need not be finite otherwise. TLC tests the
+\* finiteness of an argument before its emptiness, so these carry the message
+\* of IntValue#isFinite rather than the isEmpty message of the five below.
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
                    IsFiniteSet([1 -> 2]))
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
                    IsFiniteSet([n1 : 1, n2 : {"d1"}]))
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
                    IsFiniteSet(1 \X {"d1"}))
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the integer 1 is a finite set.",
+                   IsFiniteSet(Seq(1)))
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to check if the string \"s\" is a finite set.",
+                   IsFiniteSet(Seq("s")))
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nShouldn't call isEmpty() on value <<1>>",
+                   IsFiniteSet(Seq(<<1>>)))
+
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.IBoolValue tlc2.module.FiniteSets.IsFiniteSet(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Seq({}).",
+                   IsFiniteSet([Nat -> Seq({})]))
 
 \* Five assumptions that record a limitation instead of an acceptable
 \* refusal. EmptySetEqCases_proofs.tla derives each of them from

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -1,9 +1,10 @@
 -------------------------- MODULE EmptySetEqAssume --------------------------
 \* TLC checks every assumption at startup (Tool#checkAssumptions). Each name
 \* below is a comparison defined in EmptySetEqCases.tla and proved in
-\* EmptySetEqCases_proofs.tla. The AssertError assumptions at the end have no
-\* proof, because they state what TLC refuses to answer instead of a TLA+
-\* fact.
+\* EmptySetEqCases_proofs.tla. The AssertError assumptions at the end mostly
+\* have no proof, because they state what TLC refuses to answer instead of a
+\* TLA+ fact; the last five are proved and say so, i.e. they record a
+\* limitation.
 \*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
@@ -217,7 +218,8 @@ ASSUME SubsetEmptyDomain
 
 -----------------------------------------------------------------------------
 \* The comparisons that TLC refuses to answer. Giving up is acceptable for
-\* these sets, whereas a wrong answer is not.
+\* these sets, whereas a wrong answer is not, except for the last two
+\* assumptions of this section, which TLA+ does decide.
 
 \* A domain or a co-domain that TLC cannot enumerate.
 ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
@@ -352,4 +354,31 @@ ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the do
                    { } = [[Nat -> {"d1"}] -> {}])
 ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
                    { <<>> } = [[Nat -> {}] -> {"d2"}])
+
+\* The five assumptions of this section that record a limitation instead of an
+\* acceptable refusal. EmptySetEqCases_proofs.tla derives each of them from
+\* ESE_FcnSetCongruence, ESE_RcdSetCongruence, or ESE_TupleSetCongruence, i.e.
+\* TLA+ determines all five to be TRUE. A set is a function of the arguments
+\* of its constructor, so a comparison of a set with itself holds whatever
+\* those arguments contain, and no emptiness is needed to decide it.
+\*
+\* TLC decides a comparison the other way round: SetOfRcdsValue#equals tests
+\* the emptiness of the field sets, SetOfTuplesValue#equals that of the
+\* components, and SetOfFcnsValue#equals that of the domain and the co-domain,
+\* each before comparing them. Congruence follows from the comparison that
+\* these tests precede, whereas a test itself requires 1 = {} or 1 # {},
+\* neither of which is a theorem of TLA+. Deciding these five therefore needs
+\* an emptiness test that may answer neither, and a comparison of the
+\* arguments where it does. Until then TLC refuses, which is sound.
+\*
+\* The tests came to the three constructors separately, which is why TLC
+\* answered the five until different times. Commit 075246eea of 2014-06-09
+\* added them to SetOfRcdsValue#equals and SetOfTuplesValue#equals, so TLC has
+\* refused RcdIntReflexive and TupIntReflexive since, and it refuses the three
+\* remaining ones since the commit that added them to SetOfFcnsValue#equals.
+ASSUME AssertError("Shouldn't call isEmpty() on value 1", FcnIntReflexive)
+ASSUME AssertError("Shouldn't call isEmpty() on value \"s\"", FcnStrLitReflexive)
+ASSUME AssertError("Shouldn't call isEmpty() on value <<1>>", FcnTupleReflexive)
+ASSUME AssertError("Shouldn't call isEmpty() on value 1", RcdIntReflexive)
+ASSUME AssertError("Shouldn't call isEmpty() on value 1", TupIntReflexive)
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -119,12 +119,12 @@ ASSUME RcdEmptyArityEnum
 ASSUME RcdEmptyAritySym
 ASSUME RcdEmptyIntervalEnum
 ASSUME RcdEmptyIntervalSym
-\* ASSUME RcdEmptyNatFieldSym       \* refused
+ASSUME RcdEmptyNatFieldSym
 ASSUME RcdEmptyFieldNatSym
-\* ASSUME RcdEmptySeqFieldSym       \* refused
-\* ASSUME RcdEmptyStrFieldSym       \* refused
+ASSUME RcdEmptySeqFieldSym
+ASSUME RcdEmptyStrFieldSym
 
-\* ASSUME RcdEmptyFcnSetSym         \* refused
+ASSUME RcdEmptyFcnSetSym
 ASSUME RcdEmptyRcdSym
 ASSUME RcdEmptyTupleSym
 ASSUME RcdEmptyThenDiffSym
@@ -139,12 +139,12 @@ ASSUME TupEmptyArityEnum
 ASSUME TupEmptyAritySym
 ASSUME TupEmptyIntervalEnum
 ASSUME TupEmptyIntervalSym
-\* ASSUME TupEmptyNatFirstSym       \* refused
+ASSUME TupEmptyNatFirstSym
 ASSUME TupEmptyNatSecondSym
-\* ASSUME TupEmptySeqFirstSym       \* refused
-\* ASSUME TupEmptyStrFirstSym       \* refused
+ASSUME TupEmptySeqFirstSym
+ASSUME TupEmptyStrFirstSym
 
-\* ASSUME TupEmptyFcnSetSym         \* refused
+ASSUME TupEmptyFcnSetSym
 ASSUME TupEmptyRcdSym
 ASSUME TupEmptyTupleSym
 ASSUME TupEmptyThenDiffSym
@@ -203,13 +203,13 @@ ASSUME RangeNatIntDiffer
 ASSUME DomainFcnSetReflexive
 ASSUME RangeNestedUnitDomainDiffer
 
-\* ASSUME RcdNatReflexive           \* refused
-\* ASSUME RcdNatIntDiffer           \* refused
-\* ASSUME RcdStrReflexive           \* refused
+ASSUME RcdNatReflexive
+ASSUME RcdNatIntDiffer
+ASSUME RcdStrReflexive
 
-\* ASSUME TupNatReflexive           \* refused
-\* ASSUME TupNatIntDiffer           \* refused
-\* ASSUME TupStrReflexive           \* refused
+ASSUME TupNatReflexive
+ASSUME TupNatIntDiffer
+ASSUME TupStrReflexive
 
 -----------------------------------------------------------------------------
 \* The operators that have to agree with the comparisons above.
@@ -317,10 +317,10 @@ ASSUME AssertError("Attempted to check equality of the set {<<>>} with the value
 \*                    [{"ref"} -> {}] = [Any -> {}])  \* other error
 \* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
 \*                    [Any -> {}] = [Any -> {}])  \* other error
-\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
-\*                    [ref : {}] = [n1 : Any, n2 : {}])  \* other error
-\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
-\*                    ({"ref"} \X {}) = (Any \X {}))  \* other error
+ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+                   [ref : {}] = [n1 : Any, n2 : {}])
+ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+                   ({"ref"} \X {}) = (Any \X {}))
 
 \* An operator other than = that gives up where = decides: [Nat -> {}] is
 \* empty and [{} -> Nat] denotes {<<>>} above, so \notin and \subseteq have an

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -1,0 +1,361 @@
+-------------------------- MODULE EmptySetEqAssume --------------------------
+\* TLC checks every assumption at startup (Tool#checkAssumptions). Each name
+\* below is a comparison defined in EmptySetEqCases.tla and proved in
+\* EmptySetEqCases_proofs.tla. The AssertError assumptions at the end have no
+\* proof, because they state what TLC refuses to answer instead of a TLA+
+\* fact.
+\*
+\* TLC does not yet answer every comparison below. The commented out
+\* assumptions are the ones it gets wrong: it decides the ones marked "wrong"
+\* the wrong way, refuses the ones marked "refused" with an error, and raises
+\* an error other than the expected one for the ones marked "other error".
+\* The commits that make TLC answer them uncomment them.
+\*
+\* See https://github.com/tlaplus/tlaplus/issues/1407
+EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
+
+-----------------------------------------------------------------------------
+\* Sets of functions that denote {<<>>}, i.e. the empty domain decides.
+
+ASSUME UnitEmptyRangeEnum
+\* ASSUME UnitEmptyRangeSym         \* wrong
+ASSUME UnitSingletonRangeEnum
+\* ASSUME UnitSingletonRangeSym     \* wrong
+ASSUME UnitTripleRangeEnum
+\* ASSUME UnitTripleRangeSym        \* wrong
+\* ASSUME UnitNatRangeSym           \* refused
+
+ASSUME UnitIntervalEnum
+\* ASSUME UnitIntervalSym           \* wrong
+\* ASSUME UnitIntervalNatSym        \* refused
+
+ASSUME UnitCapEnum
+\* ASSUME UnitCapSym                \* wrong
+ASSUME UnitCupEnum
+\* ASSUME UnitCupSym                \* wrong
+ASSUME UnitDiffEnum
+\* ASSUME UnitDiffSym               \* wrong
+ASSUME UnitUnionEmptyEnum
+\* ASSUME UnitUnionEmptySym         \* wrong
+ASSUME UnitUnionOfEmptyEnum
+\* ASSUME UnitUnionOfEmptySym       \* wrong
+ASSUME UnitFilterEnum
+\* ASSUME UnitFilterSym             \* wrong
+
+ASSUME UnitRcdFieldEnum
+\* ASSUME UnitRcdFieldSym           \* wrong
+\* ASSUME UnitRcdNatFieldSym        \* refused
+\* ASSUME UnitRcdFieldNatSym        \* wrong
+
+ASSUME UnitTupleEnum
+\* ASSUME UnitTupleSym              \* wrong
+\* ASSUME UnitTupleNatFirstSym      \* refused
+\* ASSUME UnitTupleNatSecondSym     \* wrong
+\* ASSUME UnitTupleStrFirstSym      \* refused
+
+\* ASSUME UnitFcnSetSym             \* refused
+\* ASSUME UnitFcnSetNestedSym       \* refused
+ASSUME UnitDiffNestedUnitEnum
+ASSUME UnitDiffNestedUnitSym
+
+\* ASSUME UnitRcdFcnSetSym          \* refused
+\* ASSUME UnitRcdRcdSym             \* wrong
+\* ASSUME UnitRcdTupleSym           \* wrong
+\* ASSUME UnitTupleFcnSetSym        \* refused
+\* ASSUME UnitTupleRcdSym           \* wrong
+\* ASSUME UnitTupleTupleSym         \* wrong
+
+-----------------------------------------------------------------------------
+\* Sets of functions that are empty, i.e. the empty co-domain decides.
+
+ASSUME EmptySingletonEnum
+\* ASSUME EmptySingletonSym         \* wrong
+ASSUME EmptyIntervalEnum
+\* ASSUME EmptyIntervalSym          \* wrong
+
+ASSUME EmptyCapEnum
+\* ASSUME EmptyCapSym               \* wrong
+ASSUME EmptyCupEnum
+\* ASSUME EmptyCupSym               \* wrong
+ASSUME EmptyDiffEnum
+\* ASSUME EmptyDiffSym              \* wrong
+ASSUME EmptyUnionEnum
+\* ASSUME EmptyUnionSym             \* wrong
+ASSUME EmptyFilterEnum
+\* ASSUME EmptyFilterSym            \* wrong
+
+ASSUME EmptySubsetEmptyEnum
+\* ASSUME EmptySubsetEmptySym       \* refused
+\* ASSUME EmptySubsetNatSym         \* refused
+
+ASSUME EmptyRcdEnum
+\* ASSUME EmptyRcdSym               \* refused
+\* ASSUME EmptyRcdNatSym            \* refused
+
+ASSUME EmptyTupleEnum
+\* ASSUME EmptyTupleSym             \* refused
+\* ASSUME EmptyTupleNatSym          \* refused
+
+\* ASSUME EmptyNatSym               \* refused
+\* ASSUME EmptyIntSym               \* refused
+\* ASSUME EmptySeqSym               \* refused
+\* ASSUME EmptyStrSym               \* refused
+
+\* ASSUME EmptyRcdRangeSym          \* wrong
+\* ASSUME EmptyTupleRangeSym        \* wrong
+\* ASSUME EmptyRcdFcnSetRangeSym    \* wrong
+\* ASSUME EmptyTupleFcnSetRangeSym  \* wrong
+\* ASSUME EmptyFcnSetRangeSym       \* wrong
+
+\* ASSUME EmptyFcnSetSym            \* refused
+
+-----------------------------------------------------------------------------
+\* Sets of records that are empty, i.e. a single empty field decides.
+
+ASSUME RcdEmptyFieldEnum
+ASSUME RcdEmptyFieldSym
+ASSUME RcdEmptyNameSym
+ASSUME RcdEmptyArityEnum
+ASSUME RcdEmptyAritySym
+ASSUME RcdEmptyIntervalEnum
+ASSUME RcdEmptyIntervalSym
+\* ASSUME RcdEmptyNatFieldSym       \* refused
+ASSUME RcdEmptyFieldNatSym
+\* ASSUME RcdEmptySeqFieldSym       \* refused
+\* ASSUME RcdEmptyStrFieldSym       \* refused
+
+\* ASSUME RcdEmptyFcnSetSym         \* refused
+ASSUME RcdEmptyRcdSym
+ASSUME RcdEmptyTupleSym
+ASSUME RcdEmptyThenDiffSym
+
+-----------------------------------------------------------------------------
+\* Cartesian products that are empty, i.e. a single empty component decides.
+
+ASSUME TupEmptyComponentEnum
+ASSUME TupEmptyComponentSym
+ASSUME TupEmptyPositionSym
+ASSUME TupEmptyArityEnum
+ASSUME TupEmptyAritySym
+ASSUME TupEmptyIntervalEnum
+ASSUME TupEmptyIntervalSym
+\* ASSUME TupEmptyNatFirstSym       \* refused
+ASSUME TupEmptyNatSecondSym
+\* ASSUME TupEmptySeqFirstSym       \* refused
+\* ASSUME TupEmptyStrFirstSym       \* refused
+
+\* ASSUME TupEmptyFcnSetSym         \* refused
+ASSUME TupEmptyRcdSym
+ASSUME TupEmptyTupleSym
+ASSUME TupEmptyThenDiffSym
+
+-----------------------------------------------------------------------------
+\* Two sets of different constructors.
+
+ASSUME FcnSetEqRcdSetEmpty
+ASSUME FcnSetEqTupleSetEmpty
+ASSUME RcdSetEqTupleSetEmpty
+ASSUME UnitDiffRcdSetEmpty
+ASSUME UnitDiffTupleSetEmpty
+
+ASSUME RcdSetIsFcnSet
+ASSUME TupleSetIsFcnSet
+ASSUME TupleSetIsFcnSet3
+
+-----------------------------------------------------------------------------
+\* The comparisons of the sections above with their operands swapped, which
+\* is what reaches the equals of a set of functions, of records, and of a
+\* Cartesian product with an argument of another kind.
+
+ASSUME UnitEmptyRangeRev
+ASSUME UnitSingletonRangeRev
+ASSUME EmptySingletonRev
+ASSUME RcdEmptyFieldRev
+ASSUME RcdEmptyArityRev
+ASSUME TupEmptyComponentRev
+ASSUME TupEmptyArityRev
+
+ASSUME RcdSetEqFcnSetEmptyRev
+ASSUME TupleSetEqFcnSetEmptyRev
+ASSUME TupleSetEqRcdSetEmptyRev
+ASSUME RcdSetIsFcnSetRev
+ASSUME TupleSetIsFcnSetRev
+
+-----------------------------------------------------------------------------
+\* How many functions there are.
+
+ASSUME CardUnitEmptyRange
+ASSUME CardUnitTripleRange
+ASSUME CardEmptyInterval
+
+-----------------------------------------------------------------------------
+\* Sets that are neither empty nor {<<>>}, i.e. comparing the domains and the
+\* co-domains, the field sets, or the components is the only means left to
+\* decide these.
+
+ASSUME DomainNatReflexive
+ASSUME DomainNatIntDiffer
+ASSUME DomainSubsetNatReflexive
+
+ASSUME RangeNatReflexive
+ASSUME RangeNatIntDiffer
+
+ASSUME DomainFcnSetReflexive
+ASSUME RangeNestedUnitDomainDiffer
+
+\* ASSUME RcdNatReflexive           \* refused
+\* ASSUME RcdNatIntDiffer           \* refused
+\* ASSUME RcdStrReflexive           \* refused
+
+\* ASSUME TupNatReflexive           \* refused
+\* ASSUME TupNatIntDiffer           \* refused
+\* ASSUME TupStrReflexive           \* refused
+
+-----------------------------------------------------------------------------
+\* The operators that have to agree with the comparisons above.
+
+ASSUME InUnitSingletonRange
+ASSUME InUnitNatRange
+ASSUME NotInEmpty
+
+ASSUME SubsetUnitRanges
+ASSUME SubsetEmptyDomain
+
+-----------------------------------------------------------------------------
+\* The comparisons that TLC refuses to answer. Giving up is acceptable for
+\* these sets, whereas a wrong answer is not.
+
+\* A domain or a co-domain that TLC cannot enumerate.
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [(Nat \ {0}) -> {"d1"}] = [(Nat \ {0}) -> {"d1"}])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [{"d1"} -> (Nat \ {0})] = [{"d1"} -> (Nat \ {0})])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [{"ref"} -> {}] = [(Nat \ {0}) -> {}])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [{"ref"} -> {}] = [[n1 : (Nat \ {0})] -> {}])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [{"ref"} -> {}] = [((Nat \ {0}) \X {"d1"}) -> {}])
+ASSUME AssertError("Attempted to check if the value:\n\"d1\"\nis an element of Nat.",
+                   [{"ref"} -> {}] = [({"d1"} \cap Nat) -> {}])
+ASSUME AssertError("Attempted to enumerate S \\cup T when S:\n{\"d1\"}\nand T:\nNat\nare not both enumerable",
+                   [{"ref"} -> {}] = [({"d1"} \cup Nat) -> {}])
+ASSUME AssertError("Attempted to enumerate UNION(s), but some element of s is nonenumerable.",
+                   [{"ref"} -> {}] = [(UNION {Nat}) -> {}])
+ASSUME AssertError("Attempted to enumerate { x \\in S : p(x) } when S:\nNat\nis not enumerable",
+                   [{"ref"} -> {}] = [{d \in Nat : d > 0} -> {}])
+
+\* A field set or a component that TLC cannot enumerate, in the position that
+\* it reaches before the empty one. RcdEmptyThenDiffSym and TupEmptyThenDiffSym
+\* are the two comparisons in the order that TLC decides.
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [ref : {}] = [n1 : (Nat \ {0}), n2 : {}])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   ({"ref"} \X {}) = ((Nat \ {0}) \X {}))
+
+\* An emptiness that TLC does not know: Nat \ Nat is empty, i.e. the two sets
+\* differ, and answering the comparison on the two empty co-domains, field
+\* sets, or components would make TLC report them as equal.
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [{"ref"} -> {}] # [(Nat \ Nat) -> {}])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [(Nat \ Nat) -> {}] # [{"ref"} -> {}])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   [ref : {}] # [n1 : (Nat \ Nat)])
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   ({"ref"} \X {}) # ((Nat \ Nat) \X {"d1"}))
+
+\* Two sets of different constructors, where TLC enumerates both instead of
+\* taking the emptiness rules. FcnSetEqRcdSetEmpty and the cases next to it
+\* are the same comparisons on sets that TLC does enumerate.
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   [Nat -> {}] = [n1 : {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   [n1 : {}] = [Nat -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   [Nat -> {}] = ({} \X {"r1"}))
+ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
+                   ({} \X {"r1"}) = [n1 : Nat, n2 : {}])
+
+\* A record and a tuple, which differ because their domains differ
+\* (ESE_RcdSetDiffTupleSet of EmptySetEqTheorems.tla), and which TLC refuses
+\* to compare.
+ASSUME AssertError("Attempted to check equality of record:\n[n1 |-> \"a\"]\nwith non-record\n<<\"a\", \"a\">>",
+                   [n1 : {"a"}] # ({"a"} \X {"a"}))
+
+\* An overridden value compared with a set that TLC enumerates.
+ASSUME AssertError("Attempted to compare overridden value Seq({}) with non-overridden value:\n{<<>>}",
+                   Seq({}) = {<<>>})
+ASSUME AssertError("Attempted to check equality of the set {<<>>} with the value:\nSeq({})",
+                   {<<>>} = Seq({}))
+ASSUME AssertError("Attempted to compare overridden value Nat with non-overridden value:\n{\"r1\"}",
+                   [Nat -> {"d1"}] # [{"r1"} -> {"d1"}])
+ASSUME AssertError("Attempted to check equality of the set {\"r1\"} with the value:\nNat",
+                   [{"r1"} -> {"d1"}] # [Nat -> {"d1"}])
+ASSUME AssertError("Attempted to compare overridden value Seq({}) with non-overridden value:\n{<<>>}",
+                   [Seq({}) -> {"d1"}] = [{<<>>} -> {"d1"}])
+ASSUME AssertError("Attempted to check equality of the set {<<>>} with the value:\nSeq({})",
+                   [{<<>>} -> {"d1"}] = [Seq({}) -> {"d1"}])
+ASSUME AssertError("Attempted to compare overridden value Nat with non-overridden value:\n{\"r1\"}",
+                   [{"d1"} -> Nat] # [{"d1"} -> {"r1"}])
+ASSUME AssertError("Attempted to check equality of the set {\"r1\"} with the value:\nNat",
+                   [{"d1"} -> {"r1"}] # [{"d1"} -> Nat])
+ASSUME AssertError("Attempted to compare overridden value Seq({}) with non-overridden value:\n{<<>>}",
+                   [{"d1"} -> Seq({})] = [{"d1"} -> {<<>>}])
+ASSUME AssertError("Attempted to check equality of the set {<<>>} with the value:\nSeq({})",
+                   [{"d1"} -> {<<>>}] = [{"d1"} -> Seq({})])
+
+\* TLC!Any, whose emptiness no rule decides. TLA+ defines Any as
+\* CHOOSE x : TRUE, a fixed but unspecified value, so [Any -> {}] is { <<>> }
+\* if Any = {} and {} otherwise. Unlike Nat, Int, STRING, and Seq(S) above,
+\* which the Empty*Sym comparisons have TLC answer from a witness, Any has no
+\* witness to offer. TLC therefore refuses these instead of reading its own
+\* rule that every value is in Any (tlc2.module.AnySet#member, which no set
+\* satisfies) as Any # {}. Refusing a reflexive comparison is acceptable for
+\* the same reason.
+\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+\*                    [{"ref"} -> {}] = [Any -> {}])  \* other error
+\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+\*                    [Any -> {}] = [Any -> {}])  \* other error
+\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+\*                    [ref : {}] = [n1 : Any, n2 : {}])  \* other error
+\* ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
+\*                    ({"ref"} \X {}) = (Any \X {}))  \* other error
+
+\* An operator other than = that gives up where = decides: [Nat -> {}] is
+\* empty and [{} -> Nat] denotes {<<>>} above, so \notin and \subseteq have an
+\* answer that TLC does not give. ESE_EmptyNonMember, ESE_EmptySubset, and
+\* ESE_UnitSubset of EmptySetEqTheorems.tla state the three answers.
+ASSUME AssertError("Attempted to check equality of the set {} with the value:\nNat",
+                   <<>> \notin [Nat -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   [Nat -> {}] \subseteq [{"r1"} -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
+                   [{} -> Nat] \subseteq [{} -> {"d1"}])
+
+\* The reduced form { } or { <<>> } for an input that TLC cannot enumerate.
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   { } = [Nat -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   [Nat -> {}] = { })
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nInt\ncannot be enumerated.",
+                   { } = [Int -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nSeq({\"d1\"})\ncannot be enumerated.",
+                   { } = [Seq({"d1"}) -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
+                   { <<>> } = [{} -> Nat])
+ASSUME AssertError("Attempted to compute the number of elements in the overridden value Nat.",
+                   { } = [(SUBSET Nat) -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
+                   { } = [[n1 : Nat] -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
+                   { } = [(Nat \X {"d1"}) -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
+                   { } = [n1 : Nat, n2 : {}])
+ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
+                   { } = (Nat \X {}))
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   { } = [[Nat -> {"d1"}] -> {}])
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   { <<>> } = [[Nat -> {}] -> {"d2"}])
+=============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -3,8 +3,12 @@
 \* below is a comparison defined in EmptySetEqCases.tla and proved in
 \* EmptySetEqCases_proofs.tla. The AssertError assumptions at the end mostly
 \* have no proof, because they state what TLC refuses to answer instead of a
-\* TLA+ fact; the last five are proved and say so, i.e. they record a
+\* TLA+ fact; the ones that do have a proof say so, i.e. they record a
 \* limitation.
+\*
+\* TLC does not yet answer every assumption below. The commented out ones are
+\* the cardinalities it refuses, marked "refused", and the commit that fixes
+\* TLC uncomments them.
 \*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
@@ -177,11 +181,80 @@ ASSUME RcdSetIsFcnSetRev
 ASSUME TupleSetIsFcnSetRev
 
 -----------------------------------------------------------------------------
-\* How many functions there are.
+\* The cardinality of each set above. The ones TLC refuses are AssertError
+\* assumptions of the last section, and the commented out ones are refused
+\* as well, for a reason the commit that fixes TLC removes.
 
 ASSUME CardUnitEmptyRange
 ASSUME CardUnitTripleRange
+ASSUME CardUnitInterval
+ASSUME CardUnitCap
+ASSUME CardUnitFilter
+
+ASSUME CardUnitRcdField
+ASSUME CardUnitTuple
+ASSUME CardUnitFcnSet
+ASSUME CardUnitFcnSetRange
+
+ASSUME CardEmptySingleton
 ASSUME CardEmptyInterval
+ASSUME CardEmptySubsetEmpty
+ASSUME CardEmptyRcdDomain
+
+ASSUME CardEmptyRcdRange
+ASSUME CardEmptyTupleRange
+ASSUME CardEmptyFcnSetRange
+
+ASSUME CardRcdEmptyField
+ASSUME CardRcdEmptyArity
+ASSUME CardRcdEmptyPosition
+ASSUME CardRcdEmptyInterval
+ASSUME CardRcdEmptyFcnSet
+ASSUME CardRcdEmptyRcd
+ASSUME CardRcdEmptyTuple
+
+ASSUME CardTupEmptyComponent
+ASSUME CardTupEmptyPosition
+ASSUME CardTupEmptyArity
+ASSUME CardTupEmptyInterval
+ASSUME CardTupEmptyFcnSet
+ASSUME CardTupEmptyRcd
+ASSUME CardTupEmptyTuple
+
+\* ASSUME CardRcdLargeThenEmpty     \* refused
+ASSUME CardRcdEmptyThenLarge
+\* ASSUME CardTupLargeThenEmpty     \* refused
+ASSUME CardTupEmptyThenLarge
+\* ASSUME CardUnitTupleLarge        \* refused
+
+\* ASSUME CardRcdEmptyFieldNat      \* refused
+\* ASSUME CardRcdEmptyThenDiff      \* refused
+\* ASSUME CardTupEmptyNatSecond     \* refused
+
+\* ASSUME CardRcdEmptyFcnSetNat     \* refused
+\* ASSUME CardTupEmptyFcnSetNat     \* refused
+
+\* ASSUME CardUnitNatRange          \* refused
+\* ASSUME CardEmptyNatDomain        \* refused
+\* ASSUME CardUnitFcnSetNat         \* refused
+\* ASSUME CardEmptyFcnSetNat        \* refused
+\* ASSUME CardUnitSubsetRange       \* refused
+\* ASSUME CardEmptySubsetDomain     \* refused
+\* ASSUME CardSingletonNatDomain    \* refused
+\* ASSUME CardSingletonSubset       \* refused
+\* ASSUME CardSingletonAsDomain     \* refused
+\* ASSUME CardSingletonSubsetDomain    \* refused
+\* ASSUME CardSingletonLargeDomain     \* refused
+\* ASSUME CardSingletonSeqEmptyDomain  \* refused
+\* ASSUME CardSingletonUnionDomain     \* refused
+
+\* ASSUME CardSubsetSingletonFcnSet    \* refused
+\* ASSUME CardTupSingletonFcnSet       \* refused
+\* ASSUME CardRcdSingletonFcnSet       \* refused
+\* ASSUME CardSingletonSubsetAsDomain  \* refused
+\* ASSUME CardSingletonSubsetAsRange   \* refused
+\* ASSUME CardUnitLargeRange        \* refused
+\* ASSUME CardEmptyLargeDomain      \* refused
 
 -----------------------------------------------------------------------------
 \* The finiteness of the same sets.
@@ -473,4 +546,23 @@ ASSUME AssertError("Shouldn't call isEmpty() on value \"s\"", FcnStrLitReflexive
 ASSUME AssertError("Shouldn't call isEmpty() on value <<1>>", FcnTupleReflexive)
 ASSUME AssertError("Shouldn't call isEmpty() on value 1", RcdIntReflexive)
 ASSUME AssertError("Shouldn't call isEmpty() on value 1", TupIntReflexive)
+
+\* The cardinalities that record a limitation as well, for the reason their
+\* groups in EmptySetEqCases.tla give: for a set of records or a Cartesian
+\* product TLC stops at the first empty constituent, so only a non-computable
+\* constituent ahead of the empty one is refused.
+\*
+\* EmptySetEqCases_proofs.tla derives each of these from
+\* ESE_RcdSetEmptyCardinality or ESE_TupleSetEmptyCardinality. The five above
+\* wait on an emptiness test that TLA+ may answer neither way, these on the
+\* test for an empty constituent that TLC already performs.
+\*
+\* Cardinality is a module override, so the error of each of these carries
+\* the wrapper that TLC puts around one.
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Nat.",
+                   CardRcdEmptyNatField)
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   CardRcdDiffThenEmpty)
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Nat.",
+                   CardTupEmptyNatFirst)
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -349,11 +349,93 @@ ASSUME TupNatIntDiffer
 ASSUME TupStrReflexive
 
 -----------------------------------------------------------------------------
-\* The operators that have to agree with the comparisons above.
+\* The same sets read through \in.
 
+ASSUME InUnitEmptyRange
 ASSUME InUnitSingletonRange
+ASSUME InUnitTripleRange
 ASSUME InUnitNatRange
+ASSUME InUnitInterval
+ASSUME InUnitIntervalNat
+ASSUME InUnitCap
+ASSUME InUnitCup
+ASSUME InUnitDiff
+ASSUME InUnitUnionEmpty
+ASSUME InUnitUnionOfEmpty
+ASSUME InUnitFilter
+
+ASSUME InUnitRcdField
+ASSUME InUnitRcdFieldNat
+ASSUME InUnitTuple
+ASSUME InUnitTupleNatSecond
+ASSUME InUnitFcnSet
+
+ASSUME InUnitRcdRcd
+ASSUME InUnitRcdTuple
+ASSUME InUnitTupleRcd
+ASSUME InUnitTupleTuple
+
+ASSUME NotInUnitTuple
+ASSUME NotInUnitRcd
+
 ASSUME NotInEmpty
+ASSUME NotInEmptyInterval
+ASSUME NotInEmptySubsetEmpty
+
+ASSUME NotInEmptyFcn
+ASSUME NotInEmptyRcdDomain
+ASSUME NotInEmptyRcdRange
+ASSUME NotInEmptyTupleRange
+ASSUME NotInEmptyFcnSetRange
+
+ASSUME NotInRcdEmptyField
+ASSUME NotInRcdEmptyArity
+ASSUME NotInRcdEmptyPosition
+ASSUME NotInRcdEmptyInterval
+
+ASSUME NotInRcdEmptyFcnSet
+ASSUME NotInRcdEmptyRcd
+ASSUME NotInRcdEmptyTuple
+
+ASSUME NotInRcdEmptyFieldNat
+ASSUME NotInRcdEmptyNatField
+ASSUME NotInRcdEmptyStrField
+ASSUME NotInRcdEmptyThenDiff
+ASSUME NotInRcdDiffThenEmpty
+
+ASSUME NotInTupEmptyComponent
+ASSUME NotInTupEmptyPosition
+ASSUME NotInTupEmptyArity
+ASSUME NotInTupEmptyInterval
+
+ASSUME NotInTupEmptyFcnSet
+ASSUME NotInTupEmptyRcd
+ASSUME NotInTupEmptyTuple
+
+ASSUME NotInTupEmptyNatFirst
+ASSUME NotInTupEmptyNatSecond
+ASSUME NotInTupEmptySeqFirst
+ASSUME NotInTupEmptyStrFirst
+ASSUME NotInTupDiffThenEmpty
+ASSUME NotInTupEmptyThenDiff
+
+ASSUME InRcdSetIsFcnSet
+ASSUME InFcnSetIsRcdSet
+ASSUME InTupleSetIsFcnSet
+ASSUME InFcnSetIsTupleSet
+
+ASSUME NotInFcnSetDomain
+ASSUME NotInRcdSetName
+ASSUME NotInRcdSetArity
+ASSUME NotInTupleSetArity
+ASSUME NotInTupleSetOffset
+
+ASSUME InRcdSetNat
+ASSUME InTupleSetNat
+ASSUME InFcnSetNatRange
+
+-----------------------------------------------------------------------------
+\* The remaining operator that has to agree with the comparisons above.
 
 ASSUME SubsetUnitRanges
 ASSUME SubsetEmptyDomain
@@ -489,7 +571,7 @@ ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
 \* answer that TLC does not give. ESE_EmptyNonMember, ESE_EmptySubset, and
 \* ESE_UnitSubset of EmptySetEqTheorems.tla state the three answers.
 ASSUME AssertError("Attempted to check equality of the set {} with the value:\nNat",
-                   <<>> \notin [Nat -> {}])
+                   NotInEmptyNatDomain)
 ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
                    [Nat -> {}] \subseteq [{"r1"} -> {}])
 ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
@@ -584,4 +666,63 @@ ASSUME AssertError("Attempted to apply the operator overridden by the Java metho
                    ToString([{} -> Nat]) = "{<<>>}")
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nOverflow when computing the number of elements in (1..50000 \\X 1..50000)",
                    ToString([((1..50000) \X (1..50000)) -> {}]) = "{}")
+
+-----------------------------------------------------------------------------
+\* The memberships that record a limitation as well, i.e. cases that
+\* EmptySetEqCases_proofs.tla proves. Unlike equals, isFinite, and size,
+\* member tests no emptiness: it compares the domain of the set with the
+\* domain of the value, 1..0 for <<>>, and reads the field sets and the
+\* components one by one. An argument that TLC can neither compare nor read
+\* therefore refuses a membership that an empty domain, co-domain, field
+\* set, or component decides.
+
+\* An empty domain, i.e. the set is { <<>> } and <<>> is its member.
+ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
+                   InUnitRcdNatField)
+ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
+                   InUnitTupleNatFirst)
+ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nSTRING",
+                   InUnitTupleStrFirst)
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   InUnitFcnSetNat)
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   InUnitFcnSetNested)
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   InUnitRcdFcnSet)
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   InUnitTupleFcnSet)
+
+\* An empty co-domain, i.e. the set is { } and nothing is its member, where
+\* the domain is the argument that TLC gives up on.
+ASSUME AssertError("Attempted to check equality of the set {} with the value:\nInt",
+                   NotInEmptyIntDomain)
+ASSUME AssertError("Attempted to check equality of the set {} with the value:\nSeq({\"d1\"})",
+                   NotInEmptySeqDomain)
+ASSUME AssertError("Attempted to check equality of the set {} with the value:\nSTRING",
+                   NotInEmptyStrDomain)
+ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
+                   NotInEmptyDiffDomain)
+ASSUME AssertError("Attempted to compute the number of elements in the overridden value Nat.",
+                   NotInEmptySubsetNat)
+ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
+                   NotInEmptyRcdNatDomain)
+ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
+                   NotInEmptyTupleNatDomain)
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
+                   NotInEmptyFcnSetDomain)
+
+\* A field set or a component that TLC cannot check the value against,
+\* whereas the empty one beside it decides.
+ASSUME AssertError("Attempted to check if the value:\n\"s\"\nis an element of Nat.",
+                   NotInRcdEmptyNatFieldStr)
+ASSUME AssertError("Attempted to check if the value:\n\"s\"\nis an element of Nat.",
+                   NotInTupEmptyNatFirstStr)
+
+\* A tuple where a record set expects a record and a record where a
+\* Cartesian product expects a tuple, which the domains of the two values
+\* decide (ESE_TupleDomainDiffRcdDomain).
+ASSUME AssertError("Attempted to check if non-record\n<<\"a\", \"a\">>\nis in the set of records:\n{[n1 |-> \"a\"]}",
+                   NotInRcdSetTuple)
+ASSUME AssertError("Attempted to check if non-tuple\n[n1 |-> \"a\"]\nis in the set of tuples:\n{<<\"a\", \"a\">>}",
+                   NotInTupleSetRcd)
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -6,10 +6,6 @@
 \* TLA+ fact; the ones that do have a proof say so, i.e. they record a
 \* limitation.
 \*
-\* TLC does not yet answer every assumption below. The commented out ones are
-\* the cardinalities it refuses, marked "refused", and the commit that fixes
-\* TLC uncomments them.
-\*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 
@@ -182,8 +178,7 @@ ASSUME TupleSetIsFcnSetRev
 
 -----------------------------------------------------------------------------
 \* The cardinality of each set above. The ones TLC refuses are AssertError
-\* assumptions of the last section, and the commented out ones are refused
-\* as well, for a reason the commit that fixes TLC removes.
+\* assumptions of the last section.
 
 ASSUME CardUnitEmptyRange
 ASSUME CardUnitTripleRange
@@ -221,40 +216,43 @@ ASSUME CardTupEmptyFcnSet
 ASSUME CardTupEmptyRcd
 ASSUME CardTupEmptyTuple
 
-\* ASSUME CardRcdLargeThenEmpty     \* refused
+ASSUME CardRcdLargeThenEmpty
 ASSUME CardRcdEmptyThenLarge
-\* ASSUME CardTupLargeThenEmpty     \* refused
+ASSUME CardTupLargeThenEmpty
 ASSUME CardTupEmptyThenLarge
-\* ASSUME CardUnitTupleLarge        \* refused
+ASSUME CardUnitTupleLarge
 
-\* ASSUME CardRcdEmptyFieldNat      \* refused
-\* ASSUME CardRcdEmptyThenDiff      \* refused
-\* ASSUME CardTupEmptyNatSecond     \* refused
+ASSUME CardRcdEmptyFieldNat
+ASSUME CardRcdEmptyThenDiff
+ASSUME CardTupEmptyNatSecond
 
-\* ASSUME CardRcdEmptyFcnSetNat     \* refused
-\* ASSUME CardTupEmptyFcnSetNat     \* refused
+ASSUME CardRcdEmptyNatField
+ASSUME CardTupEmptyNatFirst
 
-\* ASSUME CardUnitNatRange          \* refused
-\* ASSUME CardEmptyNatDomain        \* refused
-\* ASSUME CardUnitFcnSetNat         \* refused
-\* ASSUME CardEmptyFcnSetNat        \* refused
-\* ASSUME CardUnitSubsetRange       \* refused
-\* ASSUME CardEmptySubsetDomain     \* refused
-\* ASSUME CardSingletonNatDomain    \* refused
-\* ASSUME CardSingletonSubset       \* refused
-\* ASSUME CardSingletonAsDomain     \* refused
-\* ASSUME CardSingletonSubsetDomain    \* refused
-\* ASSUME CardSingletonLargeDomain     \* refused
-\* ASSUME CardSingletonSeqEmptyDomain  \* refused
-\* ASSUME CardSingletonUnionDomain     \* refused
+ASSUME CardRcdEmptyFcnSetNat
+ASSUME CardTupEmptyFcnSetNat
 
-\* ASSUME CardSubsetSingletonFcnSet    \* refused
-\* ASSUME CardTupSingletonFcnSet       \* refused
-\* ASSUME CardRcdSingletonFcnSet       \* refused
-\* ASSUME CardSingletonSubsetAsDomain  \* refused
-\* ASSUME CardSingletonSubsetAsRange   \* refused
-\* ASSUME CardUnitLargeRange        \* refused
-\* ASSUME CardEmptyLargeDomain      \* refused
+ASSUME CardUnitNatRange
+ASSUME CardEmptyNatDomain
+ASSUME CardUnitFcnSetNat
+ASSUME CardEmptyFcnSetNat
+ASSUME CardUnitSubsetRange
+ASSUME CardEmptySubsetDomain
+ASSUME CardSingletonNatDomain
+ASSUME CardSingletonSubset
+ASSUME CardSingletonAsDomain
+ASSUME CardSingletonSubsetDomain
+ASSUME CardSingletonLargeDomain
+ASSUME CardSingletonSeqEmptyDomain
+ASSUME CardSingletonUnionDomain
+
+ASSUME CardSubsetSingletonFcnSet
+ASSUME CardTupSingletonFcnSet
+ASSUME CardRcdSingletonFcnSet
+ASSUME CardSingletonSubsetAsDomain
+ASSUME CardSingletonSubsetAsRange
+ASSUME CardUnitLargeRange
+ASSUME CardEmptyLargeDomain
 
 -----------------------------------------------------------------------------
 \* The finiteness of the same sets.
@@ -318,7 +316,7 @@ ASSUME FinSingletonRcdRange
 ASSUME FinSingletonTupleRange
 ASSUME FinSingletonSubset
 ASSUME FinSingletonFcnSet
-\* ASSUME FinSingletonNestedNat     \* refused
+ASSUME FinSingletonNestedNat
 ASSUME FinSingletonAsDomain
 
 ASSUME FinSeqEmpty
@@ -547,22 +545,12 @@ ASSUME AssertError("Shouldn't call isEmpty() on value <<1>>", FcnTupleReflexive)
 ASSUME AssertError("Shouldn't call isEmpty() on value 1", RcdIntReflexive)
 ASSUME AssertError("Shouldn't call isEmpty() on value 1", TupIntReflexive)
 
-\* The cardinalities that record a limitation as well, for the reason their
-\* groups in EmptySetEqCases.tla give: for a set of records or a Cartesian
-\* product TLC stops at the first empty constituent, so only a non-computable
-\* constituent ahead of the empty one is refused.
+\* The cardinality that records a limitation as well.
 \*
-\* EmptySetEqCases_proofs.tla derives each of these from
-\* ESE_RcdSetEmptyCardinality or ESE_TupleSetEmptyCardinality. The five above
-\* wait on an emptiness test that TLA+ may answer neither way, these on the
-\* test for an empty constituent that TLC already performs.
+\* EmptySetEqCases_proofs.tla derives it from ESE_RcdSetEmptyCardinality.
 \*
 \* Cardinality is a module override, so the error of each of these carries
 \* the wrapper that TLC puts around one.
-ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Nat.",
-                   CardRcdEmptyNatField)
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
                    CardRcdDiffThenEmpty)
-ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Nat.",
-                   CardTupEmptyNatFirst)
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -359,6 +359,30 @@ ASSUME SubsetUnitRanges
 ASSUME SubsetEmptyDomain
 
 -----------------------------------------------------------------------------
+\* The rendering that TLC prints for the same sets, which has to agree with
+\* the cardinalities above: TLC prints a set whose cardinality is below
+\* TLCGlobals.enumBound by enumerating it and prints the constructor it was
+\* written with otherwise, so a set that an empty argument reduces to { } or
+\* { <<>> } prints as that. The last assumption has no empty argument and its
+\* cardinality exceeds the bound, i.e. it is the constructor case and the
+\* empty arguments are what separates the ones above it from it.
+\*
+\* TLC!ToString reads the rendering that keeps a nested error instead of
+\* discarding it (Value#toStringUnchecked), i.e. these state what TLC prints
+\* rather than a fact about TLA+, which is why they have no proof and are
+\* written out here instead of in EmptySetEqCases.tla.
+
+ASSUME ToString([n1 : {}, n2 : Nat])                     = "{}"
+ASSUME ToString([n1 : {}, n2 : (Nat \ {0})])             = "{}"
+ASSUME ToString({} \X Nat)                               = "{}"
+ASSUME ToString([n1 : 1..50000, n2 : 1..50000, n3 : {}]) = "{}"
+ASSUME ToString((1..50000) \X (1..50000) \X {})          = "{}"
+ASSUME ToString([{} -> (SUBSET (1..40))])                = "{<<>>}"
+ASSUME ToString([{} -> ((1..50000) \X (1..50000))])      = "{<<>>}"
+
+ASSUME ToString([n1 : 1..50000, n2 : 1..50000]) = "[n1: 1..50000, n2: 1..50000]"
+
+-----------------------------------------------------------------------------
 \* The comparisons that TLC refuses to answer. Giving up is acceptable for
 \* these sets, whereas a wrong answer is not, except for the last two
 \* assumptions of this section, which TLA+ does decide.
@@ -553,4 +577,11 @@ ASSUME AssertError("Shouldn't call isEmpty() on value 1", TupIntReflexive)
 \* the wrapper that TLC puts around one.
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.IntValue tlc2.module.FiniteSets.Cardinality(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
                    CardRcdDiffThenEmpty)
+
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Nat.",
+                   ToString([n1 : Nat, n2 : {}]) = "{}")
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
+                   ToString([{} -> Nat]) = "{<<>>}")
+ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nOverflow when computing the number of elements in (1..50000 \\X 1..50000)",
+                   ToString([((1..50000) \X (1..50000)) -> {}]) = "{}")
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -1,0 +1,275 @@
+-------------------------- MODULE EmptySetEqCases ---------------------------
+\* One definition per comparison that TLC has to get right when it compares
+\* two sets that it represents without enumerating them: a set of functions,
+\* a set of records, or a Cartesian product. EmptySetEqAssume.tla assumes
+\* them, which is what puts them in front of TLC's evaluator, and
+\* EmptySetEqCases_proofs.tla proves them from the rules in
+\* EmptySetEqTheorems.tla. The definitions live in a module of their own,
+\* because a module's assumptions are hypotheses for every proof in it and in
+\* the modules extending it.
+\*
+\* The left-hand side of a comparison is the reduced form and the right-hand
+\* side the input being tested. The Enum suffix names the form that compares
+\* the input with { <<>> } or { }, which puts TLC on its enumeration path, and
+\* the Sym suffix the form that compares it with the most reduced form of the
+\* input's own constructor: [{} -> {"ref"}] and [{"ref"} -> {}] for a set of
+\* functions, [ref : {}] for a set of records, and {"ref"} \X {} for a
+\* Cartesian product. An input that TLC cannot enumerate has the Sym form
+\* only. The Rev suffix names the form whose operands are swapped, i.e. the
+\* exception to the order above, for the reason given in the section carrying
+\* it.
+\*
+\* See https://github.com/tlaplus/tlaplus/issues/1407
+EXTENDS FiniteSets, Integers, Sequences
+
+-----------------------------------------------------------------------------
+\* Sets of functions that denote {<<>>}, the set whose only element is the
+\* empty function, i.e. the empty domain decides.
+
+UnitEmptyRangeEnum     == { <<>> }        = [{} -> {}]
+UnitEmptyRangeSym      == [{} -> {"ref"}] = [{} -> {}]
+UnitSingletonRangeEnum == { <<>> }        = [{} -> {"d1"}]
+UnitSingletonRangeSym  == [{} -> {"ref"}] = [{} -> {"d1"}]
+UnitTripleRangeEnum    == { <<>> }        = [{} -> {"a", "b", "c"}]
+UnitTripleRangeSym     == [{} -> {"ref"}] = [{} -> {"a", "b", "c"}]
+UnitNatRangeSym        == [{} -> {"ref"}] = [{} -> Nat]
+
+UnitIntervalEnum       == { <<>> }        = [1..0 -> {"d1"}]
+UnitIntervalSym        == [{} -> {"ref"}] = [1..0 -> {"d1"}]
+UnitIntervalNatSym     == [{} -> {"ref"}] = [1..0 -> Nat]
+
+UnitCapEnum            == { <<>> }        = [({"d1"} \cap {"d2"}) -> {"e1"}]
+UnitCapSym             == [{} -> {"ref"}] = [({"d1"} \cap {"d2"}) -> {"e1"}]
+UnitCupEnum            == { <<>> }        = [({} \cup {}) -> {"e1"}]
+UnitCupSym             == [{} -> {"ref"}] = [({} \cup {}) -> {"e1"}]
+UnitDiffEnum           == { <<>> }        = [({"d1"} \ {"d1"}) -> {"e1"}]
+UnitDiffSym            == [{} -> {"ref"}] = [({"d1"} \ {"d1"}) -> {"e1"}]
+UnitUnionEmptyEnum     == { <<>> }        = [(UNION {}) -> {"e1"}]
+UnitUnionEmptySym      == [{} -> {"ref"}] = [(UNION {}) -> {"e1"}]
+UnitUnionOfEmptyEnum   == { <<>> }        = [(UNION {{}}) -> {"e1"}]
+UnitUnionOfEmptySym    == [{} -> {"ref"}] = [(UNION {{}}) -> {"e1"}]
+UnitFilterEnum         == { <<>> }        = [{d \in {"d1"} : FALSE} -> {"e1"}]
+UnitFilterSym          == [{} -> {"ref"}] = [{d \in {"d1"} : FALSE} -> {"e1"}]
+
+\* The domain is a set of records.
+UnitRcdFieldEnum       == { <<>> }        = [[n1 : {}] -> {"e1"}]
+UnitRcdFieldSym        == [{} -> {"ref"}] = [[n1 : {}] -> {"e1"}]
+UnitRcdNatFieldSym     == [{} -> {"ref"}] = [[n1 : Nat, n2 : {}] -> {"d1"}]
+UnitRcdFieldNatSym     == [{} -> {"ref"}] = [[n1 : {}, n2 : Nat] -> {"d1"}]
+
+\* The domain is a Cartesian product.
+UnitTupleEnum          == { <<>> }        = [({"d1"} \X {}) -> {"e1"}]
+UnitTupleSym           == [{} -> {"ref"}] = [({"d1"} \X {}) -> {"e1"}]
+UnitTupleNatFirstSym   == [{} -> {"ref"}] = [(Nat \X {}) -> {"d1"}]
+UnitTupleNatSecondSym  == [{} -> {"ref"}] = [({} \X Nat) -> {"d1"}]
+UnitTupleStrFirstSym   == [{} -> {"ref"}] = [(STRING \X {}) -> {"d1"}]
+
+\* The domain is a set of functions that is itself empty.
+UnitFcnSetSym          == [{} -> {"ref"}] = [[Nat -> {}] -> {"d2"}]
+UnitFcnSetNestedSym    == [{} -> {"ref"}] = [[[Nat -> {"d1"}] -> {}] -> {"d2"}]
+
+\* The domain is a set of functions that denotes { <<>> } instead of {}, i.e.
+\* it is a singleton, which is what makes these sets differ.
+UnitDiffNestedUnitEnum == { <<>> }        # [[{} -> {}] -> {"d2"}]
+UnitDiffNestedUnitSym  == [{} -> {"ref"}] # [[{} -> {}] -> {"d2"}]
+
+\* The domain is a set of records or of tuples whose field or component is
+\* itself an empty set.
+UnitRcdFcnSetSym       == [{} -> {"ref"}] = [[n1 : [Nat -> {}]] -> {"d1"}]
+UnitRcdRcdSym          == [{} -> {"ref"}] = [[n1 : [n2 : {}]] -> {"d1"}]
+UnitRcdTupleSym        == [{} -> {"ref"}] = [[n1 : ({"d1"} \X {})] -> {"d1"}]
+UnitTupleFcnSetSym     == [{} -> {"ref"}] = [({"d1"} \X [Nat -> {}]) -> {"e1"}]
+UnitTupleRcdSym        == [{} -> {"ref"}] = [({"d1"} \X [n1 : {}]) -> {"e1"}]
+UnitTupleTupleSym      == [{} -> {"ref"}] = [({"d1"} \X ({"d2"} \X {})) -> {"e1"}]
+
+-----------------------------------------------------------------------------
+\* Sets of functions that are empty, i.e. the empty co-domain decides. All
+\* domains are non-empty, which is what separates these from the group above.
+
+EmptySingletonEnum       == { }             = [{"r1"} -> {}]
+EmptySingletonSym        == [{"ref"} -> {}] = [{"r1"} -> {}]
+EmptyIntervalEnum        == { }             = [1..2 -> {}]
+EmptyIntervalSym         == [{"ref"} -> {}] = [1..2 -> {}]
+
+EmptyCapEnum             == { }             = [({"d1"} \cap {"d1"}) -> {}]
+EmptyCapSym              == [{"ref"} -> {}] = [({"d1"} \cap {"d1"}) -> {}]
+EmptyCupEnum             == { }             = [({} \cup {"d1"}) -> {}]
+EmptyCupSym              == [{"ref"} -> {}] = [({} \cup {"d1"}) -> {}]
+EmptyDiffEnum            == { }             = [({"d1"} \ {"d2"}) -> {}]
+EmptyDiffSym             == [{"ref"} -> {}] = [({"d1"} \ {"d2"}) -> {}]
+EmptyUnionEnum           == { }             = [(UNION {{"d1"}}) -> {}]
+EmptyUnionSym            == [{"ref"} -> {}] = [(UNION {{"d1"}}) -> {}]
+EmptyFilterEnum          == { }             = [{d \in {"d1"} : TRUE} -> {}]
+EmptyFilterSym           == [{"ref"} -> {}] = [{d \in {"d1"} : TRUE} -> {}]
+
+\* SUBSET S contains {} for every S, i.e. it is never empty.
+EmptySubsetEmptyEnum     == { }             = [(SUBSET {}) -> {}]
+EmptySubsetEmptySym      == [{"ref"} -> {}] = [(SUBSET {}) -> {}]
+EmptySubsetNatSym        == [{"ref"} -> {}] = [(SUBSET Nat) -> {}]
+
+EmptyRcdEnum             == { }             = [[n1 : {"d1"}] -> {}]
+EmptyRcdSym              == [{"ref"} -> {}] = [[n1 : {"d1"}] -> {}]
+EmptyRcdNatSym           == [{"ref"} -> {}] = [[n1 : Nat] -> {}]
+
+EmptyTupleEnum           == { }             = [({"d1"} \X {"d1"}) -> {}]
+EmptyTupleSym            == [{"ref"} -> {}] = [({"d1"} \X {"d1"}) -> {}]
+EmptyTupleNatSym         == [{"ref"} -> {}] = [(Nat \X {"d1"}) -> {}]
+
+EmptyNatSym              == [{"ref"} -> {}] = [Nat -> {}]
+EmptyIntSym              == [{"ref"} -> {}] = [Int -> {}]
+EmptySeqSym              == [{"ref"} -> {}] = [Seq({"d1"}) -> {}]
+EmptyStrSym              == [{"ref"} -> {}] = [STRING -> {}]
+
+\* The co-domain is empty, instead of the domain.
+EmptyRcdRangeSym         == [{"ref"} -> {}] = [{"d1"} -> [n1 : Nat, n2 : {}]]
+EmptyTupleRangeSym       == [{"ref"} -> {}] = [{"d1"} -> (Nat \X {})]
+EmptyRcdFcnSetRangeSym   == [{"ref"} -> {}] = [{"d1"} -> [n1 : [Nat -> {}]]]
+EmptyTupleFcnSetRangeSym == [{"ref"} -> {}] = [{"d1"} -> ({"d1"} \X [Nat -> {}])]
+EmptyFcnSetRangeSym      == [{"ref"} -> {}] = [{"x1"} -> [{"y"} -> [Nat -> {}]]]
+
+\* The domain is a set of functions that is non-empty.
+EmptyFcnSetSym           == [{"ref"} -> {}] = [[Nat -> {"d1"}] -> {}]
+
+-----------------------------------------------------------------------------
+\* Sets of records that are empty, i.e. a single empty field decides. Neither
+\* the names nor the number of the fields decides once both sets are empty.
+
+RcdEmptyFieldEnum    == { }        = [n1 : {}]
+RcdEmptyFieldSym     == [ref : {}] = [n1 : {}]
+RcdEmptyNameSym      == [ref : {}] = [n2 : {}]
+RcdEmptyArityEnum    == { }        = [n1 : {}, n2 : {"r1"}]
+RcdEmptyAritySym     == [ref : {}] = [n1 : {}, n2 : {"r1"}]
+RcdEmptyIntervalEnum == { }        = [n1 : 1..0, n2 : {"r1"}]
+RcdEmptyIntervalSym  == [ref : {}] = [n1 : 1..0, n2 : {"r1"}]
+RcdEmptyNatFieldSym  == [ref : {}] = [n1 : Nat, n2 : {}]
+RcdEmptyFieldNatSym  == [ref : {}] = [n1 : {}, n2 : Nat]
+RcdEmptySeqFieldSym  == [ref : {}] = [n1 : Seq({"d1"}), n2 : {}]
+RcdEmptyStrFieldSym  == [ref : {}] = [n1 : STRING, n2 : {}]
+
+\* The field is a set of functions, of records, or of tuples that is itself
+\* empty.
+RcdEmptyFcnSetSym    == [ref : {}] = [n1 : [Nat -> {}]]
+RcdEmptyRcdSym       == [ref : {}] = [n1 : [n2 : {}]]
+RcdEmptyTupleSym     == [ref : {}] = [n1 : ({"d1"} \X {})]
+
+\* The empty field comes before the field whose emptiness TLC cannot decide,
+\* which is why TLC decides this comparison. The reverse order is one of the
+\* AssertError assumptions of EmptySetEqAssume.tla.
+RcdEmptyThenDiffSym  == [ref : {}] = [n1 : {}, n2 : (Nat \ {0})]
+
+-----------------------------------------------------------------------------
+\* Cartesian products that are empty, i.e. a single empty component decides.
+\* Neither the position of the empty component nor the number of components
+\* decides once both products are empty.
+
+TupEmptyComponentEnum == { }             = ({} \X {"r1"})
+TupEmptyComponentSym  == ({"ref"} \X {}) = ({} \X {"r1"})
+TupEmptyPositionSym   == ({"ref"} \X {}) = ({"r1"} \X {})
+TupEmptyArityEnum     == { }             = ({} \X {"r1"} \X {"r2"})
+TupEmptyAritySym      == ({"ref"} \X {}) = ({} \X {"r1"} \X {"r2"})
+TupEmptyIntervalEnum  == { }             = ((1..0) \X {"r1"})
+TupEmptyIntervalSym   == ({"ref"} \X {}) = ((1..0) \X {"r1"})
+TupEmptyNatFirstSym   == ({"ref"} \X {}) = (Nat \X {})
+TupEmptyNatSecondSym  == ({"ref"} \X {}) = ({} \X Nat)
+TupEmptySeqFirstSym   == ({"ref"} \X {}) = (Seq({"d1"}) \X {})
+TupEmptyStrFirstSym   == ({"ref"} \X {}) = (STRING \X {})
+
+\* The component is a set of functions, of records, or of tuples that is
+\* itself empty.
+TupEmptyFcnSetSym     == ({"ref"} \X {}) = ([Nat -> {}] \X {"d1"})
+TupEmptyRcdSym        == ({"ref"} \X {}) = ([n1 : {}] \X {"d1"})
+TupEmptyTupleSym      == ({"ref"} \X {}) = (({"d1"} \X {}) \X {"d1"})
+
+\* The empty component comes before the component whose emptiness TLC cannot
+\* decide, which is why TLC decides this comparison.
+TupEmptyThenDiffSym   == ({"ref"} \X {}) = ({} \X (Nat \ {0}))
+
+-----------------------------------------------------------------------------
+\* Two sets of different constructors. TLC enumerates both instead of taking
+\* the emptiness rules, so only the enumerable ones are here and the rest are
+\* AssertError assumptions of EmptySetEqAssume.tla.
+
+FcnSetEqRcdSetEmpty   == [{"ref"} -> {}] = [n1 : {}]
+FcnSetEqTupleSetEmpty == [{"ref"} -> {}] = ({} \X {"r1"})
+RcdSetEqTupleSetEmpty == [ref : {}]      = ({} \X {"r1"})
+UnitDiffRcdSetEmpty   == [{} -> {"ref"}] # [n1 : {}]
+UnitDiffTupleSetEmpty == [{} -> {"ref"}] # ({} \X {"r1"})
+
+\* A record is a function on a set of strings and a tuple is a function on
+\* 1..n, i.e. these sets are equal however TLC represents them.
+RcdSetIsFcnSet    == [{"n1"} -> {"a"}]    = [n1 : {"a"}]
+TupleSetIsFcnSet  == [1..2 -> {"a", "b"}] = ({"a", "b"} \X {"a", "b"})
+TupleSetIsFcnSet3 == [1..3 -> {"a"}]      = ({"a"} \X {"a"} \X {"a"})
+
+-----------------------------------------------------------------------------
+\* The comparisons above with their operands swapped. TLC evaluates a = b as
+\* a.equals(b) (Tool, OPCODE_eq), i.e. the left-hand side decides whose equals
+\* runs, and every section above puts the reduced form there. The equals of a
+\* set of functions, of records, and of a Cartesian product therefore never
+\* receives an argument of another kind, which is the one case it answers by
+\* enumerating itself rather than by the emptiness of a domain, a field, or a
+\* component. Only the swapped form reaches that case.
+
+UnitEmptyRangeRev     == [{} -> {}]               = { <<>> }
+UnitSingletonRangeRev == [{} -> {"d1"}]           = { <<>> }
+EmptySingletonRev     == [{"r1"} -> {}]           = { }
+RcdEmptyFieldRev      == [n1 : {}]                = { }
+RcdEmptyArityRev      == [n1 : {}, n2 : {"r1"}]   = { }
+TupEmptyComponentRev  == ({} \X {"r1"})           = { }
+TupEmptyArityRev      == ({} \X {"r1"} \X {"r2"}) = { }
+
+\* Two sets of different constructors, with the one that the section above
+\* keeps on the right on the left instead.
+RcdSetEqFcnSetEmptyRev   == [n1 : {}]      = [{"ref"} -> {}]
+TupleSetEqFcnSetEmptyRev == ({} \X {"r1"}) = [{"ref"} -> {}]
+TupleSetEqRcdSetEmptyRev == ({} \X {"r1"}) = [ref : {}]
+RcdSetIsFcnSetRev        == [n1 : {"a"}]   = [{"n1"} -> {"a"}]
+TupleSetIsFcnSetRev      == ({"a", "b"} \X {"a", "b"}) = [1..2 -> {"a", "b"}]
+
+-----------------------------------------------------------------------------
+\* How many functions there are.
+
+CardUnitEmptyRange  == 1 = Cardinality([{} -> {}])
+CardUnitTripleRange == 1 = Cardinality([{} -> {"a", "b", "c"}])
+CardEmptyInterval   == 0 = Cardinality([1..2 -> {}])
+
+-----------------------------------------------------------------------------
+\* Sets that are neither empty nor {<<>>}, i.e. comparing the domains and the
+\* co-domains, the field sets, or the components is the only means left to
+\* decide these. They have no reduced form that TLC could compare them with.
+
+DomainNatReflexive       == [Nat -> {"d1"}] = [Nat -> {"d1"}]
+DomainNatIntDiffer       == [Nat -> {"d1"}] # [Int -> {"d1"}]
+DomainSubsetNatReflexive == [SUBSET Nat -> {"d1"}] = [SUBSET Nat -> {"d1"}]
+
+RangeNatReflexive        == [{"d1"} -> Nat] = [{"d1"} -> Nat]
+RangeNatIntDiffer        == [{"d1"} -> Nat] # [{"d1"} -> Int]
+
+DomainFcnSetReflexive ==
+    [[Nat -> {"d1"}] -> {"d2"}] = [[Nat -> {"d1"}] -> {"d2"}]
+
+\* [[Nat -> {}] -> {"d1"}] denotes {<<>>} and not {}, which is why the two
+\* sets have one element each and are distinct.
+RangeNestedUnitDomainDiffer ==
+    [[[Nat -> {}] -> {"d1"}] -> {"d2"}] # [[[Nat -> {}] -> {"d1"}] -> {"d3"}]
+
+RcdNatReflexive == [n1 : Nat, n2 : {"d1"}] = [n1 : Nat, n2 : {"d1"}]
+RcdNatIntDiffer == [n1 : Nat, n2 : {"d1"}] # [n1 : Int, n2 : {"d1"}]
+RcdStrReflexive == [n1 : STRING, n2 : {"d1"}] = [n1 : STRING, n2 : {"d1"}]
+
+TupNatReflexive == (Nat \X {"d1"}) = (Nat \X {"d1"})
+TupNatIntDiffer == (Nat \X {"d1"}) # (Int \X {"d1"})
+TupStrReflexive == (STRING \X {"d1"}) = (STRING \X {"d1"})
+
+-----------------------------------------------------------------------------
+\* The operators that have to agree with the comparisons above. TLC answers
+\* these for the sets it can enumerate and gives up for the rest, i.e. it
+\* stays silent instead of contradicting the comparisons.
+
+InUnitSingletonRange == <<>> \in [{} -> {"d1"}]
+InUnitNatRange       == <<>> \in [{} -> Nat]
+NotInEmpty           == <<>> \notin [{"r1"} -> {}]
+
+SubsetUnitRanges     == [{} -> {"d1"}] \subseteq [{} -> Nat]
+SubsetEmptyDomain    == [{"r1"} -> {}] \subseteq [Nat -> {}]
+=============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -299,32 +299,22 @@ CardUnitTupleLarge ==
 
 \* An empty field set or component before one whose cardinality TLC cannot
 \* compute, so TLC stops at the empty one. RcdEmptyFieldNatSym and
-\* TupEmptyNatSecondSym are the comparisons that this order decides, and the
-\* reverse order is refused in both, i.e. a cardinality turns on the position
-\* of the empty constituent as a comparison does.
+\* TupEmptyNatSecondSym are the comparisons that this order decides.
 CardRcdEmptyFieldNat   == 0 = Cardinality([n1 : {}, n2 : Nat])
 CardRcdEmptyThenDiff   == 0 = Cardinality([n1 : {}, n2 : (Nat \ {0})])
 CardTupEmptyNatSecond  == 0 = Cardinality({} \X Nat)
 
-\* The cardinalities that TLC refuses, i.e. the AssertError assumptions of
-\* EmptySetEqAssume.tla. TLC reads the constituents in order and stops at the
-\* first empty one, so a non-computable constituent costs TLC the cardinality
-\* only where it comes first. These are the reverses of the three
-\* above, and the second constituent being empty makes each a TLA+ fact all
-\* the same, hence the proofs.
 CardRcdEmptyNatField   == 0 = Cardinality([n1 : Nat, n2 : {}])
 CardRcdDiffThenEmpty   == 0 = Cardinality([n1 : (Nat \ {0}), n2 : {}])
 CardTupEmptyNatFirst   == 0 = Cardinality(Nat \X {})
 
-\* A field set or component that is an empty set of functions, whose own
-\* cardinality TLC cannot compute in any position, for the reason the next
-\* group states.
+\* A field set or component that is an empty set of functions, i.e. the next
+\* group counts the constituent and the empty constituent counts the whole.
 CardRcdEmptyFcnSetNat  == 0 = Cardinality([n1 : [Nat -> {}]])
 CardTupEmptyFcnSetNat  == 0 = Cardinality([Nat -> {}] \X {"d1"})
 
-\* Sets of functions, where TLC reads the cardinality of both the domain and
-\* the co-domain before either emptiness applies, so no order of the two
-\* decides.
+\* Sets of functions, where an empty domain or an empty co-domain decides the
+\* count whatever the other argument is, so no order of the two refuses one.
 CardUnitNatRange       == 1 = Cardinality([{} -> Nat])
 CardEmptyNatDomain     == 0 = Cardinality([Nat -> {}])
 CardUnitFcnSetNat      == 1 = Cardinality([[Nat -> {}] -> {"d2"}])

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -234,6 +234,86 @@ CardUnitTripleRange == 1 = Cardinality([{} -> {"a", "b", "c"}])
 CardEmptyInterval   == 0 = Cardinality([1..2 -> {}])
 
 -----------------------------------------------------------------------------
+\* The finiteness of the same sets. Every one of them is { <<>> } or {}, so
+\* one empty argument decides a finiteness whatever the other arguments are.
+\* The Fin prefix names a finiteness and the rest of a name its argument.
+
+\* Sets of functions that denote { <<>> }, i.e. the empty domain decides.
+FinUnitEmptyRange      == IsFiniteSet([{} -> {}])
+FinUnitInterval        == IsFiniteSet([1..0 -> {"d1"}])
+FinUnitRcdField        == IsFiniteSet([[n1 : {}] -> {"e1"}])
+FinUnitTuple           == IsFiniteSet([({"d1"} \X {}) -> {"e1"}])
+FinUnitFcnSet          == IsFiniteSet([[{"d1"} -> {}] -> {"e1"}])
+FinUnitFcnSetRange     == IsFiniteSet([{} -> [{"d1"} -> {}]])
+
+\* An infinite co-domain beside or inside the empty domain.
+FinUnitNatRange        == IsFiniteSet([{} -> Nat])
+FinUnitStrRange        == IsFiniteSet([{} -> STRING])
+FinUnitFcnSetNat       == IsFiniteSet([[Nat -> {}] -> {"d2"}])
+
+\* Sets of functions that are empty, i.e. the empty co-domain decides.
+FinEmptySingleton      == IsFiniteSet([{"r1"} -> {}])
+FinEmptyInterval       == IsFiniteSet([1..2 -> {}])
+FinEmptySubsetEmpty    == IsFiniteSet([(SUBSET {}) -> {}])
+FinEmptyRcdRange       == IsFiniteSet([{"d1"} -> [n1 : {}]])
+FinEmptyTupleRange     == IsFiniteSet([{"d1"} -> ({"d1"} \X {})])
+FinEmptyFcnSetRange    == IsFiniteSet([{"d1"} -> [{"e1"} -> {}]])
+
+\* An infinite domain beside or inside the empty co-domain.
+FinEmptyNatDomain      == IsFiniteSet([Nat -> {}])
+FinEmptySeqDomain      == IsFiniteSet([Seq({"d1"}) -> {}])
+FinEmptyDiffDomain     == IsFiniteSet([(Nat \ {0}) -> {}])
+FinEmptyFcnSetNat      == IsFiniteSet([{"d1"} -> [Nat -> {}]])
+
+\* Sets of records that are empty, i.e. a single empty field decides.
+FinRcdEmptyField       == IsFiniteSet([n1 : {}])
+FinRcdEmptyArity       == IsFiniteSet([n1 : {}, n2 : {"r1"}])
+FinRcdEmptyPosition    == IsFiniteSet([n1 : {"r1"}, n2 : {}])
+FinRcdEmptyFcnSet      == IsFiniteSet([n1 : [{"d1"} -> {}]])
+FinRcdEmptyRcd         == IsFiniteSet([n1 : [n2 : {}]])
+FinRcdEmptyTuple       == IsFiniteSet([n1 : ({"d1"} \X {})])
+
+\* An infinite field beside or inside the empty one, in either position.
+FinRcdEmptyFieldNat    == IsFiniteSet([n1 : {}, n2 : Nat])
+FinRcdEmptyNatField    == IsFiniteSet([n1 : Nat, n2 : {}])
+FinRcdEmptyThenDiff    == IsFiniteSet([n1 : {}, n2 : (Nat \ {0})])
+FinRcdDiffThenEmpty    == IsFiniteSet([n1 : (Nat \ {0}), n2 : {}])
+FinRcdEmptyFcnSetNat   == IsFiniteSet([n1 : [Nat -> {}]])
+
+\* Cartesian products that are empty, i.e. a single empty component decides.
+FinTupEmptyComponent   == IsFiniteSet({} \X {"r1"})
+FinTupEmptyPosition    == IsFiniteSet({"r1"} \X {})
+FinTupEmptyArity       == IsFiniteSet({} \X {"r1"} \X {"r2"})
+FinTupEmptyFcnSet      == IsFiniteSet([{"d1"} -> {}] \X {"d1"})
+FinTupEmptyRcd         == IsFiniteSet([n1 : {}] \X {"d1"})
+FinTupEmptyTuple       == IsFiniteSet(({"d1"} \X {}) \X {"d1"})
+
+\* An infinite component beside or inside the empty one, in either position.
+FinTupEmptyNatSecond   == IsFiniteSet({} \X Nat)
+FinTupEmptyNatFirst    == IsFiniteSet(Nat \X {})
+FinTupDiffThenEmpty    == IsFiniteSet((Nat \ {0}) \X {})
+FinTupEmptyFcnSetNat   == IsFiniteSet([Nat -> {}] \X {"d1"})
+FinSingletonNatDomain  == IsFiniteSet([Nat -> {"d1"}])
+FinSingletonIntDomain  == IsFiniteSet([Int -> {"d1"}])
+FinSingletonStrDomain  == IsFiniteSet([STRING -> {"d1"}])
+FinSingletonDiffDomain == IsFiniteSet([(Nat \ {0}) -> {"d1"}])
+FinSingletonSeqDomain  == IsFiniteSet([Seq({"d1"}) -> {"d1"}])
+
+FinSingletonInterval   == IsFiniteSet([Nat -> 1..1])
+FinSingletonRcdRange   == IsFiniteSet([Nat -> [n1 : {"d1"}]])
+FinSingletonTupleRange == IsFiniteSet([Nat -> ({"d1"} \X {"d2"})])
+FinSingletonSubset     == IsFiniteSet([Nat -> SUBSET {}])
+FinSingletonFcnSet     == IsFiniteSet([Nat -> [{"d1"} -> {"d2"}]])
+FinSingletonNestedNat  == IsFiniteSet([Nat -> [Nat -> {"d1"}]])
+FinSingletonAsDomain   == IsFiniteSet([[Nat -> {"d1"}] -> {"d2", "d3"}])
+
+FinSeqEmpty            == IsFiniteSet(Seq({}))
+FinSeqEmptyInterval    == IsFiniteSet(Seq(1..0))
+FinSeqEmptyRcd         == IsFiniteSet(Seq([n1 : {}]))
+FinSeqEmptyTuple       == IsFiniteSet(Seq({"d1"} \X {}))
+FinSeqEmptyFcnSet      == IsFiniteSet(Seq([{"d1"} -> {}]))
+
+-----------------------------------------------------------------------------
 \* Sets that are neither empty nor {<<>>}, i.e. comparing the domains and the
 \* co-domains, the field sets, or the components is the only means left to
 \* decide these. They have no reduced form that TLC could compare them with.

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -262,6 +262,25 @@ TupNatIntDiffer == (Nat \X {"d1"}) # (Int \X {"d1"})
 TupStrReflexive == (STRING \X {"d1"}) = (STRING \X {"d1"})
 
 -----------------------------------------------------------------------------
+\* Sets built from a value whose emptiness TLA+ leaves open, i.e. congruence
+\* is the only means left to decide these. Every TLA+ value is a set, but
+\* TLA+ does not say what the elements of 1, "s", or <<1>> are, so neither
+\* 1 = {} nor 1 # {} is provable and no rule about an empty domain, field, or
+\* component applies. The three constructors are functions of their arguments
+\* all the same, which settles a comparison of a set with itself whatever the
+\* arguments contain.
+\*
+\* Only the reflexive form belongs here. [1 -> 2] # [1 -> 3] is out of reach
+\* for the same reason 1 # {} is, because both sets are { <<>> } when 1 = {}.
+
+FcnIntReflexive    == [1 -> 2] = [1 -> 2]
+FcnStrLitReflexive == [{"d1"} -> "s"] = [{"d1"} -> "s"]
+FcnTupleReflexive  == [<<1>> -> {"d1"}] = [<<1>> -> {"d1"}]
+
+RcdIntReflexive    == [n1 : 1, n2 : {"d1"}] = [n1 : 1, n2 : {"d1"}]
+TupIntReflexive    == (1 \X {"d1"}) = (1 \X {"d1"})
+
+-----------------------------------------------------------------------------
 \* The operators that have to agree with the comparisons above. TLC answers
 \* these for the sets it can enumerate and gives up for the rest, i.e. it
 \* stays silent instead of contradicting the comparisons.

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -227,11 +227,138 @@ RcdSetIsFcnSetRev        == [n1 : {"a"}]   = [{"n1"} -> {"a"}]
 TupleSetIsFcnSetRev      == ({"a", "b"} \X {"a", "b"}) = [1..2 -> {"a", "b"}]
 
 -----------------------------------------------------------------------------
-\* How many functions there are.
+\* The cardinality of each set above. TLC computes Cardinality(S) from the
+\* cardinalities of the arguments of the constructor of S, without
+\* enumerating S, so it has to agree with the comparisons above: 1 where a
+\* set of functions denotes { <<>> } and 0 where a set is empty. The Card
+\* prefix names a cardinality and the rest of a name its argument, following
+\* the sections above.
 
-CardUnitEmptyRange  == 1 = Cardinality([{} -> {}])
-CardUnitTripleRange == 1 = Cardinality([{} -> {"a", "b", "c"}])
-CardEmptyInterval   == 0 = Cardinality([1..2 -> {}])
+\* Sets of functions that denote { <<>> }, i.e. the empty domain decides.
+CardUnitEmptyRange     == 1 = Cardinality([{} -> {}])
+CardUnitTripleRange    == 1 = Cardinality([{} -> {"a", "b", "c"}])
+CardUnitInterval       == 1 = Cardinality([1..0 -> {"d1"}])
+CardUnitCap            == 1 = Cardinality([({"d1"} \cap {"d2"}) -> {"e1"}])
+CardUnitFilter         == 1 = Cardinality([{d \in {"d1"} : FALSE} -> {"e1"}])
+
+\* The empty domain is a set of records, a Cartesian product, or a set of
+\* functions. In CardUnitFcnSetRange the co-domain is empty too, and the
+\* empty domain still decides.
+CardUnitRcdField       == 1 = Cardinality([[n1 : {}] -> {"e1"}])
+CardUnitTuple          == 1 = Cardinality([({"d1"} \X {}) -> {"e1"}])
+CardUnitFcnSet         == 1 = Cardinality([[{"d1"} -> {}] -> {"e1"}])
+CardUnitFcnSetRange    == 1 = Cardinality([{} -> [{"d1"} -> {}]])
+
+\* Sets of functions that are empty, i.e. the empty co-domain decides.
+CardEmptySingleton     == 0 = Cardinality([{"r1"} -> {}])
+CardEmptyInterval      == 0 = Cardinality([1..2 -> {}])
+CardEmptySubsetEmpty   == 0 = Cardinality([(SUBSET {}) -> {}])
+CardEmptyRcdDomain     == 0 = Cardinality([[n1 : {"d1"}] -> {}])
+
+\* The empty co-domain is a set of records, a Cartesian product, or a set of
+\* functions.
+CardEmptyRcdRange      == 0 = Cardinality([{"d1"} -> [n1 : {}]])
+CardEmptyTupleRange    == 0 = Cardinality([{"d1"} -> ({"d1"} \X {})])
+CardEmptyFcnSetRange   == 0 = Cardinality([{"d1"} -> [{"e1"} -> {}]])
+
+\* Sets of records that are empty, i.e. a single empty field decides.
+CardRcdEmptyField      == 0 = Cardinality([n1 : {}])
+CardRcdEmptyArity      == 0 = Cardinality([n1 : {}, n2 : {"r1"}])
+CardRcdEmptyPosition   == 0 = Cardinality([n1 : {"r1"}, n2 : {}])
+CardRcdEmptyInterval   == 0 = Cardinality([n1 : 1..0, n2 : {"r1"}])
+CardRcdEmptyFcnSet     == 0 = Cardinality([n1 : [{"d1"} -> {}]])
+CardRcdEmptyRcd        == 0 = Cardinality([n1 : [n2 : {}]])
+CardRcdEmptyTuple      == 0 = Cardinality([n1 : ({"d1"} \X {})])
+
+\* Cartesian products that are empty, i.e. a single empty component decides.
+CardTupEmptyComponent  == 0 = Cardinality({} \X {"r1"})
+CardTupEmptyPosition   == 0 = Cardinality({"r1"} \X {})
+CardTupEmptyArity      == 0 = Cardinality({} \X {"r1"} \X {"r2"})
+CardTupEmptyInterval   == 0 = Cardinality((1..0) \X {"r1"})
+CardTupEmptyFcnSet     == 0 = Cardinality([{"d1"} -> {}] \X {"d1"})
+CardTupEmptyRcd        == 0 = Cardinality([n1 : {}] \X {"d1"})
+CardTupEmptyTuple      == 0 = Cardinality(({"d1"} \X {}) \X {"d1"})
+
+\* An empty field set or component behind constituents whose cardinalities
+\* multiply beyond 2147483647, the largest integer TLC represents: 1..50000
+\* twice gives 2500000000. The set is empty either way, i.e. the position of
+\* the empty constituent does not decide the cardinality.
+CardRcdLargeThenEmpty ==
+    0 = Cardinality([n1 : 1..50000, n2 : 1..50000, n3 : {}])
+CardRcdEmptyThenLarge ==
+    0 = Cardinality([n1 : {}, n2 : 1..50000, n3 : 1..50000])
+CardTupLargeThenEmpty ==
+    0 = Cardinality((1..50000) \X (1..50000) \X {})
+CardTupEmptyThenLarge ==
+    0 = Cardinality({} \X (1..50000) \X (1..50000))
+
+\* The same product as the domain of a set of functions, which therefore
+\* denotes { <<>> }.
+CardUnitTupleLarge ==
+    1 = Cardinality([((1..50000) \X (1..50000) \X {}) -> {"e1"}])
+
+\* An empty field set or component before one whose cardinality TLC cannot
+\* compute, so TLC stops at the empty one. RcdEmptyFieldNatSym and
+\* TupEmptyNatSecondSym are the comparisons that this order decides, and the
+\* reverse order is refused in both, i.e. a cardinality turns on the position
+\* of the empty constituent as a comparison does.
+CardRcdEmptyFieldNat   == 0 = Cardinality([n1 : {}, n2 : Nat])
+CardRcdEmptyThenDiff   == 0 = Cardinality([n1 : {}, n2 : (Nat \ {0})])
+CardTupEmptyNatSecond  == 0 = Cardinality({} \X Nat)
+
+\* The cardinalities that TLC refuses, i.e. the AssertError assumptions of
+\* EmptySetEqAssume.tla. TLC reads the constituents in order and stops at the
+\* first empty one, so a non-computable constituent costs TLC the cardinality
+\* only where it comes first. These are the reverses of the three
+\* above, and the second constituent being empty makes each a TLA+ fact all
+\* the same, hence the proofs.
+CardRcdEmptyNatField   == 0 = Cardinality([n1 : Nat, n2 : {}])
+CardRcdDiffThenEmpty   == 0 = Cardinality([n1 : (Nat \ {0}), n2 : {}])
+CardTupEmptyNatFirst   == 0 = Cardinality(Nat \X {})
+
+\* A field set or component that is an empty set of functions, whose own
+\* cardinality TLC cannot compute in any position, for the reason the next
+\* group states.
+CardRcdEmptyFcnSetNat  == 0 = Cardinality([n1 : [Nat -> {}]])
+CardTupEmptyFcnSetNat  == 0 = Cardinality([Nat -> {}] \X {"d1"})
+
+\* Sets of functions, where TLC reads the cardinality of both the domain and
+\* the co-domain before either emptiness applies, so no order of the two
+\* decides.
+CardUnitNatRange       == 1 = Cardinality([{} -> Nat])
+CardEmptyNatDomain     == 0 = Cardinality([Nat -> {}])
+CardUnitFcnSetNat      == 1 = Cardinality([[Nat -> {}] -> {"d2"}])
+CardEmptyFcnSetNat     == 0 = Cardinality([{"d1"} -> [Nat -> {}]])
+CardUnitSubsetRange    == 1 = Cardinality([{} -> (SUBSET (1..40))])
+CardEmptySubsetDomain  == 0 = Cardinality([(SUBSET (1..40)) -> {}])
+CardUnitLargeRange     == 1 = Cardinality([{} -> ((1..50000) \X (1..50000))])
+CardEmptyLargeDomain   == 0 = Cardinality([((1..50000) \X (1..50000)) -> {}])
+
+CardSingletonNatDomain == 1 = Cardinality([Nat -> {"d1"}])
+CardSingletonSubset    == 1 = Cardinality([Nat -> SUBSET {}])
+CardSingletonAsDomain  == 2 = Cardinality([[Nat -> {"d1"}] -> {"d2", "d3"}])
+
+CardSingletonSubsetDomain ==
+    1 = Cardinality([(SUBSET (1..40)) -> {"d1"}])
+CardSingletonLargeDomain ==
+    1 = Cardinality([((1..50000) \X (1..50000)) -> {"d1"}])
+
+CardSingletonSeqEmptyDomain ==
+    1 = Cardinality([Seq({}) -> {"d1"}])
+CardSingletonUnionDomain ==
+    1 = Cardinality([(UNION {1..2000000, {"a"}}) -> {"d1"}])
+
+CardSubsetSingletonFcnSet ==
+    2 = Cardinality(SUBSET [(SUBSET (1..40)) -> {"d1"}])
+CardTupSingletonFcnSet ==
+    1 = Cardinality([(SUBSET (1..40)) -> {"d1"}]
+                      \X [(SUBSET (1..40)) -> {"d1"}])
+CardRcdSingletonFcnSet ==
+    1 = Cardinality([n1 : [(SUBSET (1..40)) -> {"d1"}]])
+CardSingletonSubsetAsDomain ==
+    2 = Cardinality([[(SUBSET (1..40)) -> {"d1"}] -> {"d2", "d3"}])
+CardSingletonSubsetAsRange ==
+    1 = Cardinality([{"a", "b"} -> [(SUBSET (1..40)) -> {"d1"}]])
 
 -----------------------------------------------------------------------------
 \* The finiteness of the same sets. Every one of them is { <<>> } or {}, so

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -478,13 +478,163 @@ RcdIntReflexive    == [n1 : 1, n2 : {"d1"}] = [n1 : 1, n2 : {"d1"}]
 TupIntReflexive    == (1 \X {"d1"}) = (1 \X {"d1"})
 
 -----------------------------------------------------------------------------
-\* The operators that have to agree with the comparisons above. TLC answers
-\* these for the sets it can enumerate and gives up for the rest, i.e. it
-\* stays silent instead of contradicting the comparisons.
-
+\* Sets of functions that denote {<<>>}, i.e. the empty domain decides.
+InUnitEmptyRange     == <<>> \in [{} -> {}]
 InUnitSingletonRange == <<>> \in [{} -> {"d1"}]
+InUnitTripleRange    == <<>> \in [{} -> {"a", "b", "c"}]
 InUnitNatRange       == <<>> \in [{} -> Nat]
-NotInEmpty           == <<>> \notin [{"r1"} -> {}]
+InUnitInterval       == <<>> \in [1..0 -> {"d1"}]
+InUnitIntervalNat    == <<>> \in [1..0 -> Nat]
+InUnitCap            == <<>> \in [({"d1"} \cap {"d2"}) -> {"e1"}]
+InUnitCup            == <<>> \in [({} \cup {}) -> {"e1"}]
+InUnitDiff           == <<>> \in [({"d1"} \ {"d1"}) -> {"e1"}]
+InUnitUnionEmpty     == <<>> \in [(UNION {}) -> {"e1"}]
+InUnitUnionOfEmpty   == <<>> \in [(UNION {{}}) -> {"e1"}]
+InUnitFilter         == <<>> \in [{d \in {"d1"} : FALSE} -> {"e1"}]
+
+\* The empty domain is a set of records, a Cartesian product, or a set of
+\* functions.
+InUnitRcdField       == <<>> \in [[n1 : {}] -> {"e1"}]
+InUnitRcdFieldNat    == <<>> \in [[n1 : {}, n2 : Nat] -> {"d1"}]
+InUnitRcdNatField    == <<>> \in [[n1 : Nat, n2 : {}] -> {"d1"}]
+InUnitTuple          == <<>> \in [({"d1"} \X {}) -> {"e1"}]
+InUnitTupleNatSecond == <<>> \in [({} \X Nat) -> {"d1"}]
+InUnitTupleNatFirst  == <<>> \in [(Nat \X {}) -> {"d1"}]
+InUnitTupleStrFirst  == <<>> \in [(STRING \X {}) -> {"d1"}]
+InUnitFcnSet         == <<>> \in [[{"d1"} -> {}] -> {"e1"}]
+InUnitFcnSetNat      == <<>> \in [[Nat -> {}] -> {"d2"}]
+InUnitFcnSetNested   == <<>> \in [[[Nat -> {"d1"}] -> {}] -> {"d2"}]
+
+\* The empty domain is a set of records or of tuples whose field or component
+\* is itself an empty set.
+InUnitRcdFcnSet      == <<>> \in [[n1 : [Nat -> {}]] -> {"d1"}]
+InUnitRcdRcd         == <<>> \in [[n1 : [n2 : {}]] -> {"d1"}]
+InUnitRcdTuple       == <<>> \in [[n1 : ({"d1"} \X {})] -> {"d1"}]
+InUnitTupleFcnSet    == <<>> \in [({"d1"} \X [Nat -> {}]) -> {"e1"}]
+InUnitTupleRcd       == <<>> \in [({"d1"} \X [n1 : {}]) -> {"e1"}]
+InUnitTupleTuple     == <<>> \in [({"d1"} \X ({"d2"} \X {})) -> {"e1"}]
+
+\* A value other than <<>>, i.e. a one-element tuple and a record, both of
+\* which are functions whose domain is not {}.
+NotInUnitTuple       == <<"d1">> \notin [{} -> {"d1"}]
+NotInUnitRcd         == [n1 |-> "d1"] \notin [{} -> {"d1"}]
+
+-----------------------------------------------------------------------------
+\* Sets of functions that are empty, i.e. the empty co-domain decides.
+
+NotInEmpty               == <<>> \notin [{"r1"} -> {}]
+NotInEmptyInterval       == <<"v", "v">> \notin [1..2 -> {}]
+NotInEmptySubsetEmpty    == <<>> \notin [(SUBSET {}) -> {}]
+NotInEmptySubsetNat      == <<>> \notin [(SUBSET Nat) -> {}]
+NotInEmptyNatDomain      == <<>> \notin [Nat -> {}]
+NotInEmptyIntDomain      == <<>> \notin [Int -> {}]
+NotInEmptySeqDomain      == <<>> \notin [Seq({"d1"}) -> {}]
+NotInEmptyStrDomain      == <<>> \notin [STRING -> {}]
+NotInEmptyDiffDomain     == <<>> \notin [(Nat \ {0}) -> {}]
+
+\* The domain is a set of records, a Cartesian product, or a set of
+\* functions.
+NotInEmptyRcdNatDomain   == <<>> \notin [[n1 : Nat] -> {}]
+NotInEmptyTupleNatDomain == <<>> \notin [(Nat \X {"d1"}) -> {}]
+NotInEmptyFcnSetDomain   == <<>> \notin [[Nat -> {"d1"}] -> {}]
+
+\* The value is a function on the domain of the set, i.e. the empty
+\* co-domain is all that decides these.
+NotInEmptyFcn ==
+    [d \in {"r1"} |-> "v"] \notin [{"r1"} -> {}]
+NotInEmptyRcdDomain ==
+    [d \in [n1 : {"d1"}] |-> "v"] \notin [[n1 : {"d1"}] -> {}]
+NotInEmptyRcdRange ==
+    [d \in {"d1"} |-> [n1 |-> "v"]] \notin [{"d1"} -> [n1 : {}]]
+NotInEmptyTupleRange ==
+    [d \in {"d1"} |-> <<"v", "w">>] \notin [{"d1"} -> ({"d1"} \X {})]
+NotInEmptyFcnSetRange ==
+    [d \in {"d1"} |-> <<>>] \notin [{"d1"} -> [{"e1"} -> {}]]
+
+-----------------------------------------------------------------------------
+\* Sets of records that are empty, i.e. a single empty field decides.
+
+NotInRcdEmptyField    == [n1 |-> "d1"] \notin [n1 : {}]
+NotInRcdEmptyArity    == [n1 |-> "d1", n2 |-> "r1"] \notin [n1 : {}, n2 : {"r1"}]
+NotInRcdEmptyPosition == [n1 |-> "r1", n2 |-> "d1"] \notin [n1 : {"r1"}, n2 : {}]
+NotInRcdEmptyInterval == [n1 |-> 1, n2 |-> "r1"] \notin [n1 : 1..0, n2 : {"r1"}]
+
+\* The field is a set of functions, of records, or of tuples that is itself
+\* empty.
+NotInRcdEmptyFcnSet   == [n1 |-> <<>>] \notin [n1 : [{"d1"} -> {}]]
+NotInRcdEmptyRcd      == [n1 |-> [n2 |-> "d1"]] \notin [n1 : [n2 : {}]]
+NotInRcdEmptyTuple    == [n1 |-> <<"d1", "d2">>] \notin [n1 : ({"d1"} \X {})]
+
+\* An infinite field beside the empty one, in either position, with a value
+\* that is in that field.
+NotInRcdEmptyFieldNat == [n1 |-> "d1", n2 |-> 0] \notin [n1 : {}, n2 : Nat]
+NotInRcdEmptyNatField == [n1 |-> 0, n2 |-> "d1"] \notin [n1 : Nat, n2 : {}]
+NotInRcdEmptyStrField == [n1 |-> "s", n2 |-> "d1"] \notin [n1 : STRING, n2 : {}]
+
+\* The same field with a value that is not in it.
+NotInRcdEmptyNatFieldStr ==
+    [n1 |-> "s", n2 |-> "d1"] \notin [n1 : Nat, n2 : {}]
+
+\* A field that is a set difference, in either position.
+NotInRcdEmptyThenDiff ==
+    [n1 |-> "d1", n2 |-> 1] \notin [n1 : {}, n2 : (Nat \ {0})]
+NotInRcdDiffThenEmpty ==
+    [n1 |-> 1, n2 |-> "d1"] \notin [n1 : (Nat \ {0}), n2 : {}]
+
+-----------------------------------------------------------------------------
+\* Cartesian products that are empty, i.e. a single empty component decides.
+
+NotInTupEmptyComponent == <<"d1", "r1">> \notin ({} \X {"r1"})
+NotInTupEmptyPosition  == <<"r1", "d1">> \notin ({"r1"} \X {})
+NotInTupEmptyArity     == <<"d1", "r1", "r2">> \notin ({} \X {"r1"} \X {"r2"})
+NotInTupEmptyInterval  == <<1, "r1">> \notin ((1..0) \X {"r1"})
+
+\* The component is a set of functions, of records, or of tuples that is
+\* itself empty.
+NotInTupEmptyFcnSet    == <<<<>>, "d1">> \notin ([{"d1"} -> {}] \X {"d1"})
+NotInTupEmptyRcd       == <<[n1 |-> "d1"], "d1">> \notin ([n1 : {}] \X {"d1"})
+NotInTupEmptyTuple     == <<<<>>, "d1">> \notin (({"d1"} \X {}) \X {"d1"})
+
+\* An infinite component beside the empty one, in either position, with a
+\* value that is in that component.
+NotInTupEmptyNatFirst  == <<0, "d1">> \notin (Nat \X {})
+NotInTupEmptyNatSecond == <<"d1", 0>> \notin ({} \X Nat)
+NotInTupEmptySeqFirst  == <<<<>>, "d1">> \notin (Seq({"d1"}) \X {})
+NotInTupEmptyStrFirst  == <<"s", "d1">> \notin (STRING \X {})
+
+\* The same component with a value that is not in it.
+NotInTupEmptyNatFirstStr == <<"s", "d1">> \notin (Nat \X {})
+
+\* A component that is a set difference, in either position.
+NotInTupDiffThenEmpty  == <<1, "d1">> \notin ((Nat \ {0}) \X {})
+NotInTupEmptyThenDiff  == <<"d1", 1>> \notin ({} \X (Nat \ {0}))
+
+-----------------------------------------------------------------------------
+\* Sets that are neither empty nor {<<>>}, i.e. the domains and the
+\* co-domains, the fields, or the components are the only means left to
+\* decide these. A record is a function on a set of strings and a tuple one
+\* on 1..n, so a domain decides which of the three sets a value is in.
+
+InRcdSetIsFcnSet    == [n1 |-> "a"] \in [{"n1"} -> {"a"}]
+InFcnSetIsRcdSet    == [x \in {"n1"} |-> "a"] \in [n1 : {"a"}]
+InTupleSetIsFcnSet  == <<"a", "b">> \in [1..2 -> {"a", "b"}]
+InFcnSetIsTupleSet  == [x \in 1..2 |-> "a"] \in ({"a"} \X {"a"})
+
+NotInFcnSetDomain   == [x \in {"n1", "n2"} |-> "a"] \notin [{"n1"} -> {"a"}]
+NotInRcdSetName     == [n2 |-> "a"] \notin [n1 : {"a"}]
+NotInRcdSetArity    == [n1 |-> "a", n2 |-> "b"] \notin [n1 : {"a"}]
+NotInTupleSetArity  == <<"a", "a", "a">> \notin ({"a"} \X {"a"})
+NotInTupleSetOffset == [x \in 2..3 |-> "a"] \notin ({"a"} \X {"a"})
+NotInRcdSetTuple    == <<"a", "a">> \notin [n1 : {"a"}]
+NotInTupleSetRcd    == [n1 |-> "a"] \notin ({"a"} \X {"a"})
+
+\* An infinite field, component, or co-domain.
+InRcdSetNat      == [n1 |-> 0] \in [n1 : Nat]
+InTupleSetNat    == <<0, "d1">> \in (Nat \X {"d1"})
+InFcnSetNatRange == [d \in {"d1"} |-> 0] \in [{"d1"} -> Nat]
+
+-----------------------------------------------------------------------------
+\* The same sets read through \subseteq, which has to agree as well.
 
 SubsetUnitRanges     == [{} -> {"d1"}] \subseteq [{} -> Nat]
 SubsetEmptyDomain    == [{"r1"} -> {}] \subseteq [Nat -> {}]

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -1,0 +1,710 @@
+----------------------- MODULE EmptySetEqCases_proofs -----------------------
+\* The proof of every comparison that EmptySetEqCases.tla defines and
+\* EmptySetEqAssume.tla assumes, from the rules of EmptySetEqTheorems.tla. A
+\* proof names the rules it instantiates, and supplies the witness or the
+\* nested emptiness that the rule asks for.
+\*
+\* TLC does not parse this module. Check it from tlatools/org.lamport.tlatools
+\* with:
+\*   tlapm -I test-model test-model/EmptySetEqCases_proofs.tla
+\*
+\* See https://github.com/tlaplus/tlaplus/issues/1407
+EXTENDS EmptySetEqCases, EmptySetEqTheorems
+
+\* The reduced forms that the comparisons below compare an input with, and
+\* the nested set that recurs in them.
+LEMMA RefUnit == [{} -> {"ref"}] = { <<>> }
+  BY ESE_UnitDomain
+
+LEMMA RefEmpty == [{"ref"} -> {}] = {}
+  <1>1. "ref" \in {"ref"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange
+
+LEMMA RefRcdEmpty == [ref : {}] = {}
+  <1>1. ASSUME NEW r \in [ref : {}]
+        PROVE  FALSE
+    <2>1. r.ref \in {}
+      OBVIOUS
+    <2>2. QED BY <2>1
+  <1>2. QED BY <1>1
+
+LEMMA RefTupEmpty == {"ref"} \X {} = {}
+  BY ESE_TupleSetEmpty
+
+LEMMA NatToEmpty == [Nat -> {}] = {}
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange
+
+-----------------------------------------------------------------------------
+\* Sets of functions that denote {<<>>}, i.e. the empty domain decides.
+
+THEOREM UnitEmptyRangeEnum
+  BY ESE_UnitDomain DEF UnitEmptyRangeEnum
+
+THEOREM UnitEmptyRangeSym
+  BY RefUnit, ESE_UnitDomain DEF UnitEmptyRangeSym
+
+THEOREM UnitSingletonRangeEnum
+  BY ESE_UnitDomain DEF UnitSingletonRangeEnum
+
+THEOREM UnitSingletonRangeSym
+  BY RefUnit, ESE_UnitDomain DEF UnitSingletonRangeSym
+
+THEOREM UnitTripleRangeEnum
+  BY ESE_UnitDomain DEF UnitTripleRangeEnum
+
+THEOREM UnitTripleRangeSym
+  BY RefUnit, ESE_UnitDomain DEF UnitTripleRangeSym
+
+THEOREM UnitNatRangeSym
+  BY RefUnit, ESE_UnitDomain DEF UnitNatRangeSym
+
+THEOREM UnitIntervalEnum
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitIntervalEnum
+
+THEOREM UnitIntervalSym
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitIntervalSym
+
+THEOREM UnitIntervalNatSym
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitIntervalNatSym
+
+THEOREM UnitCapEnum
+  <1>1. {"d1"} \cap {"d2"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitCapEnum
+
+THEOREM UnitCapSym
+  <1>1. {"d1"} \cap {"d2"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitCapSym
+
+THEOREM UnitCupEnum
+  <1>1. {} \cup {} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitCupEnum
+
+THEOREM UnitCupSym
+  <1>1. {} \cup {} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitCupSym
+
+THEOREM UnitDiffEnum
+  <1>1. {"d1"} \ {"d1"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitDiffEnum
+
+THEOREM UnitDiffSym
+  <1>1. {"d1"} \ {"d1"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitDiffSym
+
+THEOREM UnitUnionEmptyEnum
+  <1>1. UNION {} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitUnionEmptyEnum
+
+THEOREM UnitUnionEmptySym
+  <1>1. UNION {} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitUnionEmptySym
+
+THEOREM UnitUnionOfEmptyEnum
+  <1>1. UNION {{}} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitUnionOfEmptyEnum
+
+THEOREM UnitUnionOfEmptySym
+  <1>1. UNION {{}} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitUnionOfEmptySym
+
+THEOREM UnitFilterEnum
+  <1>1. {d \in {"d1"} : FALSE} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitFilterEnum
+
+THEOREM UnitFilterSym
+  <1>1. {d \in {"d1"} : FALSE} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitFilterSym
+
+\* The domain is a set of records.
+
+THEOREM UnitRcdFieldEnum
+  BY ESE_UnitDomainRcd1 DEF UnitRcdFieldEnum
+
+THEOREM UnitRcdFieldSym
+  BY RefUnit, ESE_UnitDomainRcd1 DEF UnitRcdFieldSym
+
+THEOREM UnitRcdNatFieldSym
+  BY RefUnit, ESE_UnitDomainRcd DEF UnitRcdNatFieldSym
+
+THEOREM UnitRcdFieldNatSym
+  BY RefUnit, ESE_UnitDomainRcd DEF UnitRcdFieldNatSym
+
+\* The domain is a Cartesian product.
+
+THEOREM UnitTupleEnum
+  BY ESE_UnitDomainTuple DEF UnitTupleEnum
+
+THEOREM UnitTupleSym
+  BY RefUnit, ESE_UnitDomainTuple DEF UnitTupleSym
+
+THEOREM UnitTupleNatFirstSym
+  BY RefUnit, ESE_UnitDomainTuple DEF UnitTupleNatFirstSym
+
+THEOREM UnitTupleNatSecondSym
+  BY RefUnit, ESE_UnitDomainTuple DEF UnitTupleNatSecondSym
+
+THEOREM UnitTupleStrFirstSym
+  BY RefUnit, ESE_UnitDomainTuple DEF UnitTupleStrFirstSym
+
+\* The domain is a set of functions that is itself empty.
+
+THEOREM UnitFcnSetSym
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainFcnSet DEF UnitFcnSetSym
+
+THEOREM UnitFcnSetNestedSym
+  <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainFcnSet DEF UnitFcnSetNestedSym
+
+\* The domain is a set of functions that denotes { <<>> }, i.e. the domains of
+\* the two sets are { <<>> } and {}, which ESE_DomainDecides tells apart.
+
+THEOREM UnitDiffNestedUnitEnum
+  <1>1. [{} -> {}] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. "d2" \in {"d2"}
+    OBVIOUS
+  <1>3. { <<>> } # {}
+    OBVIOUS
+  <1>4. [{ <<>> } -> {"d2"}] # [{} -> {"d2"}]
+    BY <1>2, <1>3, ESE_DomainDecides
+  <1>5. QED BY <1>1, <1>4, ESE_UnitDomain DEF UnitDiffNestedUnitEnum
+
+THEOREM UnitDiffNestedUnitSym
+  <1>1. [{} -> {}] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. "d2" \in {"d2"}
+    OBVIOUS
+  <1>3. { <<>> } # {}
+    OBVIOUS
+  <1>4. [{ <<>> } -> {"d2"}] # [{} -> {"d2"}]
+    BY <1>2, <1>3, ESE_DomainDecides
+  <1>5. QED BY <1>1, <1>4, RefUnit, ESE_UnitDomain DEF UnitDiffNestedUnitSym
+
+\* The domain is a set of records or of tuples whose field or component is
+\* itself an empty set.
+
+THEOREM UnitRcdFcnSetSym
+  BY NatToEmpty, RefUnit, ESE_UnitDomainRcd1 DEF UnitRcdFcnSetSym
+
+THEOREM UnitRcdRcdSym
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainRcd1 DEF UnitRcdRcdSym
+
+THEOREM UnitRcdTupleSym
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainRcd1 DEF UnitRcdTupleSym
+
+THEOREM UnitTupleFcnSetSym
+  BY NatToEmpty, RefUnit, ESE_UnitDomainTuple DEF UnitTupleFcnSetSym
+
+THEOREM UnitTupleRcdSym
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainTuple DEF UnitTupleRcdSym
+
+THEOREM UnitTupleTupleSym
+  <1>1. {"d2"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainTuple DEF UnitTupleTupleSym
+
+-----------------------------------------------------------------------------
+\* Sets of functions that are empty, i.e. the empty co-domain decides.
+
+THEOREM EmptySingletonEnum
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptySingletonEnum
+
+THEOREM EmptySingletonSym
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptySingletonSym
+
+THEOREM EmptyIntervalEnum
+  <1>1. 1 \in 1..2
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyIntervalEnum
+
+THEOREM EmptyIntervalSym
+  <1>1. 1 \in 1..2
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyIntervalSym
+
+THEOREM EmptyCapEnum
+  <1>1. "d1" \in {"d1"} \cap {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyCapEnum
+
+THEOREM EmptyCapSym
+  <1>1. "d1" \in {"d1"} \cap {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyCapSym
+
+THEOREM EmptyCupEnum
+  <1>1. "d1" \in {} \cup {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyCupEnum
+
+THEOREM EmptyCupSym
+  <1>1. "d1" \in {} \cup {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyCupSym
+
+THEOREM EmptyDiffEnum
+  <1>1. "d1" \in {"d1"} \ {"d2"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyDiffEnum
+
+THEOREM EmptyDiffSym
+  <1>1. "d1" \in {"d1"} \ {"d2"}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyDiffSym
+
+THEOREM EmptyUnionEnum
+  <1>1. "d1" \in UNION {{"d1"}}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyUnionEnum
+
+THEOREM EmptyUnionSym
+  <1>1. "d1" \in UNION {{"d1"}}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyUnionSym
+
+THEOREM EmptyFilterEnum
+  <1>1. "d1" \in {d \in {"d1"} : TRUE}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyFilterEnum
+
+THEOREM EmptyFilterSym
+  <1>1. "d1" \in {d \in {"d1"} : TRUE}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyFilterSym
+
+\* SUBSET S contains {} for every S, i.e. it is never empty.
+
+THEOREM EmptySubsetEmptyEnum
+  <1>1. {} \in SUBSET {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptySubsetEmptyEnum
+
+THEOREM EmptySubsetEmptySym
+  <1>1. {} \in SUBSET {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptySubsetEmptySym
+
+THEOREM EmptySubsetNatSym
+  <1>1. {} \in SUBSET Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptySubsetNatSym
+
+THEOREM EmptyRcdEnum
+  <1>1. [n1 |-> "d1"] \in [n1 : {"d1"}]
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyRcdEnum
+
+THEOREM EmptyRcdSym
+  <1>1. [n1 |-> "d1"] \in [n1 : {"d1"}]
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyRcdSym
+
+THEOREM EmptyRcdNatSym
+  <1>1. [n1 |-> 0] \in [n1 : Nat]
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyRcdNatSym
+
+THEOREM EmptyTupleEnum
+  <1>1. <<"d1", "d1">> \in {"d1"} \X {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyTupleEnum
+
+THEOREM EmptyTupleSym
+  <1>1. <<"d1", "d1">> \in {"d1"} \X {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyTupleSym
+
+THEOREM EmptyTupleNatSym
+  <1>1. <<0, "d1">> \in Nat \X {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyTupleNatSym
+
+THEOREM EmptyNatSym
+  BY NatToEmpty, RefEmpty DEF EmptyNatSym
+
+THEOREM EmptyIntSym
+  <1>1. 0 \in Int
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyIntSym
+
+THEOREM EmptySeqSym
+  <1>1. <<>> \in Seq({"d1"})
+    <2>1. <<>> \in [1..0 -> {"d1"}]
+      OBVIOUS
+    <2>2. QED BY <2>1
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptySeqSym
+
+THEOREM EmptyStrSym
+  <1>1. "" \in STRING
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyStrSym
+
+\* The co-domain is empty, instead of the domain.
+
+THEOREM EmptyRcdRangeSym
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [n1 : Nat, n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>3. QED BY <1>1, <1>2, RefEmpty, ESE_EmptyRange DEF EmptyRcdRangeSym
+
+THEOREM EmptyTupleRangeSym
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. Nat \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>3. QED BY <1>1, <1>2, RefEmpty, ESE_EmptyRange DEF EmptyTupleRangeSym
+
+THEOREM EmptyRcdFcnSetRangeSym
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [n1 : [Nat -> {}]] = {}
+    BY NatToEmpty, ESE_RcdSetEmpty1
+  <1>3. QED BY <1>1, <1>2, RefEmpty, ESE_EmptyRange DEF EmptyRcdFcnSetRangeSym
+
+THEOREM EmptyTupleFcnSetRangeSym
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. {"d1"} \X [Nat -> {}] = {}
+    BY NatToEmpty, ESE_TupleSetEmpty
+  <1>3. QED BY <1>1, <1>2, RefEmpty, ESE_EmptyRange
+        DEF EmptyTupleFcnSetRangeSym
+
+THEOREM EmptyFcnSetRangeSym
+  <1>1. "y" \in {"y"}
+    OBVIOUS
+  <1>2. "x1" \in {"x1"}
+    OBVIOUS
+  <1>3. [{"y"} -> [Nat -> {}]] = {}
+    BY <1>1, NatToEmpty, ESE_EmptyRange
+  <1>4. QED BY <1>2, <1>3, RefEmpty, ESE_EmptyRange DEF EmptyFcnSetRangeSym
+
+\* The domain is a set of functions that is non-empty.
+
+THEOREM EmptyFcnSetSym
+  <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
+    OBVIOUS
+  <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyFcnSetSym
+
+-----------------------------------------------------------------------------
+\* Sets of records that are empty, i.e. a single empty field decides.
+
+THEOREM RcdEmptyFieldEnum
+  BY ESE_RcdSetEmpty1 DEF RcdEmptyFieldEnum
+
+THEOREM RcdEmptyFieldSym
+  BY RefRcdEmpty, ESE_RcdSetEmpty1 DEF RcdEmptyFieldSym
+
+THEOREM RcdEmptyNameSym
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefRcdEmpty DEF RcdEmptyNameSym
+
+THEOREM RcdEmptyArityEnum
+  BY ESE_RcdSetEmpty DEF RcdEmptyArityEnum
+
+THEOREM RcdEmptyAritySym
+  BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyAritySym
+
+THEOREM RcdEmptyIntervalEnum
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetEmpty DEF RcdEmptyIntervalEnum
+
+THEOREM RcdEmptyIntervalSym
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyIntervalSym
+
+THEOREM RcdEmptyNatFieldSym
+  BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyNatFieldSym
+
+THEOREM RcdEmptyFieldNatSym
+  BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyFieldNatSym
+
+THEOREM RcdEmptySeqFieldSym
+  BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptySeqFieldSym
+
+THEOREM RcdEmptyStrFieldSym
+  BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyStrFieldSym
+
+\* The field is a set of functions, of records, or of tuples that is itself
+\* empty.
+
+THEOREM RcdEmptyFcnSetSym
+  BY NatToEmpty, RefRcdEmpty, ESE_RcdSetEmpty1 DEF RcdEmptyFcnSetSym
+
+THEOREM RcdEmptyRcdSym
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefRcdEmpty, ESE_RcdSetEmpty1 DEF RcdEmptyRcdSym
+
+THEOREM RcdEmptyTupleSym
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, RefRcdEmpty, ESE_RcdSetEmpty1 DEF RcdEmptyTupleSym
+
+THEOREM RcdEmptyThenDiffSym
+  BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyThenDiffSym
+
+-----------------------------------------------------------------------------
+\* Cartesian products that are empty, i.e. a single empty component decides.
+
+THEOREM TupEmptyComponentEnum
+  BY ESE_TupleSetEmpty DEF TupEmptyComponentEnum
+
+THEOREM TupEmptyComponentSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyComponentSym
+
+THEOREM TupEmptyPositionSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyPositionSym
+
+THEOREM TupEmptyArityEnum
+  BY ESE_TupleSetEmpty3 DEF TupEmptyArityEnum
+
+THEOREM TupEmptyAritySym
+  BY RefTupEmpty, ESE_TupleSetEmpty3 DEF TupEmptyAritySym
+
+THEOREM TupEmptyIntervalEnum
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleSetEmpty DEF TupEmptyIntervalEnum
+
+THEOREM TupEmptyIntervalSym
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyIntervalSym
+
+THEOREM TupEmptyNatFirstSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyNatFirstSym
+
+THEOREM TupEmptyNatSecondSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyNatSecondSym
+
+THEOREM TupEmptySeqFirstSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptySeqFirstSym
+
+THEOREM TupEmptyStrFirstSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyStrFirstSym
+
+\* The component is a set of functions, of records, or of tuples that is
+\* itself empty.
+
+THEOREM TupEmptyFcnSetSym
+  BY NatToEmpty, RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyFcnSetSym
+
+THEOREM TupEmptyRcdSym
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyRcdSym
+
+THEOREM TupEmptyTupleSym
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyTupleSym
+
+THEOREM TupEmptyThenDiffSym
+  BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyThenDiffSym
+
+-----------------------------------------------------------------------------
+\* Two sets of different constructors.
+
+THEOREM FcnSetEqRcdSetEmpty
+  BY RefEmpty, ESE_RcdSetEmpty1 DEF FcnSetEqRcdSetEmpty
+
+THEOREM FcnSetEqTupleSetEmpty
+  BY RefEmpty, ESE_TupleSetEmpty DEF FcnSetEqTupleSetEmpty
+
+THEOREM RcdSetEqTupleSetEmpty
+  BY RefRcdEmpty, ESE_TupleSetEmpty DEF RcdSetEqTupleSetEmpty
+
+THEOREM UnitDiffRcdSetEmpty
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. <<>> \in { <<>> }
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2, RefUnit DEF UnitDiffRcdSetEmpty
+
+THEOREM UnitDiffTupleSetEmpty
+  <1>1. {} \X {"r1"} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. <<>> \in { <<>> }
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2, RefUnit DEF UnitDiffTupleSetEmpty
+
+THEOREM RcdSetIsFcnSet
+  BY ESE_RcdSetIsFcnSet DEF RcdSetIsFcnSet
+
+THEOREM TupleSetIsFcnSet
+  BY ESE_TupleSetIsFcnSet DEF TupleSetIsFcnSet
+
+THEOREM TupleSetIsFcnSet3
+  BY ESE_TupleSetIsFcnSet3 DEF TupleSetIsFcnSet3
+
+-----------------------------------------------------------------------------
+\* The comparisons above with their operands swapped. Equality is symmetric,
+\* so each of these is its counterpart above and needs the same rules.
+
+THEOREM UnitEmptyRangeRev
+  BY ESE_UnitDomain DEF UnitEmptyRangeRev
+
+THEOREM UnitSingletonRangeRev
+  BY ESE_UnitDomain DEF UnitSingletonRangeRev
+
+THEOREM EmptySingletonRev
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptySingletonRev
+
+THEOREM RcdEmptyFieldRev
+  BY ESE_RcdSetEmpty1 DEF RcdEmptyFieldRev
+
+THEOREM RcdEmptyArityRev
+  BY ESE_RcdSetEmpty DEF RcdEmptyArityRev
+
+THEOREM TupEmptyComponentRev
+  BY ESE_TupleSetEmpty DEF TupEmptyComponentRev
+
+THEOREM TupEmptyArityRev
+  BY ESE_TupleSetEmpty3 DEF TupEmptyArityRev
+
+THEOREM RcdSetEqFcnSetEmptyRev
+  BY RefEmpty, ESE_RcdSetEmpty1 DEF RcdSetEqFcnSetEmptyRev
+
+THEOREM TupleSetEqFcnSetEmptyRev
+  BY RefEmpty, ESE_TupleSetEmpty DEF TupleSetEqFcnSetEmptyRev
+
+THEOREM TupleSetEqRcdSetEmptyRev
+  BY RefRcdEmpty, ESE_TupleSetEmpty DEF TupleSetEqRcdSetEmptyRev
+
+THEOREM RcdSetIsFcnSetRev
+  BY ESE_RcdSetIsFcnSet DEF RcdSetIsFcnSetRev
+
+THEOREM TupleSetIsFcnSetRev
+  BY ESE_TupleSetIsFcnSet DEF TupleSetIsFcnSetRev
+
+-----------------------------------------------------------------------------
+\* How many functions there are.
+
+THEOREM CardUnitEmptyRange
+  BY ESE_UnitCardinality DEF CardUnitEmptyRange
+
+THEOREM CardUnitTripleRange
+  BY ESE_UnitCardinality DEF CardUnitTripleRange
+
+THEOREM CardEmptyInterval
+  <1>1. 1 \in 1..2
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptyInterval
+
+-----------------------------------------------------------------------------
+\* Sets of functions that are neither empty nor {<<>>}, i.e. comparing the
+\* domains and the co-domains is the only means left to decide these.
+
+THEOREM DomainNatReflexive
+  BY DEF DomainNatReflexive
+
+THEOREM DomainNatIntDiffer
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_DomainDecides, ESE_NatIntDiffer
+        DEF DomainNatIntDiffer
+
+THEOREM DomainSubsetNatReflexive
+  BY DEF DomainSubsetNatReflexive
+
+THEOREM RangeNatReflexive
+  BY DEF RangeNatReflexive
+
+THEOREM RangeNatIntDiffer
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RangeDecides, ESE_NatIntDiffer DEF RangeNatIntDiffer
+
+THEOREM DomainFcnSetReflexive
+  BY DEF DomainFcnSetReflexive
+
+THEOREM RangeNestedUnitDomainDiffer
+  <1>1. <<>> \in [[Nat -> {}] -> {"d1"}]
+    BY NatToEmpty, ESE_UnitMember
+  <1>2. QED BY <1>1, ESE_RangeDecides DEF RangeNestedUnitDomainDiffer
+
+THEOREM RcdNatReflexive
+  BY DEF RcdNatReflexive
+
+THEOREM RcdNatIntDiffer
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdFieldDecides, ESE_NatIntDiffer DEF RcdNatIntDiffer
+
+THEOREM RcdStrReflexive
+  BY DEF RcdStrReflexive
+
+THEOREM TupNatReflexive
+  BY DEF TupNatReflexive
+
+THEOREM TupNatIntDiffer
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleComponentDecides, ESE_NatIntDiffer
+        DEF TupNatIntDiffer
+
+THEOREM TupStrReflexive
+  BY DEF TupStrReflexive
+
+-----------------------------------------------------------------------------
+\* The operators that have to agree with the comparisons above.
+
+THEOREM InUnitSingletonRange
+  BY ESE_UnitMember DEF InUnitSingletonRange
+
+THEOREM InUnitNatRange
+  BY ESE_UnitMember DEF InUnitNatRange
+
+THEOREM NotInEmpty
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyNonMember DEF NotInEmpty
+
+THEOREM SubsetUnitRanges
+  BY ESE_UnitSubset DEF SubsetUnitRanges
+
+THEOREM SubsetEmptyDomain
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptySubset DEF SubsetEmptyDomain
+=============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -687,6 +687,26 @@ THEOREM TupStrReflexive
   BY DEF TupStrReflexive
 
 -----------------------------------------------------------------------------
+\* Sets built from a value whose emptiness TLA+ leaves open, where the
+\* congruence rules are all that is left. No witness w \in 1 exists to
+\* instantiate a rule about a non-empty domain, field, or component with.
+
+THEOREM FcnIntReflexive
+  BY ESE_FcnSetCongruence DEF FcnIntReflexive
+
+THEOREM FcnStrLitReflexive
+  BY ESE_FcnSetCongruence DEF FcnStrLitReflexive
+
+THEOREM FcnTupleReflexive
+  BY ESE_FcnSetCongruence DEF FcnTupleReflexive
+
+THEOREM RcdIntReflexive
+  BY ESE_RcdSetCongruence DEF RcdIntReflexive
+
+THEOREM TupIntReflexive
+  BY ESE_TupleSetCongruence DEF TupIntReflexive
+
+-----------------------------------------------------------------------------
 \* The operators that have to agree with the comparisons above.
 
 THEOREM InUnitSingletonRange

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -819,12 +819,6 @@ THEOREM CardRcdEmptyThenDiff
 THEOREM CardTupEmptyNatSecond
   BY ESE_TupleSetEmptyCardinality DEF CardTupEmptyNatSecond
 
-\* The cardinalities that TLC refuses. Each is a TLA+ fact, i.e. these proofs
-\* are what makes the AssertError assumptions of EmptySetEqAssume.tla record
-\* a limitation instead of an acceptable refusal. The first three are the
-\* three proofs above with the constituents swapped, i.e. TLC's order, and no
-\* rule of TLA+, separates the two groups.
-
 THEOREM CardRcdEmptyNatField
   BY ESE_RcdSetEmptyCardinality DEF CardRcdEmptyNatField
 

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -632,6 +632,268 @@ THEOREM CardEmptyInterval
   <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptyInterval
 
 -----------------------------------------------------------------------------
+\* The finiteness of the same sets. A finiteness rule needs one empty
+\* argument and no witness, so these proofs supply only an emptiness.
+
+\* Sets of functions that denote { <<>> }.
+
+THEOREM FinUnitEmptyRange
+  BY ESE_UnitFinite DEF FinUnitEmptyRange
+
+THEOREM FinUnitInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitFinite DEF FinUnitInterval
+
+THEOREM FinUnitRcdField
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_UnitFinite DEF FinUnitRcdField
+
+THEOREM FinUnitTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitFinite DEF FinUnitTuple
+
+THEOREM FinUnitFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_UnitFinite DEF FinUnitFcnSet
+
+THEOREM FinUnitFcnSetRange
+  BY ESE_UnitFinite DEF FinUnitFcnSetRange
+
+\* An infinite co-domain beside or inside the empty domain.
+
+THEOREM FinUnitNatRange
+  BY ESE_UnitFinite DEF FinUnitNatRange
+
+THEOREM FinUnitStrRange
+  BY ESE_UnitFinite DEF FinUnitStrRange
+
+THEOREM FinUnitFcnSetNat
+  BY NatToEmpty, ESE_UnitFinite DEF FinUnitFcnSetNat
+
+\* Sets of functions that are empty, where ESE_EmptyRangeFinite needs no
+\* witness in the domain.
+
+THEOREM FinEmptySingleton
+  BY ESE_EmptyRangeFinite DEF FinEmptySingleton
+
+THEOREM FinEmptyInterval
+  BY ESE_EmptyRangeFinite DEF FinEmptyInterval
+
+THEOREM FinEmptySubsetEmpty
+  BY ESE_EmptyRangeFinite DEF FinEmptySubsetEmpty
+
+THEOREM FinEmptyRcdRange
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_EmptyRangeFinite DEF FinEmptyRcdRange
+
+THEOREM FinEmptyTupleRange
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyRangeFinite DEF FinEmptyTupleRange
+
+THEOREM FinEmptyFcnSetRange
+  <1>1. "e1" \in {"e1"}
+    OBVIOUS
+  <1>2. [{"e1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyRangeFinite DEF FinEmptyFcnSetRange
+
+\* An infinite domain beside or inside the empty co-domain.
+
+THEOREM FinEmptyNatDomain
+  BY ESE_EmptyRangeFinite DEF FinEmptyNatDomain
+
+THEOREM FinEmptySeqDomain
+  BY ESE_EmptyRangeFinite DEF FinEmptySeqDomain
+
+THEOREM FinEmptyDiffDomain
+  BY ESE_EmptyRangeFinite DEF FinEmptyDiffDomain
+
+THEOREM FinEmptyFcnSetNat
+  BY NatToEmpty, ESE_EmptyRangeFinite DEF FinEmptyFcnSetNat
+
+\* Sets of records that are empty.
+
+THEOREM FinRcdEmptyField
+  BY ESE_RcdSetEmptyFinite1 DEF FinRcdEmptyField
+
+THEOREM FinRcdEmptyArity
+  BY ESE_RcdSetEmptyFinite DEF FinRcdEmptyArity
+
+THEOREM FinRcdEmptyPosition
+  BY ESE_RcdSetEmptyFinite DEF FinRcdEmptyPosition
+
+THEOREM FinRcdEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_RcdSetEmptyFinite1 DEF FinRcdEmptyFcnSet
+
+THEOREM FinRcdEmptyRcd
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetEmptyFinite1 DEF FinRcdEmptyRcd
+
+THEOREM FinRcdEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_RcdSetEmptyFinite1 DEF FinRcdEmptyTuple
+
+\* An infinite field beside or inside the empty one, in either position.
+
+THEOREM FinRcdEmptyFieldNat
+  BY ESE_RcdSetEmptyFinite DEF FinRcdEmptyFieldNat
+
+THEOREM FinRcdEmptyNatField
+  BY ESE_RcdSetEmptyFinite DEF FinRcdEmptyNatField
+
+THEOREM FinRcdEmptyThenDiff
+  BY ESE_RcdSetEmptyFinite DEF FinRcdEmptyThenDiff
+
+THEOREM FinRcdDiffThenEmpty
+  BY ESE_RcdSetEmptyFinite DEF FinRcdDiffThenEmpty
+
+THEOREM FinRcdEmptyFcnSetNat
+  BY NatToEmpty, ESE_RcdSetEmptyFinite1 DEF FinRcdEmptyFcnSetNat
+
+\* Cartesian products that are empty.
+
+THEOREM FinTupEmptyComponent
+  BY ESE_TupleSetEmptyFinite DEF FinTupEmptyComponent
+
+THEOREM FinTupEmptyPosition
+  BY ESE_TupleSetEmptyFinite DEF FinTupEmptyPosition
+
+THEOREM FinTupEmptyArity
+  BY ESE_TupleSetEmptyFinite3 DEF FinTupEmptyArity
+
+THEOREM FinTupEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_TupleSetEmptyFinite DEF FinTupEmptyFcnSet
+
+THEOREM FinTupEmptyRcd
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_TupleSetEmptyFinite DEF FinTupEmptyRcd
+
+THEOREM FinTupEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_TupleSetEmptyFinite DEF FinTupEmptyTuple
+
+\* An infinite component beside or inside the empty one, in either position.
+
+THEOREM FinTupEmptyNatSecond
+  BY ESE_TupleSetEmptyFinite DEF FinTupEmptyNatSecond
+
+THEOREM FinTupEmptyNatFirst
+  BY ESE_TupleSetEmptyFinite DEF FinTupEmptyNatFirst
+
+THEOREM FinTupDiffThenEmpty
+  BY ESE_TupleSetEmptyFinite DEF FinTupDiffThenEmpty
+
+THEOREM FinTupEmptyFcnSetNat
+  BY NatToEmpty, ESE_TupleSetEmptyFinite DEF FinTupEmptyFcnSetNat
+
+THEOREM FinSingletonNatDomain
+  BY ESE_SingletonRangeFinite DEF FinSingletonNatDomain
+
+THEOREM FinSingletonIntDomain
+  BY ESE_SingletonRangeFinite DEF FinSingletonIntDomain
+
+THEOREM FinSingletonStrDomain
+  BY ESE_SingletonRangeFinite DEF FinSingletonStrDomain
+
+THEOREM FinSingletonDiffDomain
+  BY ESE_SingletonRangeFinite DEF FinSingletonDiffDomain
+
+THEOREM FinSingletonSeqDomain
+  BY ESE_SingletonRangeFinite DEF FinSingletonSeqDomain
+
+THEOREM FinSingletonInterval
+  <1>1. 1..1 = {1}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_SingletonRangeFinite DEF FinSingletonInterval
+
+THEOREM FinSingletonRcdRange
+  <1>1. [n1 : {"d1"}] = { [n1 |-> "d1"] }
+    <2>1. ASSUME NEW r \in [n1 : {"d1"}]
+          PROVE  r = [n1 |-> "d1"]
+      OBVIOUS
+    <2>2. [n1 |-> "d1"] \in [n1 : {"d1"}]
+      OBVIOUS
+    <2>3. QED BY <2>1, <2>2
+  <1>2. QED BY <1>1, ESE_SingletonRangeFinite DEF FinSingletonRcdRange
+
+THEOREM FinSingletonTupleRange
+  <1>1. {"d1"} \X {"d2"} = { <<"d1", "d2">> }
+    <2>1. ASSUME NEW t \in ({"d1"} \X {"d2"})
+          PROVE  t = <<"d1", "d2">>
+      OBVIOUS
+    <2>2. <<"d1", "d2">> \in ({"d1"} \X {"d2"})
+      OBVIOUS
+    <2>3. QED BY <2>1, <2>2
+  <1>2. QED BY <1>1, ESE_SingletonRangeFinite DEF FinSingletonTupleRange
+
+THEOREM FinSingletonSubset
+  <1>1. SUBSET {} = {{}}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_SingletonRangeFinite DEF FinSingletonSubset
+
+THEOREM FinSingletonFcnSet
+  <1>1. [{"d1"} -> {"d2"}] = { [x \in {"d1"} |-> "d2"] }
+    BY ESE_SingletonRange
+  <1>2. QED BY <1>1, ESE_SingletonRangeFinite DEF FinSingletonFcnSet
+
+THEOREM FinSingletonNestedNat
+  <1>1. [Nat -> {"d1"}] = { [x \in Nat |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>2. QED BY <1>1, ESE_SingletonRangeFinite DEF FinSingletonNestedNat
+
+THEOREM FinSingletonAsDomain
+  <1>1. [Nat -> {"d1"}] = { [x \in Nat |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>2. IsFiniteSet({"d2", "d3"})
+    BY ESE_PairFinite
+  <1>3. QED BY <1>1, <1>2, ESE_SingletonDomainFinite DEF FinSingletonAsDomain
+
+THEOREM FinSeqEmpty
+  BY ESE_SeqEmptyFinite DEF FinSeqEmpty
+
+THEOREM FinSeqEmptyInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_SeqEmptyFinite DEF FinSeqEmptyInterval
+
+THEOREM FinSeqEmptyRcd
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_SeqEmptyFinite DEF FinSeqEmptyRcd
+
+THEOREM FinSeqEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_SeqEmptyFinite DEF FinSeqEmptyTuple
+
+THEOREM FinSeqEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_SeqEmptyFinite DEF FinSeqEmptyFcnSet
+
+-----------------------------------------------------------------------------
 \* Sets of functions that are neither empty nor {<<>>}, i.e. comparing the
 \* domains and the co-domains is the only means left to decide these.
 

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -1291,18 +1291,545 @@ THEOREM TupIntReflexive
   BY ESE_TupleSetCongruence DEF TupIntReflexive
 
 -----------------------------------------------------------------------------
-\* The operators that have to agree with the comparisons above.
+\* Sets of functions that denote { <<>> }.
+
+THEOREM InUnitEmptyRange
+  BY ESE_UnitMember DEF InUnitEmptyRange
 
 THEOREM InUnitSingletonRange
   BY ESE_UnitMember DEF InUnitSingletonRange
 
+THEOREM InUnitTripleRange
+  BY ESE_UnitMember DEF InUnitTripleRange
+
 THEOREM InUnitNatRange
   BY ESE_UnitMember DEF InUnitNatRange
+
+THEOREM InUnitInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitInterval
+
+THEOREM InUnitIntervalNat
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitIntervalNat
+
+THEOREM InUnitCap
+  <1>1. {"d1"} \cap {"d2"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitCap
+
+THEOREM InUnitCup
+  <1>1. {} \cup {} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitCup
+
+THEOREM InUnitDiff
+  <1>1. {"d1"} \ {"d1"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitDiff
+
+THEOREM InUnitUnionEmpty
+  <1>1. UNION {} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitUnionEmpty
+
+THEOREM InUnitUnionOfEmpty
+  <1>1. UNION {{}} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitUnionOfEmpty
+
+THEOREM InUnitFilter
+  <1>1. {d \in {"d1"} : FALSE} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitFilter
+
+\* The empty domain is a set of records, a Cartesian product, or a set of
+\* functions.
+
+THEOREM InUnitRcdField
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitRcdField
+
+THEOREM InUnitRcdFieldNat
+  <1>1. [n1 : {}, n2 : Nat] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitRcdFieldNat
+
+THEOREM InUnitRcdNatField
+  <1>1. [n1 : Nat, n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitRcdNatField
+
+THEOREM InUnitTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitTuple
+
+THEOREM InUnitTupleNatSecond
+  <1>1. {} \X Nat = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitTupleNatSecond
+
+THEOREM InUnitTupleNatFirst
+  <1>1. Nat \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitTupleNatFirst
+
+THEOREM InUnitTupleStrFirst
+  <1>1. STRING \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitTupleStrFirst
+
+THEOREM InUnitFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_UnitMember DEF InUnitFcnSet
+
+THEOREM InUnitFcnSetNat
+  BY NatToEmpty, ESE_UnitMember DEF InUnitFcnSetNat
+
+THEOREM InUnitFcnSetNested
+  <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
+    OBVIOUS
+  <1>2. [[Nat -> {"d1"}] -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_UnitMember DEF InUnitFcnSetNested
+
+\* The empty domain is a set of records or of tuples whose field or component
+\* is itself an empty set.
+
+THEOREM InUnitRcdFcnSet
+  <1>1. [n1 : [Nat -> {}]] = {}
+    BY NatToEmpty, ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitRcdFcnSet
+
+THEOREM InUnitRcdRcd
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. [n1 : [n2 : {}]] = {}
+    BY <1>1, ESE_RcdSetEmpty1
+  <1>3. QED BY <1>2, ESE_UnitMember DEF InUnitRcdRcd
+
+THEOREM InUnitRcdTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. [n1 : ({"d1"} \X {})] = {}
+    BY <1>1, ESE_RcdSetEmpty1
+  <1>3. QED BY <1>2, ESE_UnitMember DEF InUnitRcdTuple
+
+THEOREM InUnitTupleFcnSet
+  <1>1. {"d1"} \X [Nat -> {}] = {}
+    BY NatToEmpty, ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitMember DEF InUnitTupleFcnSet
+
+THEOREM InUnitTupleRcd
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. {"d1"} \X [n1 : {}] = {}
+    BY <1>1, ESE_TupleSetEmpty
+  <1>3. QED BY <1>2, ESE_UnitMember DEF InUnitTupleRcd
+
+THEOREM InUnitTupleTuple
+  <1>1. {"d2"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. {"d1"} \X ({"d2"} \X {}) = {}
+    BY <1>1, ESE_TupleSetEmpty
+  <1>3. QED BY <1>2, ESE_UnitMember DEF InUnitTupleTuple
+
+\* A value other than <<>>, i.e. a one-element tuple and a record.
+
+THEOREM NotInUnitTuple
+  <1>1. <<"d1">> # <<>>
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitNonMember DEF NotInUnitTuple
+
+THEOREM NotInUnitRcd
+  <1>1. [n1 |-> "d1"] # <<>>
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitNonMember DEF NotInUnitRcd
+
+-----------------------------------------------------------------------------
+\* Sets of functions that are empty.
 
 THEOREM NotInEmpty
   <1>1. "r1" \in {"r1"}
     OBVIOUS
   <1>2. QED BY <1>1, ESE_EmptyNonMember DEF NotInEmpty
+
+THEOREM NotInEmptyInterval
+  <1>1. 1 \in 1..2
+    OBVIOUS
+  <1>2. [1..2 -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyInterval
+
+THEOREM NotInEmptySubsetEmpty
+  <1>1. {} \in SUBSET {}
+    OBVIOUS
+  <1>2. [(SUBSET {}) -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptySubsetEmpty
+
+THEOREM NotInEmptySubsetNat
+  <1>1. {} \in SUBSET Nat
+    OBVIOUS
+  <1>2. [(SUBSET Nat) -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptySubsetNat
+
+THEOREM NotInEmptyNatDomain
+  BY NatToEmpty, ESE_EmptyNoMember DEF NotInEmptyNatDomain
+
+THEOREM NotInEmptyIntDomain
+  <1>1. 0 \in Int
+    OBVIOUS
+  <1>2. [Int -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyIntDomain
+
+THEOREM NotInEmptySeqDomain
+  <1>1. <<>> \in Seq({"d1"})
+    <2>1. <<>> \in [1..0 -> {"d1"}]
+      OBVIOUS
+    <2>2. QED BY <2>1
+  <1>2. [Seq({"d1"}) -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptySeqDomain
+
+THEOREM NotInEmptyStrDomain
+  <1>1. "" \in STRING
+    OBVIOUS
+  <1>2. [STRING -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyStrDomain
+
+THEOREM NotInEmptyDiffDomain
+  <1>1. 1 \in Nat \ {0}
+    OBVIOUS
+  <1>2. [(Nat \ {0}) -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyDiffDomain
+
+\* The domain is a set of records, a Cartesian product, or a set of
+\* functions.
+
+THEOREM NotInEmptyRcdNatDomain
+  <1>1. [n1 |-> 0] \in [n1 : Nat]
+    OBVIOUS
+  <1>2. [[n1 : Nat] -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyRcdNatDomain
+
+THEOREM NotInEmptyTupleNatDomain
+  <1>1. <<0, "d1">> \in Nat \X {"d1"}
+    OBVIOUS
+  <1>2. [(Nat \X {"d1"}) -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyTupleNatDomain
+
+THEOREM NotInEmptyFcnSetDomain
+  <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
+    OBVIOUS
+  <1>2. [[Nat -> {"d1"}] -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyFcnSetDomain
+
+\* The value is a function on the domain of the set.
+
+THEOREM NotInEmptyFcn
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. [{"r1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyFcn
+
+THEOREM NotInEmptyRcdDomain
+  <1>1. [n1 |-> "d1"] \in [n1 : {"d1"}]
+    OBVIOUS
+  <1>2. [[n1 : {"d1"}] -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInEmptyRcdDomain
+
+THEOREM NotInEmptyRcdRange
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>3. [{"d1"} -> [n1 : {}]] = {}
+    BY <1>1, <1>2, ESE_EmptyRange
+  <1>4. QED BY <1>3, ESE_EmptyNoMember DEF NotInEmptyRcdRange
+
+THEOREM NotInEmptyTupleRange
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>3. [{"d1"} -> ({"d1"} \X {})] = {}
+    BY <1>1, <1>2, ESE_EmptyRange
+  <1>4. QED BY <1>3, ESE_EmptyNoMember DEF NotInEmptyTupleRange
+
+THEOREM NotInEmptyFcnSetRange
+  <1>1. "e1" \in {"e1"}
+    OBVIOUS
+  <1>2. [{"e1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. "d1" \in {"d1"}
+    OBVIOUS
+  <1>4. [{"d1"} -> [{"e1"} -> {}]] = {}
+    BY <1>2, <1>3, ESE_EmptyRange
+  <1>5. QED BY <1>4, ESE_EmptyNoMember DEF NotInEmptyFcnSetRange
+
+-----------------------------------------------------------------------------
+\* Sets of records that are empty.
+
+THEOREM NotInRcdEmptyField
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyField
+
+THEOREM NotInRcdEmptyArity
+  <1>1. [n1 : {}, n2 : {"r1"}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyArity
+
+THEOREM NotInRcdEmptyPosition
+  <1>1. [n1 : {"r1"}, n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyPosition
+
+THEOREM NotInRcdEmptyInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. [n1 : 1..0, n2 : {"r1"}] = {}
+    BY <1>1, ESE_RcdSetEmpty
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInRcdEmptyInterval
+
+\* The field is a set of functions, of records, or of tuples that is itself
+\* empty.
+
+THEOREM NotInRcdEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. [n1 : [{"d1"} -> {}]] = {}
+    BY <1>2, ESE_RcdSetEmpty1
+  <1>4. QED BY <1>3, ESE_EmptyNoMember DEF NotInRcdEmptyFcnSet
+
+THEOREM NotInRcdEmptyRcd
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. [n1 : [n2 : {}]] = {}
+    BY <1>1, ESE_RcdSetEmpty1
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInRcdEmptyRcd
+
+THEOREM NotInRcdEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. [n1 : ({"d1"} \X {})] = {}
+    BY <1>1, ESE_RcdSetEmpty1
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInRcdEmptyTuple
+
+THEOREM NotInRcdEmptyFieldNat
+  <1>1. [n1 : {}, n2 : Nat] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyFieldNat
+
+THEOREM NotInRcdEmptyNatField
+  <1>1. [n1 : Nat, n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyNatField
+
+THEOREM NotInRcdEmptyStrField
+  <1>1. [n1 : STRING, n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyStrField
+
+THEOREM NotInRcdEmptyNatFieldStr
+  <1>1. [n1 : Nat, n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyNatFieldStr
+
+THEOREM NotInRcdEmptyThenDiff
+  <1>1. [n1 : {}, n2 : (Nat \ {0})] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdEmptyThenDiff
+
+THEOREM NotInRcdDiffThenEmpty
+  <1>1. [n1 : (Nat \ {0}), n2 : {}] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInRcdDiffThenEmpty
+
+-----------------------------------------------------------------------------
+\* Cartesian products that are empty.
+
+THEOREM NotInTupEmptyComponent
+  <1>1. {} \X {"r1"} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyComponent
+
+THEOREM NotInTupEmptyPosition
+  <1>1. {"r1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyPosition
+
+THEOREM NotInTupEmptyArity
+  <1>1. {} \X {"r1"} \X {"r2"} = {}
+    BY ESE_TupleSetEmpty3
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyArity
+
+THEOREM NotInTupEmptyInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. (1..0) \X {"r1"} = {}
+    BY <1>1, ESE_TupleSetEmpty
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInTupEmptyInterval
+
+\* The component is a set of functions, of records, or of tuples that is
+\* itself empty.
+
+THEOREM NotInTupEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. [{"d1"} -> {}] \X {"d1"} = {}
+    BY <1>2, ESE_TupleSetEmpty
+  <1>4. QED BY <1>3, ESE_EmptyNoMember DEF NotInTupEmptyFcnSet
+
+THEOREM NotInTupEmptyRcd
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. [n1 : {}] \X {"d1"} = {}
+    BY <1>1, ESE_TupleSetEmpty
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInTupEmptyRcd
+
+THEOREM NotInTupEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. ({"d1"} \X {}) \X {"d1"} = {}
+    BY <1>1, ESE_TupleSetEmpty
+  <1>3. QED BY <1>2, ESE_EmptyNoMember DEF NotInTupEmptyTuple
+
+THEOREM NotInTupEmptyNatFirst
+  <1>1. Nat \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyNatFirst
+
+THEOREM NotInTupEmptyNatSecond
+  <1>1. {} \X Nat = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyNatSecond
+
+THEOREM NotInTupEmptySeqFirst
+  <1>1. Seq({"d1"}) \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptySeqFirst
+
+THEOREM NotInTupEmptyStrFirst
+  <1>1. STRING \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyStrFirst
+
+THEOREM NotInTupEmptyNatFirstStr
+  <1>1. Nat \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyNatFirstStr
+
+THEOREM NotInTupDiffThenEmpty
+  <1>1. (Nat \ {0}) \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupDiffThenEmpty
+
+THEOREM NotInTupEmptyThenDiff
+  <1>1. {} \X (Nat \ {0}) = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_EmptyNoMember DEF NotInTupEmptyThenDiff
+
+-----------------------------------------------------------------------------
+
+THEOREM InRcdSetIsFcnSet
+  <1>1. [n1 : {"a"}] = [{"n1"} -> {"a"}]
+    BY ESE_RcdSetIsFcnSet
+  <1>2. [n1 |-> "a"] \in [n1 : {"a"}]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2 DEF InRcdSetIsFcnSet
+
+THEOREM InFcnSetIsRcdSet
+  <1>1. [n1 : {"a"}] = [{"n1"} -> {"a"}]
+    BY ESE_RcdSetIsFcnSet
+  <1>2. [x \in {"n1"} |-> "a"] \in [{"n1"} -> {"a"}]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2 DEF InFcnSetIsRcdSet
+
+THEOREM InTupleSetIsFcnSet
+  BY ESE_FcnSetMember DEF InTupleSetIsFcnSet
+
+THEOREM InFcnSetIsTupleSet
+  <1>1. {"a"} \X {"a"} = [1..2 -> {"a"}]
+    BY ESE_TupleSetIsFcnSet
+  <1>2. [x \in 1..2 |-> "a"] \in [1..2 -> {"a"}]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2 DEF InFcnSetIsTupleSet
+
+THEOREM NotInFcnSetDomain
+  <1>1. DOMAIN [x \in {"n1", "n2"} |-> "a"] # {"n1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_FcnSetMember DEF NotInFcnSetDomain
+
+THEOREM NotInRcdSetName
+  <1>1. DOMAIN [n2 |-> "a"] # {"n1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetMember1 DEF NotInRcdSetName
+
+THEOREM NotInRcdSetArity
+  <1>1. DOMAIN [n1 |-> "a", n2 |-> "b"] # {"n1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetMember1 DEF NotInRcdSetArity
+
+THEOREM NotInTupleSetArity
+  <1>1. DOMAIN <<"a", "a", "a">> # 1..2
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleSetMember DEF NotInTupleSetArity
+
+THEOREM NotInTupleSetOffset
+  <1>1. DOMAIN [x \in 2..3 |-> "a"] # 1..2
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleSetMember DEF NotInTupleSetOffset
+
+THEOREM NotInRcdSetTuple
+  <1>1. DOMAIN <<"a", "a">> = 1..2
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleDomainDiffRcdDomain, ESE_RcdSetMember1
+        DEF NotInRcdSetTuple
+
+THEOREM NotInTupleSetRcd
+  <1>1. DOMAIN [n1 |-> "a"] = {"n1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleDomainDiffRcdDomain, ESE_TupleSetMember
+        DEF NotInTupleSetRcd
+
+THEOREM InRcdSetNat
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetMember1 DEF InRcdSetNat
+
+THEOREM InTupleSetNat
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleSetMember DEF InTupleSetNat
+
+THEOREM InFcnSetNatRange
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_FcnSetMember DEF InFcnSetNatRange
+
+-----------------------------------------------------------------------------
 
 THEOREM SubsetUnitRanges
   BY ESE_UnitSubset DEF SubsetUnitRanges

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -618,7 +618,12 @@ THEOREM TupleSetIsFcnSetRev
   BY ESE_TupleSetIsFcnSet DEF TupleSetIsFcnSetRev
 
 -----------------------------------------------------------------------------
-\* How many functions there are.
+\* The cardinality of each set above. A cardinality of 1 instantiates the
+\* rule for an empty domain and a cardinality of 0 the rule for an empty
+\* co-domain, field set, or component, i.e. the rules and the witnesses of
+\* the comparisons above.
+
+\* Sets of functions that denote { <<>> }.
 
 THEOREM CardUnitEmptyRange
   BY ESE_UnitCardinality DEF CardUnitEmptyRange
@@ -626,10 +631,333 @@ THEOREM CardUnitEmptyRange
 THEOREM CardUnitTripleRange
   BY ESE_UnitCardinality DEF CardUnitTripleRange
 
+THEOREM CardUnitInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitCardinality DEF CardUnitInterval
+
+THEOREM CardUnitCap
+  <1>1. {"d1"} \cap {"d2"} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitCardinality DEF CardUnitCap
+
+THEOREM CardUnitFilter
+  <1>1. {d \in {"d1"} : FALSE} = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitCardinality DEF CardUnitFilter
+
+\* The empty domain is a set of records, a Cartesian product, or a set of
+\* functions. In CardUnitFcnSetRange the co-domain is empty too, and the
+\* empty domain still decides.
+
+THEOREM CardUnitRcdField
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_UnitCardinality DEF CardUnitRcdField
+
+THEOREM CardUnitTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitCardinality DEF CardUnitTuple
+
+THEOREM CardUnitFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_UnitCardinality DEF CardUnitFcnSet
+
+THEOREM CardUnitFcnSetRange
+  BY ESE_UnitCardinality DEF CardUnitFcnSetRange
+
+\* Sets of functions that are empty.
+
+THEOREM CardEmptySingleton
+  <1>1. "r1" \in {"r1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptySingleton
+
 THEOREM CardEmptyInterval
   <1>1. 1 \in 1..2
     OBVIOUS
   <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptyInterval
+
+THEOREM CardEmptySubsetEmpty
+  <1>1. {} \in SUBSET {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptySubsetEmpty
+
+THEOREM CardEmptyRcdDomain
+  <1>1. [n1 |-> "d1"] \in [n1 : {"d1"}]
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptyRcdDomain
+
+\* The empty co-domain is a set of records, a Cartesian product, or a set of
+\* functions.
+
+THEOREM CardEmptyRcdRange
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>3. QED BY <1>1, <1>2, ESE_EmptyCardinality DEF CardEmptyRcdRange
+
+THEOREM CardEmptyTupleRange
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>3. QED BY <1>1, <1>2, ESE_EmptyCardinality DEF CardEmptyTupleRange
+
+THEOREM CardEmptyFcnSetRange
+  <1>1. "e1" \in {"e1"}
+    OBVIOUS
+  <1>2. [{"e1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. "d1" \in {"d1"}
+    OBVIOUS
+  <1>4. QED BY <1>2, <1>3, ESE_EmptyCardinality DEF CardEmptyFcnSetRange
+
+\* Sets of records that are empty.
+
+THEOREM CardRcdEmptyField
+  BY ESE_RcdSetEmptyCardinality1 DEF CardRcdEmptyField
+
+THEOREM CardRcdEmptyArity
+  BY ESE_RcdSetEmptyCardinality DEF CardRcdEmptyArity
+
+THEOREM CardRcdEmptyPosition
+  BY ESE_RcdSetEmptyCardinality DEF CardRcdEmptyPosition
+
+THEOREM CardRcdEmptyInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetEmptyCardinality DEF CardRcdEmptyInterval
+
+THEOREM CardRcdEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_RcdSetEmptyCardinality1 DEF CardRcdEmptyFcnSet
+
+THEOREM CardRcdEmptyRcd
+  <1>1. [n2 : {}] = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_RcdSetEmptyCardinality1 DEF CardRcdEmptyRcd
+
+THEOREM CardRcdEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_RcdSetEmptyCardinality1 DEF CardRcdEmptyTuple
+
+\* Cartesian products that are empty.
+
+THEOREM CardTupEmptyComponent
+  BY ESE_TupleSetEmptyCardinality DEF CardTupEmptyComponent
+
+THEOREM CardTupEmptyPosition
+  BY ESE_TupleSetEmptyCardinality DEF CardTupEmptyPosition
+
+THEOREM CardTupEmptyArity
+  BY ESE_TupleSetEmptyCardinality3 DEF CardTupEmptyArity
+
+THEOREM CardTupEmptyInterval
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_TupleSetEmptyCardinality DEF CardTupEmptyInterval
+
+THEOREM CardTupEmptyFcnSet
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. [{"d1"} -> {}] = {}
+    BY <1>1, ESE_EmptyRange
+  <1>3. QED BY <1>2, ESE_TupleSetEmptyCardinality DEF CardTupEmptyFcnSet
+
+THEOREM CardTupEmptyRcd
+  <1>1. [n1 : {}] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_TupleSetEmptyCardinality DEF CardTupEmptyRcd
+
+THEOREM CardTupEmptyTuple
+  <1>1. {"d1"} \X {} = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_TupleSetEmptyCardinality DEF CardTupEmptyTuple
+
+\* An empty field set or component behind constituents whose cardinalities
+\* multiply beyond what TLC counts. No rule reads the cardinality of a
+\* constituent, i.e. these are the rules of the two groups above with
+\* 1..50000 in place of a singleton.
+
+THEOREM CardRcdLargeThenEmpty
+  BY ESE_RcdSetEmptyCardinality3 DEF CardRcdLargeThenEmpty
+
+THEOREM CardRcdEmptyThenLarge
+  BY ESE_RcdSetEmptyCardinality3 DEF CardRcdEmptyThenLarge
+
+THEOREM CardTupLargeThenEmpty
+  BY ESE_TupleSetEmptyCardinality3 DEF CardTupLargeThenEmpty
+
+THEOREM CardTupEmptyThenLarge
+  BY ESE_TupleSetEmptyCardinality3 DEF CardTupEmptyThenLarge
+
+THEOREM CardUnitTupleLarge
+  <1>1. (1..50000) \X (1..50000) \X {} = {}
+    BY ESE_TupleSetEmpty3
+  <1>2. QED BY <1>1, ESE_UnitCardinality DEF CardUnitTupleLarge
+
+\* An empty field set or component before one whose cardinality TLC cannot
+\* compute. The rules ask only for the emptiness of one constituent, i.e. the
+\* other never enters these proofs, in either position.
+
+THEOREM CardRcdEmptyFieldNat
+  BY ESE_RcdSetEmptyCardinality DEF CardRcdEmptyFieldNat
+
+THEOREM CardRcdEmptyThenDiff
+  BY ESE_RcdSetEmptyCardinality DEF CardRcdEmptyThenDiff
+
+THEOREM CardTupEmptyNatSecond
+  BY ESE_TupleSetEmptyCardinality DEF CardTupEmptyNatSecond
+
+\* The cardinalities that TLC refuses. Each is a TLA+ fact, i.e. these proofs
+\* are what makes the AssertError assumptions of EmptySetEqAssume.tla record
+\* a limitation instead of an acceptable refusal. The first three are the
+\* three proofs above with the constituents swapped, i.e. TLC's order, and no
+\* rule of TLA+, separates the two groups.
+
+THEOREM CardRcdEmptyNatField
+  BY ESE_RcdSetEmptyCardinality DEF CardRcdEmptyNatField
+
+THEOREM CardRcdDiffThenEmpty
+  BY ESE_RcdSetEmptyCardinality DEF CardRcdDiffThenEmpty
+
+THEOREM CardTupEmptyNatFirst
+  BY ESE_TupleSetEmptyCardinality DEF CardTupEmptyNatFirst
+
+THEOREM CardRcdEmptyFcnSetNat
+  BY NatToEmpty, ESE_RcdSetEmptyCardinality1 DEF CardRcdEmptyFcnSetNat
+
+THEOREM CardTupEmptyFcnSetNat
+  BY NatToEmpty, ESE_TupleSetEmptyCardinality DEF CardTupEmptyFcnSetNat
+
+THEOREM CardUnitNatRange
+  BY ESE_UnitCardinality DEF CardUnitNatRange
+
+THEOREM CardEmptyNatDomain
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptyNatDomain
+
+THEOREM CardUnitFcnSetNat
+  BY NatToEmpty, ESE_UnitCardinality DEF CardUnitFcnSetNat
+
+THEOREM CardEmptyFcnSetNat
+  <1>1. "d1" \in {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, NatToEmpty, ESE_EmptyCardinality DEF CardEmptyFcnSetNat
+
+THEOREM CardUnitSubsetRange
+  BY ESE_UnitCardinality DEF CardUnitSubsetRange
+
+THEOREM CardEmptySubsetDomain
+  <1>1. {} \in SUBSET (1..40)
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptySubsetDomain
+
+THEOREM CardSingletonNatDomain
+  BY ESE_SingletonRangeCardinality DEF CardSingletonNatDomain
+
+THEOREM CardSingletonSubset
+  <1>1. SUBSET {} = {{}}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_SingletonRangeCardinality DEF CardSingletonSubset
+
+THEOREM CardSingletonAsDomain
+  <1>1. [Nat -> {"d1"}] = { [x \in Nat |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>2. IsFiniteSet({"d2", "d3"}) /\ Cardinality({"d2", "d3"}) = 2
+    BY ESE_PairFinite
+  <1>3. QED BY <1>1, <1>2, ESE_SingletonDomainCardinality
+        DEF CardSingletonAsDomain
+
+THEOREM CardUnitLargeRange
+  BY ESE_UnitCardinality DEF CardUnitLargeRange
+
+THEOREM CardEmptyLargeDomain
+  <1>1. <<1, 1>> \in (1..50000) \X (1..50000)
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyCardinality DEF CardEmptyLargeDomain
+
+THEOREM CardSingletonSubsetDomain
+  BY ESE_SingletonRangeCardinality DEF CardSingletonSubsetDomain
+
+THEOREM CardSingletonLargeDomain
+  <1>1. ASSUME NEW S
+        PROVE  Cardinality([S -> {"d1"}]) = 1
+    BY ESE_SingletonRangeCardinality
+  <1>2. QED BY <1>1 DEF CardSingletonLargeDomain
+
+THEOREM CardSingletonSeqEmptyDomain
+  <1>1. ASSUME NEW S
+        PROVE  Cardinality([S -> {"d1"}]) = 1
+    BY ESE_SingletonRangeCardinality
+  <1>2. QED BY <1>1 DEF CardSingletonSeqEmptyDomain
+
+THEOREM CardSingletonUnionDomain
+  <1>1. ASSUME NEW S
+        PROVE  Cardinality([S -> {"d1"}]) = 1
+    BY ESE_SingletonRangeCardinality
+  <1>2. QED BY <1>1 DEF CardSingletonUnionDomain
+
+THEOREM CardSubsetSingletonFcnSet
+  <1>1. [(SUBSET (1..40)) -> {"d1"}] = { [x \in SUBSET (1..40) |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>2. ASSUME NEW a
+        PROVE  SUBSET {a} = { {}, {a} }
+    <2>1. ASSUME NEW s \in SUBSET {a}, s # {}
+          PROVE  s = {a}
+      <3>1. PICK y \in s : TRUE
+        BY <2>1
+      <3>2. y = a
+        BY <3>1
+      <3>3. QED BY <3>1, <3>2
+    <2>2. QED BY <2>1
+  <1>3. {} # { [x \in SUBSET (1..40) |-> "d1"] }
+    OBVIOUS
+  <1>4. QED BY <1>1, <1>2, <1>3, ESE_PairFinite
+        DEF CardSubsetSingletonFcnSet
+
+THEOREM CardTupSingletonFcnSet
+  <1>1. [(SUBSET (1..40)) -> {"d1"}] \X [(SUBSET (1..40)) -> {"d1"}]
+          = [1..2 -> [(SUBSET (1..40)) -> {"d1"}]]
+    BY ESE_TupleSetIsFcnSet
+  <1>2. [(SUBSET (1..40)) -> {"d1"}] = { [x \in SUBSET (1..40) |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>3. QED BY <1>1, <1>2, ESE_SingletonRangeCardinality
+        DEF CardTupSingletonFcnSet
+
+THEOREM CardRcdSingletonFcnSet
+  <1>1. [n1 : [(SUBSET (1..40)) -> {"d1"}]]
+          = [{"n1"} -> [(SUBSET (1..40)) -> {"d1"}]]
+    BY ESE_RcdSetIsFcnSet
+  <1>2. [(SUBSET (1..40)) -> {"d1"}] = { [x \in SUBSET (1..40) |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>3. QED BY <1>1, <1>2, ESE_SingletonRangeCardinality
+        DEF CardRcdSingletonFcnSet
+
+THEOREM CardSingletonSubsetAsDomain
+  <1>1. [(SUBSET (1..40)) -> {"d1"}] = { [x \in SUBSET (1..40) |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>2. IsFiniteSet({"d2", "d3"}) /\ Cardinality({"d2", "d3"}) = 2
+    BY ESE_PairFinite
+  <1>3. QED BY <1>1, <1>2, ESE_SingletonDomainCardinality
+        DEF CardSingletonSubsetAsDomain
+
+THEOREM CardSingletonSubsetAsRange
+  <1>1. [(SUBSET (1..40)) -> {"d1"}] = { [x \in SUBSET (1..40) |-> "d1"] }
+    BY ESE_SingletonRange
+  <1>2. QED BY <1>1, ESE_SingletonRangeCardinality
+        DEF CardSingletonSubsetAsRange
 
 -----------------------------------------------------------------------------
 \* The finiteness of the same sets. A finiteness rule needs one empty

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqStates.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqStates.cfg
@@ -1,0 +1,5 @@
+\* EmptySetEqStatesTest
+SPECIFICATION
+Spec
+INVARIANT
+Inv

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqStates.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqStates.tla
@@ -1,0 +1,211 @@
+------------------------- MODULE EmptySetEqStates --------------------------
+\* The assumptions of EmptySetEqAssume.tla have TLC compare the sets of
+\* EmptySetEqCases.tla, i.e. they reach Value#equals. A state reaches
+\* Value#fingerPrint, because TLC stores a state under the fingerprint of its
+\* variables. The two have to agree: equals decides from the emptiness of a
+\* domain, a co-domain, a field, or a component, fingerPrint by enumerating
+\* the set, and two equal sets that fingerprint differently leave TLC with
+\* two states where the behavior spec has one.
+\*
+\* Each set below is the right-hand side of a comparison in
+\* EmptySetEqCases.tla, named beside it and proved in
+\* EmptySetEqCases_proofs.tla. Only the enumerable ones are here, because a
+\* fingerprint is taken of the enumeration.
+\*
+\* Spec (EmptySetEqStates.cfg, EmptySetEqStatesTest) holds the sets whose
+\* elements are functions and tuples, RcdSpec (EmptySetEqStatesRcd.cfg,
+\* EmptySetEqStatesRcdTest) the one whose elements are records, because TLC
+\* refuses to compare a record with a tuple.
+\*
+\* See https://github.com/tlaplus/tlaplus/issues/1407
+EXTENDS FiniteSets, Integers, Sequences
+
+VARIABLE x
+
+-----------------------------------------------------------------------------
+\* What each group below denotes, written as TLC enumerates it.
+
+Unit  == { <<>> }
+Empty == { }
+Tup   == { <<"a", "a">>, <<"a", "b">>, <<"b", "a">>, <<"b", "b">> }
+Tup3  == { <<"a", "a", "a">> }
+Rcd   == { [n1 |-> "a"] }
+
+Reduced == { Unit, Empty, Tup, Tup3 }
+
+\* Unit and Empty written as a set of functions. Next and Extensionality
+\* compare x with these rather than with Unit or Empty, because two sets of
+\* functions is the comparison of issue #1407, whereas a set of functions and
+\* an explicit set only has TLC enumerate the former.
+UnitSym  == [{} -> {"ref"}]
+EmptySym == [{"ref"} -> {}]
+
+-----------------------------------------------------------------------------
+\* The sets, grouped by what they denote and given as tuples, because an
+\* explicit set drops the duplicates by normalizing before TLC fingerprints
+\* them.
+
+\* Sets of functions that denote { <<>> }, i.e. the empty domain decides.
+UnitForms ==
+  << [{} -> {}],                            \* UnitEmptyRangeEnum
+     [{} -> {"d1"}],                        \* UnitSingletonRangeEnum
+     [{} -> {"a", "b", "c"}],               \* UnitTripleRangeEnum
+     [1..0 -> {"d1"}],                      \* UnitIntervalEnum
+     [({"d1"} \cap {"d2"}) -> {"e1"}],      \* UnitCapEnum
+     [({} \cup {}) -> {"e1"}],              \* UnitCupEnum
+     [({"d1"} \ {"d1"}) -> {"e1"}],         \* UnitDiffEnum
+     [(UNION {}) -> {"e1"}],                \* UnitUnionEmptyEnum
+     [(UNION {{}}) -> {"e1"}],              \* UnitUnionOfEmptyEnum
+     [{d \in {"d1"} : FALSE} -> {"e1"}],    \* UnitFilterEnum
+     [[n1 : {}] -> {"e1"}],                 \* UnitRcdFieldEnum
+     [({"d1"} \X {}) -> {"e1"}] >>          \* UnitTupleEnum
+
+\* Sets that are empty, whether a co-domain, a field, or a component decides.
+EmptyForms ==
+  << [{"r1"} -> {}],                        \* EmptySingletonEnum
+     [1..2 -> {}],                          \* EmptyIntervalEnum
+     [({"d1"} \cap {"d1"}) -> {}],          \* EmptyCapEnum
+     [({} \cup {"d1"}) -> {}],              \* EmptyCupEnum
+     [({"d1"} \ {"d2"}) -> {}],             \* EmptyDiffEnum
+     [(UNION {{"d1"}}) -> {}],              \* EmptyUnionEnum
+     [{d \in {"d1"} : TRUE} -> {}],         \* EmptyFilterEnum
+     [(SUBSET {}) -> {}],                   \* EmptySubsetEmptyEnum
+     [[n1 : {"d1"}] -> {}],                 \* EmptyRcdEnum
+     [({"d1"} \X {"d1"}) -> {}],            \* EmptyTupleEnum
+     [n1 : {}],                             \* RcdEmptyFieldEnum
+     [n2 : {}],                             \* RcdEmptyNameSym
+     [n1 : {}, n2 : {"r1"}],                \* RcdEmptyArityEnum
+     [n1 : 1..0, n2 : {"r1"}],              \* RcdEmptyIntervalEnum
+     ({} \X {"r1"}),                        \* TupEmptyComponentEnum
+     ({"r1"} \X {}),                        \* TupEmptyPositionSym
+     ({} \X {"r1"} \X {"r2"}),              \* TupEmptyArityEnum
+     ((1..0) \X {"r1"}) >>                  \* TupEmptyIntervalEnum
+
+\* A tuple is a function on 1..n, i.e. both denote the same set.
+TupForms  == << [1..2 -> {"a", "b"}],
+                ({"a", "b"} \X {"a", "b"}) >>       \* TupleSetIsFcnSet
+Tup3Forms == << [1..3 -> {"a"}],
+                ({"a"} \X {"a"} \X {"a"}) >>        \* TupleSetIsFcnSet3
+
+\* A record is a function on a set of strings, likewise.
+RcdForms  == << [n1 : {"a"}],
+                [{"n1"} -> {"a"}] >>                \* RcdSetIsFcnSet
+
+Forms == UnitForms \o EmptyForms \o TupForms \o Tup3Forms
+
+-----------------------------------------------------------------------------
+\* Spec. Init has one initial state per set of Forms, so the distinct states
+\* are the groups above, counted by fingerprint. Next cycles through the
+\* groups, comparing x with what its group denotes, i.e. equality decides
+\* whether a sub-action is enabled and a wrong answer deadlocks.
+
+Init == \E i \in 1..Len(Forms) : x = Forms[i]
+
+Next == \/ /\ x = UnitSym  /\ x' = Empty
+        \/ /\ x = EmptySym /\ x' = Tup
+        \/ /\ x = Tup      /\ x' = Tup3
+        \/ /\ x = Tup3     /\ x' = Unit
+
+Spec == Init /\ [][Next]_<<x>>
+
+\* The same count through Value#compareTo: an explicit set drops its
+\* duplicates by normalizing where the state graph drops them by
+\* fingerprinting.
+FormsCollapse == Cardinality({ Forms[i] : i \in 1..Len(Forms) }) = Cardinality(Reduced)
+
+\* Every state is one reduced form and no state is two, i.e. equality
+\* separates the groups as well as it merges each.
+OneReducedForm == Cardinality({ r \in Reduced : x = r }) = 1
+
+\* Equality and \subseteq have to agree, although \subseteq enumerates the two
+\* sets (Enumerable#isSubsetEq, which no set of functions overrides) where
+\* equals decides from the emptiness of a domain or a co-domain.
+Extensionality ==
+  /\ (x \subseteq UnitSym  /\ UnitSym  \subseteq x) <=> (x = UnitSym)
+  /\ (x \subseteq EmptySym /\ EmptySym \subseteq x) <=> (x = EmptySym)
+
+Inv == FormsCollapse /\ OneReducedForm /\ Extensionality
+
+-----------------------------------------------------------------------------
+\* RcdSpec. A set of records and the set of functions that denotes it, in a
+\* behavior spec of their own: TLC refuses to compare a record with a tuple,
+\* which the invariant of Spec would. ESE_RcdSetDiffTupleSet of
+\* EmptySetEqTheorems.tla is such a comparison that TLA+ decides.
+
+RcdInit == \E i \in 1..Len(RcdForms) : x = RcdForms[i]
+
+RcdNext == UNCHANGED x
+
+RcdSpec == RcdInit /\ [][RcdNext]_<<x>>
+
+RcdInv == /\ Cardinality({ RcdForms[i] : i \in 1..Len(RcdForms) }) = 1
+          /\ x = Rcd
+
+-----------------------------------------------------------------------------
+\* What the two behavior specs expect TLC to agree with. Each comparison is
+\* proved in EmptySetEqCases_proofs.tla, leaving the number of groups and the
+\* rule behind Extensionality.
+
+THEOREM Extensional ==
+  ASSUME NEW S, NEW T
+  PROVE  (S \subseteq T /\ T \subseteq S) <=> (S = T)
+  OBVIOUS
+
+\* Spec has four states, not fewer.
+THEOREM ReducedDistinct ==
+  /\ Unit # Empty
+  /\ Unit # Tup
+  /\ Unit # Tup3
+  /\ Empty # Tup
+  /\ Empty # Tup3
+  /\ Tup # Tup3
+  <1>1. <<>> \in Unit /\ <<"a", "a">> \in Tup /\ <<"a", "a", "a">> \in Tup3
+    BY DEF Unit, Tup, Tup3
+  <1>2. <<>> \notin Tup /\ <<>> \notin Tup3
+    <2>1. DOMAIN <<>> = {}
+      OBVIOUS
+    <2>2. \A t \in Tup : 1 \in DOMAIN t
+      BY DEF Tup
+    <2>3. \A t \in Tup3 : 1 \in DOMAIN t
+      BY DEF Tup3
+    <2>4. QED BY <2>1, <2>2, <2>3
+  <1>3. <<"a", "a">> \notin Tup3
+    <2>1. DOMAIN <<"a", "a">> = 1..2 /\ \A t \in Tup3 : DOMAIN t = 1..3
+      BY DEF Tup3
+    <2>2. 3 \in 1..3 /\ 3 \notin 1..2
+      OBVIOUS
+    <2>3. QED BY <2>1, <2>2
+  <1>4. QED BY <1>1, <1>2, <1>3 DEF Empty
+
+\* The group of RcdSpec is none of the four, i.e. a behavior spec of its own
+\* rather than a fifth state.
+THEOREM RcdDistinct ==
+  /\ Rcd # Unit
+  /\ Rcd # Empty
+  /\ Rcd # Tup
+  /\ Rcd # Tup3
+  <1>1. [n1 |-> "a"] \in Rcd /\ "n1" \in DOMAIN [n1 |-> "a"]
+    BY DEF Rcd
+  <1>2. [n1 |-> "a"] \notin Unit
+    <2>1. DOMAIN <<>> = {}
+      OBVIOUS
+    <2>2. QED BY <1>1, <2>1 DEF Unit
+  \* Not because "n1" is no number, which TLA+ leaves open, but because a
+  \* record has one field where either tuple has two components or more.
+  <1>3. [n1 |-> "a"] \notin Tup /\ [n1 |-> "a"] \notin Tup3
+    <2>1. \A t \in Tup : DOMAIN t = 1..2
+      BY DEF Tup
+    <2>2. \A t \in Tup3 : DOMAIN t = 1..3
+      BY DEF Tup3
+    <2>3. DOMAIN [n1 |-> "a"] = {"n1"}
+      OBVIOUS
+    <2>4. ASSUME NEW S, {1, 2} \subseteq S, S = {"n1"}
+          PROVE  FALSE
+      <3>1. 1 = "n1" /\ 2 = "n1"
+        BY <2>4
+      <3>2. QED BY <3>1
+    <2>5. {1, 2} \subseteq 1..2 /\ {1, 2} \subseteq 1..3
+      OBVIOUS
+    <2>6. QED BY <2>1, <2>2, <2>3, <2>4, <2>5
+  <1>4. QED BY <1>1, <1>2, <1>3 DEF Empty
+=============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqStatesRcd.cfg
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqStatesRcd.cfg
@@ -1,0 +1,5 @@
+\* EmptySetEqStatesRcdTest
+SPECIFICATION
+RcdSpec
+INVARIANT
+RcdInv

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
@@ -17,7 +17,7 @@
 (*                                                                         *)
 (* See https://github.com/tlaplus/tlaplus/issues/1407                      *)
 (***************************************************************************)
-EXTENDS FiniteSets, Integers
+EXTENDS FiniteSets, Integers, Sequences
 
 (***************************************************************************)
 (* When each of the four set constructors that TLC represents without      *)
@@ -35,6 +35,10 @@ THEOREM ESE_RcdSetEmpty1 ==
 THEOREM ESE_RcdSetEmpty ==
   ASSUME NEW S, NEW T
   PROVE  [n1 : S, n2 : T] = {} <=> (S = {} \/ T = {})
+
+THEOREM ESE_RcdSetEmpty3 ==
+  ASSUME NEW S, NEW T, NEW U
+  PROVE  [n1 : S, n2 : T, n3 : U] = {} <=> (S = {} \/ T = {} \/ U = {})
 
 THEOREM ESE_TupleSetEmpty ==
   ASSUME NEW S, NEW T
@@ -188,6 +192,65 @@ THEOREM ESE_UnitCardinality ==
 THEOREM ESE_EmptyCardinality ==
   ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
   PROVE  Cardinality([S -> T]) = 0
+
+(***************************************************************************)
+(* The same sets read through IsFiniteSet. Each is { <<>> } or {}, so one  *)
+(* empty argument decides, and ESE_EmptyRangeFinite needs no witness in S: *)
+(* [S -> {}] is {} where S is non-empty and { <<>> } where it is not.      *)
+(***************************************************************************)
+
+THEOREM ESE_UnitFinite ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  IsFiniteSet([S -> T])
+
+THEOREM ESE_EmptyRangeFinite ==
+  ASSUME NEW S, NEW T, T = {}
+  PROVE  IsFiniteSet([S -> T])
+
+THEOREM ESE_RcdSetEmptyFinite1 ==
+  ASSUME NEW S, S = {}
+  PROVE  IsFiniteSet([n1 : S])
+
+THEOREM ESE_RcdSetEmptyFinite ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  IsFiniteSet([n1 : S, n2 : T])
+
+THEOREM ESE_RcdSetEmptyFinite3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  IsFiniteSet([n1 : S, n2 : T, n3 : U])
+
+THEOREM ESE_TupleSetEmptyFinite ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  IsFiniteSet(S \X T)
+
+THEOREM ESE_TupleSetEmptyFinite3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  IsFiniteSet(S \X T \X U)
+
+THEOREM ESE_SingletonRange ==
+  ASSUME NEW S, NEW T, NEW w, T = {w}
+  PROVE  [S -> T] = { [x \in S |-> w] }
+
+THEOREM ESE_SingletonRangeFinite ==
+  ASSUME NEW S, NEW T, NEW w, T = {w}
+  PROVE  IsFiniteSet([S -> T])
+
+THEOREM ESE_SingletonDomainFinite ==
+  ASSUME NEW S, NEW T, NEW w, S = {w}, IsFiniteSet(T)
+  PROVE  IsFiniteSet([S -> T])
+
+THEOREM ESE_PairFinite ==
+  ASSUME NEW a, NEW b, a # b
+  PROVE  /\ IsFiniteSet({a, b})
+         /\ Cardinality({a, b}) = 2
+
+THEOREM ESE_SeqEmpty ==
+  ASSUME NEW S, S = {}
+  PROVE  Seq(S) = { <<>> }
+
+THEOREM ESE_SeqEmptyFinite ==
+  ASSUME NEW S, S = {}
+  PROVE  IsFiniteSet(Seq(S))
 
 (***************************************************************************)
 (* The operators that have to agree with the equalities above.             *)

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
@@ -134,6 +134,27 @@ THEOREM ESE_TupleComponentDecides ==
 THEOREM ESE_NatIntDiffer == Nat # Int
 
 (***************************************************************************)
+(* Congruence, which decides a comparison that none of the rules above     *)
+(* reaches. Every TLA+ value is a set, but TLA+ does not say what the      *)
+(* elements of a value such as 1 are, so neither 1 = {} nor 1 # {} is      *)
+(* provable and no witness w \in 1 can be supplied. Each of the three      *)
+(* constructors is a function of its arguments all the same, so equal      *)
+(* arguments denote the same set whatever the arguments contain.           *)
+(***************************************************************************)
+
+THEOREM ESE_FcnSetCongruence ==
+  ASSUME NEW S, NEW T
+  PROVE  [S -> T] = [S -> T]
+
+THEOREM ESE_RcdSetCongruence ==
+  ASSUME NEW S, NEW T
+  PROVE  [n1 : S, n2 : T] = [n1 : S, n2 : T]
+
+THEOREM ESE_TupleSetCongruence ==
+  ASSUME NEW S, NEW T
+  PROVE  S \X T = S \X T
+
+(***************************************************************************)
 (* Where the two sets are of different constructors. A record is a         *)
 (* function on a set of strings and a tuple is a function on 1..n, so a    *)
 (* set of records and a Cartesian product are sets of functions as well,   *)

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
@@ -182,7 +182,9 @@ THEOREM ESE_RcdSetDiffTupleSet ==
   PROVE  [n1 : S] # S \X T
 
 (***************************************************************************)
-(* How many functions there are.                                           *)
+(* The cardinality of a set of functions that denotes {<<>>} and of an     *)
+(* empty set of each of the three constructors, i.e. the equalities above  *)
+(* read through Cardinality.                                               *)
 (***************************************************************************)
 
 THEOREM ESE_UnitCardinality ==
@@ -192,6 +194,26 @@ THEOREM ESE_UnitCardinality ==
 THEOREM ESE_EmptyCardinality ==
   ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
   PROVE  Cardinality([S -> T]) = 0
+
+THEOREM ESE_RcdSetEmptyCardinality1 ==
+  ASSUME NEW S, S = {}
+  PROVE  Cardinality([n1 : S]) = 0
+
+THEOREM ESE_RcdSetEmptyCardinality ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  Cardinality([n1 : S, n2 : T]) = 0
+
+THEOREM ESE_RcdSetEmptyCardinality3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  Cardinality([n1 : S, n2 : T, n3 : U]) = 0
+
+THEOREM ESE_TupleSetEmptyCardinality ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  Cardinality(S \X T) = 0
+
+THEOREM ESE_TupleSetEmptyCardinality3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  Cardinality(S \X T \X U) = 0
 
 (***************************************************************************)
 (* The same sets read through IsFiniteSet. Each is { <<>> } or {}, so one  *)
@@ -235,9 +257,17 @@ THEOREM ESE_SingletonRangeFinite ==
   ASSUME NEW S, NEW T, NEW w, T = {w}
   PROVE  IsFiniteSet([S -> T])
 
+THEOREM ESE_SingletonRangeCardinality ==
+  ASSUME NEW S, NEW T, NEW w, T = {w}
+  PROVE  Cardinality([S -> T]) = 1
+
 THEOREM ESE_SingletonDomainFinite ==
   ASSUME NEW S, NEW T, NEW w, S = {w}, IsFiniteSet(T)
   PROVE  IsFiniteSet([S -> T])
+
+THEOREM ESE_SingletonDomainCardinality ==
+  ASSUME NEW S, NEW T, NEW w, S = {w}, IsFiniteSet(T)
+  PROVE  Cardinality([S -> T]) = Cardinality(T)
 
 THEOREM ESE_PairFinite ==
   ASSUME NEW a, NEW b, a # b

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
@@ -1,0 +1,190 @@
+------------------------- MODULE EmptySetEqTheorems -------------------------
+(***************************************************************************)
+(* The TLA+ facts that TLC has to agree with when it compares two sets     *)
+(* that it represents without enumerating them, a set of functions, a set  *)
+(* of records, or a Cartesian product, one of which may be empty, and the  *)
+(* emptiness of the other kinds of set that such a comparison rests on.    *)
+(* This module only lists theorem statements for reference. The proofs can *)
+(* be found in module EmptySetEqTheorems_proofs.tla.                       *)
+(*                                                                         *)
+(* EmptySetEqCases_proofs.tla instantiates these statements to prove the   *)
+(* individual comparisons that EmptySetEqAssume.tla has TLC check.         *)
+(*                                                                         *)
+(* A witness w \in S stands in for S # {} wherever TLC cannot decide       *)
+(* S # {} itself, as it cannot for Nat, Int, and Seq(T). The field names   *)
+(* n1 and n2 are arbitrary, because the emptiness of a set of records does *)
+(* not depend on them, but TLA+ requires a record set to name its fields.  *)
+(*                                                                         *)
+(* See https://github.com/tlaplus/tlaplus/issues/1407                      *)
+(***************************************************************************)
+EXTENDS FiniteSets, Integers
+
+(***************************************************************************)
+(* When each of the four set constructors that TLC represents without      *)
+(* enumerating it is empty.                                                *)
+(***************************************************************************)
+
+THEOREM ESE_FcnSetEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  [S -> T] = {} <=> (S # {} /\ T = {})
+
+THEOREM ESE_RcdSetEmpty1 ==
+  ASSUME NEW S
+  PROVE  [n1 : S] = {} <=> S = {}
+
+THEOREM ESE_RcdSetEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  [n1 : S, n2 : T] = {} <=> (S = {} \/ T = {})
+
+THEOREM ESE_TupleSetEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \X T = {} <=> (S = {} \/ T = {})
+
+THEOREM ESE_TupleSetEmpty3 ==
+  ASSUME NEW S, NEW T, NEW U
+  PROVE  S \X T \X U = {} <=> (S = {} \/ T = {} \/ U = {})
+
+THEOREM ESE_SubsetNonEmpty ==
+  ASSUME NEW S
+  PROVE  SUBSET S # {}
+
+(***************************************************************************)
+(* When each of the remaining kinds of set is empty. TLC decides these per *)
+(* kind as well (Value#isEmpty), and the comparisons above short-circuit   *)
+(* on that decision.                                                      *)
+(***************************************************************************)
+
+THEOREM ESE_IntervalEmpty ==
+  ASSUME NEW a \in Int, NEW b \in Int
+  PROVE  a..b = {} <=> b < a
+
+THEOREM ESE_CapEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \cap T = {} <=> \A e \in S : e \notin T
+
+THEOREM ESE_CupEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \cup T = {} <=> (S = {} /\ T = {})
+
+THEOREM ESE_DiffEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \ T = {} <=> S \subseteq T
+
+THEOREM ESE_UnionEmpty ==
+  ASSUME NEW S
+  PROVE  UNION S = {} <=> \A e \in S : e = {}
+
+(***************************************************************************)
+(* The two rules that decide the equality of two sets of functions as soon *)
+(* as one of them is empty or denotes {<<>>}.                              *)
+(***************************************************************************)
+
+THEOREM ESE_UnitDomain ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  [S -> T] = { <<>> }
+
+THEOREM ESE_EmptyRange ==
+  ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  PROVE  [S -> T] = {}
+
+(***************************************************************************)
+(* The shapes in which a domain is empty: a set of records, a Cartesian    *)
+(* product, and a set of functions. A domain that is empty because of a    *)
+(* nested set instantiates one of these with the emptiness of the nested   *)
+(* set.                                                                    *)
+(***************************************************************************)
+
+THEOREM ESE_UnitDomainRcd1 ==
+  ASSUME NEW S, NEW R, S = {}
+  PROVE  [[n1 : S] -> R] = { <<>> }
+
+THEOREM ESE_UnitDomainRcd ==
+  ASSUME NEW S, NEW T, NEW R, S = {} \/ T = {}
+  PROVE  [[n1 : S, n2 : T] -> R] = { <<>> }
+
+THEOREM ESE_UnitDomainTuple ==
+  ASSUME NEW S, NEW T, NEW R, S = {} \/ T = {}
+  PROVE  [(S \X T) -> R] = { <<>> }
+
+THEOREM ESE_UnitDomainFcnSet ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in S, T = {}
+  PROVE  [[S -> T] -> R] = { <<>> }
+
+(***************************************************************************)
+(* Where neither set is empty nor {<<>>}, the domains and the co-domains,  *)
+(* the field sets, and the components decide the equality.                 *)
+(***************************************************************************)
+
+THEOREM ESE_DomainDecides ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  PROVE  [S -> R] = [T -> R] <=> S = T
+
+THEOREM ESE_RangeDecides ==
+  ASSUME NEW S, NEW R, NEW Q, NEW w, w \in S
+  PROVE  [S -> R] = [S -> Q] <=> R = Q
+
+THEOREM ESE_RcdFieldDecides ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  PROVE  [n1 : S, n2 : R] = [n1 : T, n2 : R] <=> S = T
+
+THEOREM ESE_TupleComponentDecides ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  PROVE  S \X R = T \X R <=> S = T
+
+THEOREM ESE_NatIntDiffer == Nat # Int
+
+(***************************************************************************)
+(* Where the two sets are of different constructors. A record is a         *)
+(* function on a set of strings and a tuple is a function on 1..n, so a    *)
+(* set of records and a Cartesian product are sets of functions as well,   *)
+(* and a set of records and a product meet only where both are empty.      *)
+(***************************************************************************)
+
+THEOREM ESE_RcdSetIsFcnSet ==
+  ASSUME NEW S
+  PROVE  [n1 : S] = [{"n1"} -> S]
+
+THEOREM ESE_TupleSetIsFcnSet ==
+  ASSUME NEW S
+  PROVE  S \X S = [1..2 -> S]
+
+THEOREM ESE_TupleSetIsFcnSet3 ==
+  ASSUME NEW S
+  PROVE  S \X S \X S = [1..3 -> S]
+
+THEOREM ESE_RcdSetDiffTupleSet ==
+  ASSUME NEW S, NEW T, NEW w, w \in S
+  PROVE  [n1 : S] # S \X T
+
+(***************************************************************************)
+(* How many functions there are.                                           *)
+(***************************************************************************)
+
+THEOREM ESE_UnitCardinality ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  Cardinality([S -> T]) = 1
+
+THEOREM ESE_EmptyCardinality ==
+  ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  PROVE  Cardinality([S -> T]) = 0
+
+(***************************************************************************)
+(* The operators that have to agree with the equalities above.             *)
+(***************************************************************************)
+
+THEOREM ESE_UnitMember ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  <<>> \in [S -> T]
+
+THEOREM ESE_EmptyNonMember ==
+  ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  PROVE  <<>> \notin [S -> T]
+
+THEOREM ESE_UnitSubset ==
+  ASSUME NEW S, NEW T, NEW U, NEW R, S = {}, U = {}
+  PROVE  [S -> T] \subseteq [U -> R]
+
+THEOREM ESE_EmptySubset ==
+  ASSUME NEW S, NEW T, NEW U, NEW w, w \in S, T = {}
+  PROVE  [S -> T] \subseteq U
+=============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems.tla
@@ -182,6 +182,13 @@ THEOREM ESE_RcdSetDiffTupleSet ==
   PROVE  [n1 : S] # S \X T
 
 (***************************************************************************)
+(* The domain of a one-field record beside the domain of a pair, i.e. the  *)
+(* two domains that a membership has to tell apart.                        *)
+(***************************************************************************)
+
+THEOREM ESE_TupleDomainDiffRcdDomain == 1..2 # {"n1"}
+
+(***************************************************************************)
 (* The cardinality of a set of functions that denotes {<<>>} and of an     *)
 (* empty set of each of the three constructors, i.e. the equalities above  *)
 (* read through Cardinality.                                               *)
@@ -286,9 +293,43 @@ THEOREM ESE_SeqEmptyFinite ==
 (* The operators that have to agree with the equalities above.             *)
 (***************************************************************************)
 
+THEOREM ESE_FcnSetMember ==
+  ASSUME NEW S, NEW T, NEW f
+  PROVE  f \in [S -> T] <=> /\ f = [x \in DOMAIN f |-> f[x]]
+                            /\ DOMAIN f = S
+                            /\ \A x \in S : f[x] \in T
+
+THEOREM ESE_RcdSetMember1 ==
+  ASSUME NEW S, NEW r
+  PROVE  r \in [n1 : S] <=> /\ r = [x \in DOMAIN r |-> r[x]]
+                            /\ DOMAIN r = {"n1"}
+                            /\ r.n1 \in S
+
+THEOREM ESE_RcdSetMember ==
+  ASSUME NEW S, NEW T, NEW r
+  PROVE  r \in [n1 : S, n2 : T] <=> /\ r = [x \in DOMAIN r |-> r[x]]
+                                    /\ DOMAIN r = {"n1", "n2"}
+                                    /\ r.n1 \in S
+                                    /\ r.n2 \in T
+
+THEOREM ESE_TupleSetMember ==
+  ASSUME NEW S, NEW T, NEW t
+  PROVE  t \in S \X T <=> /\ t = [x \in DOMAIN t |-> t[x]]
+                          /\ DOMAIN t = 1..2
+                          /\ t[1] \in S
+                          /\ t[2] \in T
+
+THEOREM ESE_EmptyNoMember ==
+  ASSUME NEW S, NEW e, S = {}
+  PROVE  e \notin S
+
 THEOREM ESE_UnitMember ==
   ASSUME NEW S, NEW T, S = {}
   PROVE  <<>> \in [S -> T]
+
+THEOREM ESE_UnitNonMember ==
+  ASSUME NEW S, NEW T, NEW e, S = {}, e # <<>>
+  PROVE  e \notin [S -> T]
 
 THEOREM ESE_EmptyNonMember ==
   ASSUME NEW S, NEW T, NEW w, w \in S, T = {}

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
@@ -13,8 +13,9 @@
 (*                                                                         *)
 (* See https://github.com/tlaplus/tlaplus/issues/1407                      *)
 (***************************************************************************)
-EXTENDS FiniteSets, Integers, TLAPS
+EXTENDS FiniteSets, Integers, Sequences, TLAPS
 LOCAL INSTANCE FiniteSetTheorems
+LOCAL INSTANCE SequenceTheorems
 
 (***************************************************************************)
 (* When each of the four set constructors that TLC represents without       *)
@@ -90,6 +91,30 @@ THEOREM ESE_RcdSetEmpty ==
       BY <2>1, <2>2
     <2>4. QED BY <2>3
   \* An empty field set is the only way the right-hand side can hold.
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdSetEmpty3 ==
+  ASSUME NEW S, NEW T, NEW U
+  PROVE  [n1 : S, n2 : T, n3 : U] = {} <=> (S = {} \/ T = {} \/ U = {})
+  <1>1. ASSUME S = {} \/ T = {} \/ U = {}
+        PROVE  [n1 : S, n2 : T, n3 : U] = {}
+    <2>1. ASSUME NEW r \in [n1 : S, n2 : T, n3 : U]
+          PROVE  FALSE
+      <3>1. r.n1 \in S /\ r.n2 \in T /\ r.n3 \in U
+        OBVIOUS
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME S # {}, T # {}, U # {}
+        PROVE  [n1 : S, n2 : T, n3 : U] # {}
+    <2>1. PICK s \in S : TRUE
+      BY <1>2
+    <2>2. PICK t \in T : TRUE
+      BY <1>2
+    <2>3. PICK u \in U : TRUE
+      BY <1>2
+    <2>4. [n1 |-> s, n2 |-> t, n3 |-> u] \in [n1 : S, n2 : T, n3 : U]
+      BY <2>1, <2>2, <2>3
+    <2>5. QED BY <2>4
   <1>3. QED BY <1>1, <1>2
 
 THEOREM ESE_TupleSetEmpty ==
@@ -503,6 +528,164 @@ THEOREM ESE_EmptyCardinality ==
   <1>2. Cardinality({}) = 0
     BY FS_EmptySet
   <1>3. QED BY <1>1, <1>2
+
+(***************************************************************************)
+(* The same sets read through IsFiniteSet. Each is { <<>> } or {}, so one  *)
+(* empty argument decides, and ESE_EmptyRangeFinite needs no witness in S: *)
+(* [S -> {}] is {} where S is non-empty and { <<>> } where it is not.      *)
+(***************************************************************************)
+
+THEOREM ESE_UnitFinite ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  IsFiniteSet([S -> T])
+  <1>1. [S -> T] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. IsFiniteSet({ <<>> })
+    BY FS_Singleton
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_EmptyRangeFinite ==
+  ASSUME NEW S, NEW T, T = {}
+  PROVE  IsFiniteSet([S -> T])
+  \* The two cases of S, neither of which needs a witness supplied: an empty S
+  \* makes [S -> T] the singleton { <<>> } and a non-empty S supplies its own.
+  <1>1. CASE S = {}
+    <2>1. [S -> T] = { <<>> }
+      BY <1>1, ESE_UnitDomain
+    <2>2. QED BY <2>1, FS_Singleton
+  <1>2. CASE S # {}
+    <2>1. PICK w \in S : TRUE
+      BY <1>2
+    <2>2. [S -> T] = {}
+      BY <2>1, ESE_EmptyRange
+    <2>3. QED BY <2>2, FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdSetEmptyFinite1 ==
+  ASSUME NEW S, S = {}
+  PROVE  IsFiniteSet([n1 : S])
+  <1>1. [n1 : S] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, FS_EmptySet
+
+THEOREM ESE_RcdSetEmptyFinite ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  IsFiniteSet([n1 : S, n2 : T])
+  <1>1. [n1 : S, n2 : T] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, FS_EmptySet
+
+THEOREM ESE_RcdSetEmptyFinite3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  IsFiniteSet([n1 : S, n2 : T, n3 : U])
+  <1>1. [n1 : S, n2 : T, n3 : U] = {}
+    BY ESE_RcdSetEmpty3
+  <1>2. QED BY <1>1, FS_EmptySet
+
+THEOREM ESE_TupleSetEmptyFinite ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  IsFiniteSet(S \X T)
+  <1>1. S \X T = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, FS_EmptySet
+
+THEOREM ESE_TupleSetEmptyFinite3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  IsFiniteSet(S \X T \X U)
+  <1>1. S \X T \X U = {}
+    BY ESE_TupleSetEmpty3
+  <1>2. QED BY <1>1, FS_EmptySet
+
+THEOREM ESE_SingletonRange ==
+  ASSUME NEW S, NEW T, NEW w, T = {w}
+  PROVE  [S -> T] = { [x \in S |-> w] }
+  \* Extensionality is what makes the two inclusions a singleton: a function
+  \* on S whose every value is w is the function [x \in S |-> w] itself.
+  <1>1. ASSUME NEW f \in [S -> T]
+        PROVE  f = [x \in S |-> w]
+    <2>1. DOMAIN f = S
+      OBVIOUS
+    <2>2. \A x \in S : f[x] = w
+      OBVIOUS
+    <2>3. QED BY <2>1, <2>2
+  <1>2. [x \in S |-> w] \in [S -> T]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_SingletonRangeFinite ==
+  ASSUME NEW S, NEW T, NEW w, T = {w}
+  PROVE  IsFiniteSet([S -> T])
+  <1>1. [S -> T] = { [x \in S |-> w] }
+    BY ESE_SingletonRange
+  <1>2. QED BY <1>1, FS_Singleton
+
+LEMMA SingletonDomainBijection ==
+  ASSUME NEW S, NEW T, NEW w, S = {w}
+  PROVE  ExistsBijection(T, [S -> T])
+  <1> DEFINE g == [v \in T |-> [x \in S |-> v]]
+  <1>1. g \in Injection(T, [S -> T])
+    <2>1. g \in [T -> [S -> T]]
+      OBVIOUS
+    <2>2. \A v1, v2 \in DOMAIN g : g[v1] = g[v2] => v1 = v2
+      <3>1. ASSUME NEW v1 \in T, NEW v2 \in T, g[v1] = g[v2]
+            PROVE  v1 = v2
+        <4>1. g[v1][w] = v1 /\ g[v2][w] = v2
+          OBVIOUS
+        <4>2. QED BY <3>1, <4>1
+      <3>2. QED BY <3>1
+    <2>3. QED BY <2>1, <2>2 DEF Injection, IsInjective
+  <1>2. g \in Surjection(T, [S -> T])
+    <2>1. ASSUME NEW f \in [S -> T]
+          PROVE  f = g[f[w]]
+      <3>1. f[w] \in T
+        OBVIOUS
+      <3>2. g[f[w]] = [x \in S |-> f[w]]
+        BY <3>1
+      <3>3. DOMAIN f = S /\ \A x \in S : f[x] = f[w]
+        OBVIOUS
+      <3>4. QED BY <3>2, <3>3
+    <2>2. QED BY <2>1 DEF Surjection
+  <1>3. QED BY <1>1, <1>2, Zenon DEF ExistsBijection, Bijection
+
+THEOREM ESE_SingletonDomainFinite ==
+  ASSUME NEW S, NEW T, NEW w, S = {w}, IsFiniteSet(T)
+  PROVE  IsFiniteSet([S -> T])
+  BY SingletonDomainBijection, FS_Bijection
+
+THEOREM ESE_PairFinite ==
+  ASSUME NEW a, NEW b, a # b
+  PROVE  /\ IsFiniteSet({a, b})
+         /\ Cardinality({a, b}) = 2
+  <1>1. {a, b} = {a} \cup {b}
+    OBVIOUS
+  <1>2. IsFiniteSet({a}) /\ Cardinality({a}) = 1
+    BY FS_Singleton
+  <1>3. b \notin {a}
+    OBVIOUS
+  <1>4. QED BY <1>1, <1>2, <1>3, FS_AddElement
+
+THEOREM ESE_SeqEmpty ==
+  ASSUME NEW S, S = {}
+  PROVE  Seq(S) = { <<>> }
+  <1>1. ASSUME NEW s \in Seq(S), s # <<>>
+        PROVE  FALSE
+    <2>1. Len(s) \in Nat \ {0}
+      BY <1>1, EmptySeq
+    <2>2. 1 \in 1..Len(s)
+      BY <2>1
+    <2>3. s[1] \in S
+      BY <1>1, <2>2, ElementOfSeq
+    <2>4. QED BY <2>3
+  <1>2. <<>> \in Seq(S)
+    BY EmptySeq
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_SeqEmptyFinite ==
+  ASSUME NEW S, S = {}
+  PROVE  IsFiniteSet(Seq(S))
+  <1>1. Seq(S) = { <<>> }
+    BY ESE_SeqEmpty
+  <1>2. QED BY <1>1, FS_Singleton
 
 (***************************************************************************)
 (* The operators that have to agree with the equalities above.              *)

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
@@ -391,6 +391,30 @@ THEOREM ESE_NatIntDiffer == Nat # Int
   <1>3. QED BY <1>1, <1>2
 
 (***************************************************************************)
+(* Congruence, which decides a comparison that none of the rules above      *)
+(* reaches. Every TLA+ value is a set, but TLA+ does not say what the       *)
+(* elements of a value such as 1 are, so neither 1 = {} nor 1 # {} is       *)
+(* provable and no witness w \in 1 can be supplied. Each of the three       *)
+(* constructors is a function of its arguments all the same, so equal       *)
+(* arguments denote the same set whatever the arguments contain.            *)
+(***************************************************************************)
+
+THEOREM ESE_FcnSetCongruence ==
+  ASSUME NEW S, NEW T
+  PROVE  [S -> T] = [S -> T]
+  OBVIOUS
+
+THEOREM ESE_RcdSetCongruence ==
+  ASSUME NEW S, NEW T
+  PROVE  [n1 : S, n2 : T] = [n1 : S, n2 : T]
+  OBVIOUS
+
+THEOREM ESE_TupleSetCongruence ==
+  ASSUME NEW S, NEW T
+  PROVE  S \X T = S \X T
+  OBVIOUS
+
+(***************************************************************************)
 (* Where the two sets are of different constructors. A record is a          *)
 (* function on a set of strings and a tuple is a function on 1..n, so a     *)
 (* set of records and a Cartesian product are sets of functions as well,    *)

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
@@ -1,0 +1,516 @@
+--------------------- MODULE EmptySetEqTheorems_proofs ----------------------
+(***************************************************************************)
+(* The TLA+ facts that TLC has to agree with when it compares two sets     *)
+(* that it represents without enumerating them, one of which may be empty, *)
+(* and the emptiness of the other kinds of set that such a comparison      *)
+(* rests on, with their proofs. Module EmptySetEqTheorems.tla lists the    *)
+(* statements without the proofs, and is the module that                   *)
+(* EmptySetEqCases_proofs.tla cites. Keep the statements in the two        *)
+(* modules in sync.                                                       *)
+(*                                                                         *)
+(* TLC does not parse this module. Check it with:                          *)
+(*   tlapm test-model/EmptySetEqTheorems_proofs.tla                        *)
+(*                                                                         *)
+(* See https://github.com/tlaplus/tlaplus/issues/1407                      *)
+(***************************************************************************)
+EXTENDS FiniteSets, Integers, TLAPS
+LOCAL INSTANCE FiniteSetTheorems
+
+(***************************************************************************)
+(* When each of the four set constructors that TLC represents without       *)
+(* enumerating it is empty.                                                 *)
+(***************************************************************************)
+
+THEOREM ESE_FcnSetEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  [S -> T] = {} <=> (S # {} /\ T = {})
+  <1>1. ASSUME S # {}, T = {}
+        PROVE  [S -> T] = {}
+    <2>1. PICK x \in S : TRUE
+      BY <1>1
+    <2>2. ASSUME NEW f \in [S -> T]
+          PROVE  FALSE
+      <3>1. f[x] \in T
+        BY <2>1
+      <3>2. QED BY <1>1, <3>1
+    <2>3. QED BY <2>2
+  <1>2. ASSUME S = {}
+        PROVE  [S -> T] # {}
+    <2>1. [x \in S |-> x] \in [S -> T]
+      BY <1>2
+    <2>2. QED BY <2>1
+  <1>3. ASSUME T # {}
+        PROVE  [S -> T] # {}
+    <2>1. PICK t \in T : TRUE
+      BY <1>3
+    <2>2. [x \in S |-> t] \in [S -> T]
+      BY <2>1
+    <2>3. QED BY <2>2
+  \* The two cases are the only ways the right-hand side can fail.
+  <1>4. QED BY <1>1, <1>2, <1>3
+
+THEOREM ESE_RcdSetEmpty1 ==
+  ASSUME NEW S
+  PROVE  [n1 : S] = {} <=> S = {}
+  <1>1. ASSUME S = {}
+        PROVE  [n1 : S] = {}
+    <2>1. ASSUME NEW r \in [n1 : S]
+          PROVE  FALSE
+      <3>1. r.n1 \in S
+        OBVIOUS
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME S # {}
+        PROVE  [n1 : S] # {}
+    <2>1. PICK s \in S : TRUE
+      BY <1>2
+    <2>2. [n1 |-> s] \in [n1 : S]
+      BY <2>1
+    <2>3. QED BY <2>2
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdSetEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  [n1 : S, n2 : T] = {} <=> (S = {} \/ T = {})
+  <1>1. ASSUME S = {} \/ T = {}
+        PROVE  [n1 : S, n2 : T] = {}
+    <2>1. ASSUME NEW r \in [n1 : S, n2 : T]
+          PROVE  FALSE
+      <3>1. r.n1 \in S /\ r.n2 \in T
+        OBVIOUS
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME S # {}, T # {}
+        PROVE  [n1 : S, n2 : T] # {}
+    <2>1. PICK s \in S : TRUE
+      BY <1>2
+    <2>2. PICK t \in T : TRUE
+      BY <1>2
+    <2>3. [n1 |-> s, n2 |-> t] \in [n1 : S, n2 : T]
+      BY <2>1, <2>2
+    <2>4. QED BY <2>3
+  \* An empty field set is the only way the right-hand side can hold.
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_TupleSetEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \X T = {} <=> (S = {} \/ T = {})
+  <1>1. ASSUME S = {} \/ T = {}
+        PROVE  S \X T = {}
+    <2>1. ASSUME NEW t \in S \X T
+          PROVE  FALSE
+      <3>1. t[1] \in S /\ t[2] \in T
+        OBVIOUS
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME S # {}, T # {}
+        PROVE  S \X T # {}
+    <2>1. PICK s \in S : TRUE
+      BY <1>2
+    <2>2. PICK t \in T : TRUE
+      BY <1>2
+    <2>3. <<s, t>> \in S \X T
+      BY <2>1, <2>2
+    <2>4. QED BY <2>3
+  \* An empty component is the only way the right-hand side can hold.
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_TupleSetEmpty3 ==
+  ASSUME NEW S, NEW T, NEW U
+  PROVE  S \X T \X U = {} <=> (S = {} \/ T = {} \/ U = {})
+  <1>1. ASSUME S = {} \/ T = {} \/ U = {}
+        PROVE  S \X T \X U = {}
+    <2>1. ASSUME NEW t \in S \X T \X U
+          PROVE  FALSE
+      <3>1. t[1] \in S /\ t[2] \in T /\ t[3] \in U
+        OBVIOUS
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME S # {}, T # {}, U # {}
+        PROVE  S \X T \X U # {}
+    <2>1. PICK s \in S : TRUE
+      BY <1>2
+    <2>2. PICK t \in T : TRUE
+      BY <1>2
+    <2>3. PICK u \in U : TRUE
+      BY <1>2
+    <2>4. <<s, t, u>> \in S \X T \X U
+      BY <2>1, <2>2, <2>3
+    <2>5. QED BY <2>4
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_SubsetNonEmpty ==
+  ASSUME NEW S
+  PROVE  SUBSET S # {}
+  <1>1. {} \in SUBSET S
+    OBVIOUS
+  <1>2. QED BY <1>1
+
+(***************************************************************************)
+(* When each of the remaining kinds of set is empty. TLC decides these per  *)
+(* kind as well (Value#isEmpty), and the comparisons above short-circuit    *)
+(* on that decision.                                                       *)
+(***************************************************************************)
+
+THEOREM ESE_IntervalEmpty ==
+  ASSUME NEW a \in Int, NEW b \in Int
+  PROVE  a..b = {} <=> b < a
+  <1>1. ASSUME b < a
+        PROVE  a..b = {}
+    <2>1. ASSUME NEW i \in a..b
+          PROVE  FALSE
+      <3>1. i \in Int /\ a =< i /\ i =< b
+        OBVIOUS
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME a =< b
+        PROVE  a..b # {}
+    <2>1. a \in a..b
+      BY <1>2
+    <2>2. QED BY <2>1
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_CapEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \cap T = {} <=> \A e \in S : e \notin T
+  OBVIOUS
+
+THEOREM ESE_CupEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \cup T = {} <=> (S = {} /\ T = {})
+  OBVIOUS
+
+THEOREM ESE_DiffEmpty ==
+  ASSUME NEW S, NEW T
+  PROVE  S \ T = {} <=> S \subseteq T
+  OBVIOUS
+
+THEOREM ESE_UnionEmpty ==
+  ASSUME NEW S
+  PROVE  UNION S = {} <=> \A e \in S : e = {}
+  <1>1. ASSUME UNION S = {}, NEW e \in S
+        PROVE  e = {}
+    <2>1. ASSUME NEW x \in e
+          PROVE  FALSE
+      <3>1. x \in UNION S
+        BY <1>1, <2>1
+      <3>2. QED BY <1>1, <3>1
+    <2>2. QED BY <2>1
+  <1>2. ASSUME \A e \in S : e = {}
+        PROVE  UNION S = {}
+    <2>1. ASSUME NEW x \in UNION S
+          PROVE  FALSE
+      <3>1. PICK e \in S : x \in e
+        BY <2>1
+      <3>2. e = {}
+        BY <1>2, <3>1
+      <3>3. QED BY <3>1, <3>2
+    <2>2. QED BY <2>1
+  <1>3. QED BY <1>1, <1>2
+
+(***************************************************************************)
+(* The two rules that decide the equality of two sets of functions as soon  *)
+(* as one of them is empty or denotes {<<>>}.                               *)
+(***************************************************************************)
+
+THEOREM ESE_UnitDomain ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  [S -> T] = { <<>> }
+  <1>1. ASSUME NEW f \in [S -> T]
+        PROVE  f = <<>>
+    <2>1. DOMAIN f = {}
+      OBVIOUS
+    <2>2. DOMAIN <<>> = {}
+      OBVIOUS
+    <2>3. QED BY <2>1, <2>2
+  <1>2. <<>> \in [S -> T]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_EmptyRange ==
+  ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  PROVE  [S -> T] = {}
+  <1>1. ASSUME NEW f \in [S -> T]
+        PROVE  FALSE
+    <2>1. f[w] \in T
+      OBVIOUS
+    <2>2. QED BY <2>1
+  <1>2. QED BY <1>1
+
+(***************************************************************************)
+(* The shapes in which a domain is empty: a set of records, a Cartesian     *)
+(* product, and a set of functions. A domain that is empty because of a     *)
+(* nested set instantiates one of these with the emptiness of the nested    *)
+(* set.                                                                     *)
+(***************************************************************************)
+
+THEOREM ESE_UnitDomainRcd1 ==
+  ASSUME NEW S, NEW R, S = {}
+  PROVE  [[n1 : S] -> R] = { <<>> }
+  <1>1. [n1 : S] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. QED BY <1>1, ESE_UnitDomain
+
+THEOREM ESE_UnitDomainRcd ==
+  ASSUME NEW S, NEW T, NEW R, S = {} \/ T = {}
+  PROVE  [[n1 : S, n2 : T] -> R] = { <<>> }
+  <1>1. [n1 : S, n2 : T] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitDomain
+
+THEOREM ESE_UnitDomainTuple ==
+  ASSUME NEW S, NEW T, NEW R, S = {} \/ T = {}
+  PROVE  [(S \X T) -> R] = { <<>> }
+  <1>1. S \X T = {}
+    BY ESE_TupleSetEmpty
+  <1>2. QED BY <1>1, ESE_UnitDomain
+
+THEOREM ESE_UnitDomainFcnSet ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in S, T = {}
+  PROVE  [[S -> T] -> R] = { <<>> }
+  <1>1. [S -> T] = {}
+    BY ESE_EmptyRange
+  <1>2. QED BY <1>1, ESE_UnitDomain
+
+(***************************************************************************)
+(* Where neither set is empty nor {<<>>}, the domains and the co-domains,  *)
+(* the field sets, and the components decide the equality.                 *)
+(***************************************************************************)
+
+THEOREM ESE_DomainDecides ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  PROVE  [S -> R] = [T -> R] <=> S = T
+  <1>1. ASSUME [S -> R] = [T -> R]
+        PROVE  S = T
+    <2>1. [x \in S |-> w] \in [S -> R]
+      OBVIOUS
+    <2>2. [x \in S |-> w] \in [T -> R]
+      BY <1>1, <2>1
+    <2>3. DOMAIN [x \in S |-> w] = S
+      OBVIOUS
+    <2>4. DOMAIN [x \in S |-> w] = T
+      BY <2>2
+    <2>5. QED BY <2>3, <2>4
+  <1>2. S = T => [S -> R] = [T -> R]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RangeDecides ==
+  ASSUME NEW S, NEW R, NEW Q, NEW w, w \in S
+  PROVE  [S -> R] = [S -> Q] <=> R = Q
+  <1>1. ASSUME [S -> R] = [S -> Q]
+        PROVE  R = Q
+    <2>1. ASSUME NEW r \in R
+          PROVE  r \in Q
+      <3>1. [x \in S |-> r] \in [S -> R]
+        OBVIOUS
+      <3>2. [x \in S |-> r] \in [S -> Q]
+        BY <1>1, <3>1
+      <3>3. [x \in S |-> r][w] = r
+        OBVIOUS
+      <3>4. [x \in S |-> r][w] \in Q
+        BY <3>2
+      <3>5. QED BY <3>3, <3>4
+    <2>2. ASSUME NEW q \in Q
+          PROVE  q \in R
+      <3>1. [x \in S |-> q] \in [S -> Q]
+        OBVIOUS
+      <3>2. [x \in S |-> q] \in [S -> R]
+        BY <1>1, <3>1
+      <3>3. [x \in S |-> q][w] = q
+        OBVIOUS
+      <3>4. [x \in S |-> q][w] \in R
+        BY <3>2
+      <3>5. QED BY <3>3, <3>4
+    <2>3. QED BY <2>1, <2>2
+  <1>2. R = Q => [S -> R] = [S -> Q]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdFieldDecides ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  PROVE  [n1 : S, n2 : R] = [n1 : T, n2 : R] <=> S = T
+  <1>1. ASSUME [n1 : S, n2 : R] = [n1 : T, n2 : R]
+        PROVE  S = T
+    <2>1. ASSUME NEW s \in S
+          PROVE  s \in T
+      <3>1. [n1 |-> s, n2 |-> w] \in [n1 : S, n2 : R]
+        OBVIOUS
+      <3>2. [n1 |-> s, n2 |-> w] \in [n1 : T, n2 : R]
+        BY <1>1, <3>1
+      <3>3. [n1 |-> s, n2 |-> w].n1 \in T
+        BY <3>2
+      <3>4. QED BY <3>3
+    <2>2. ASSUME NEW t \in T
+          PROVE  t \in S
+      <3>1. [n1 |-> t, n2 |-> w] \in [n1 : T, n2 : R]
+        OBVIOUS
+      <3>2. [n1 |-> t, n2 |-> w] \in [n1 : S, n2 : R]
+        BY <1>1, <3>1
+      <3>3. [n1 |-> t, n2 |-> w].n1 \in S
+        BY <3>2
+      <3>4. QED BY <3>3
+    <2>3. QED BY <2>1, <2>2
+  <1>2. S = T => [n1 : S, n2 : R] = [n1 : T, n2 : R]
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_TupleComponentDecides ==
+  ASSUME NEW S, NEW T, NEW R, NEW w, w \in R
+  PROVE  S \X R = T \X R <=> S = T
+  <1>1. ASSUME S \X R = T \X R
+        PROVE  S = T
+    <2>1. ASSUME NEW s \in S
+          PROVE  s \in T
+      <3>1. <<s, w>> \in S \X R
+        OBVIOUS
+      <3>2. <<s, w>> \in T \X R
+        BY <1>1, <3>1
+      <3>3. <<s, w>>[1] \in T
+        BY <3>2
+      <3>4. QED BY <3>3
+    <2>2. ASSUME NEW t \in T
+          PROVE  t \in S
+      <3>1. <<t, w>> \in T \X R
+        OBVIOUS
+      <3>2. <<t, w>> \in S \X R
+        BY <1>1, <3>1
+      <3>3. <<t, w>>[1] \in S
+        BY <3>2
+      <3>4. QED BY <3>3
+    <2>3. QED BY <2>1, <2>2
+  <1>2. S = T => S \X R = T \X R
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_NatIntDiffer == Nat # Int
+  <1>1. -1 \in Int
+    OBVIOUS
+  <1>2. -1 \notin Nat
+    OBVIOUS
+  <1>3. QED BY <1>1, <1>2
+
+(***************************************************************************)
+(* Where the two sets are of different constructors. A record is a          *)
+(* function on a set of strings and a tuple is a function on 1..n, so a     *)
+(* set of records and a Cartesian product are sets of functions as well,    *)
+(* and a set of records and a product meet only where both are empty.       *)
+(***************************************************************************)
+
+THEOREM ESE_RcdSetIsFcnSet ==
+  ASSUME NEW S
+  PROVE  [n1 : S] = [{"n1"} -> S]
+  OBVIOUS
+
+THEOREM ESE_TupleSetIsFcnSet ==
+  ASSUME NEW S
+  PROVE  S \X S = [1..2 -> S]
+  <1>1. ASSUME NEW t \in S \X S
+        PROVE  t \in [1..2 -> S]
+    OBVIOUS
+  <1>2. ASSUME NEW f \in [1..2 -> S]
+        PROVE  f \in S \X S
+    <2>1. f = <<f[1], f[2]>>
+      OBVIOUS
+    <2>2. f[1] \in S /\ f[2] \in S
+      OBVIOUS
+    <2>3. <<f[1], f[2]>> \in S \X S
+      BY <2>2
+    <2>4. QED BY <2>1, <2>3
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_TupleSetIsFcnSet3 ==
+  ASSUME NEW S
+  PROVE  S \X S \X S = [1..3 -> S]
+  <1>1. ASSUME NEW t \in S \X S \X S
+        PROVE  t \in [1..3 -> S]
+    OBVIOUS
+  <1>2. ASSUME NEW f \in [1..3 -> S]
+        PROVE  f \in S \X S \X S
+    <2>1. f = <<f[1], f[2], f[3]>>
+      OBVIOUS
+    <2>2. f[1] \in S /\ f[2] \in S /\ f[3] \in S
+      OBVIOUS
+    <2>3. <<f[1], f[2], f[3]>> \in S \X S \X S
+      BY <2>2
+    <2>4. QED BY <2>1, <2>3
+  <1>3. QED BY <1>1, <1>2
+
+\* The domain of a record is a set of field names and the domain of a tuple
+\* is 1..n, i.e. the two differ in size already.
+THEOREM ESE_RcdSetDiffTupleSet ==
+  ASSUME NEW S, NEW T, NEW w, w \in S
+  PROVE  [n1 : S] # S \X T
+  <1>1. [n1 |-> w] \in [n1 : S]
+    OBVIOUS
+  <1>2. ASSUME [n1 : S] = S \X T
+        PROVE  FALSE
+    <2>1. [n1 |-> w] \in S \X T
+      BY <1>1, <1>2
+    <2>2. DOMAIN [n1 |-> w] = 1..2
+      BY <2>1
+    <2>3. DOMAIN [n1 |-> w] = {"n1"}
+      OBVIOUS
+    <2>4. Cardinality(1..2) = 2
+      BY FS_Interval
+    <2>5. Cardinality({"n1"}) = 1
+      BY FS_Singleton
+    <2>6. QED BY <2>2, <2>3, <2>4, <2>5
+  <1>3. QED BY <1>2
+
+(***************************************************************************)
+(* How many functions there are.                                            *)
+(***************************************************************************)
+
+THEOREM ESE_UnitCardinality ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  Cardinality([S -> T]) = 1
+  <1>1. [S -> T] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. Cardinality({ <<>> }) = 1
+    BY FS_Singleton
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_EmptyCardinality ==
+  ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  PROVE  Cardinality([S -> T]) = 0
+  <1>1. [S -> T] = {}
+    BY ESE_EmptyRange
+  <1>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+(***************************************************************************)
+(* The operators that have to agree with the equalities above.              *)
+(***************************************************************************)
+
+THEOREM ESE_UnitMember ==
+  ASSUME NEW S, NEW T, S = {}
+  PROVE  <<>> \in [S -> T]
+  <1>1. [S -> T] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. QED BY <1>1
+
+THEOREM ESE_EmptyNonMember ==
+  ASSUME NEW S, NEW T, NEW w, w \in S, T = {}
+  PROVE  <<>> \notin [S -> T]
+  <1>1. [S -> T] = {}
+    BY ESE_EmptyRange
+  <1>2. QED BY <1>1
+
+THEOREM ESE_UnitSubset ==
+  ASSUME NEW S, NEW T, NEW U, NEW R, S = {}, U = {}
+  PROVE  [S -> T] \subseteq [U -> R]
+  <1>1. [S -> T] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. [U -> R] = { <<>> }
+    BY ESE_UnitDomain
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_EmptySubset ==
+  ASSUME NEW S, NEW T, NEW U, NEW w, w \in S, T = {}
+  PROVE  [S -> T] \subseteq U
+  <1>1. [S -> T] = {}
+    BY ESE_EmptyRange
+  <1>2. QED BY <1>1
+=============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
@@ -508,7 +508,9 @@ THEOREM ESE_RcdSetDiffTupleSet ==
   <1>3. QED BY <1>2
 
 (***************************************************************************)
-(* How many functions there are.                                            *)
+(* The cardinality of a set of functions that denotes {<<>>} and of an      *)
+(* empty set of each of the three constructors, i.e. the equalities above   *)
+(* read through Cardinality.                                                *)
 (***************************************************************************)
 
 THEOREM ESE_UnitCardinality ==
@@ -525,6 +527,51 @@ THEOREM ESE_EmptyCardinality ==
   PROVE  Cardinality([S -> T]) = 0
   <1>1. [S -> T] = {}
     BY ESE_EmptyRange
+  <1>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdSetEmptyCardinality1 ==
+  ASSUME NEW S, S = {}
+  PROVE  Cardinality([n1 : S]) = 0
+  <1>1. [n1 : S] = {}
+    BY ESE_RcdSetEmpty1
+  <1>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdSetEmptyCardinality ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  Cardinality([n1 : S, n2 : T]) = 0
+  <1>1. [n1 : S, n2 : T] = {}
+    BY ESE_RcdSetEmpty
+  <1>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_RcdSetEmptyCardinality3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  Cardinality([n1 : S, n2 : T, n3 : U]) = 0
+  <1>1. [n1 : S, n2 : T, n3 : U] = {}
+    BY ESE_RcdSetEmpty3
+  <1>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_TupleSetEmptyCardinality ==
+  ASSUME NEW S, NEW T, S = {} \/ T = {}
+  PROVE  Cardinality(S \X T) = 0
+  <1>1. S \X T = {}
+    BY ESE_TupleSetEmpty
+  <1>2. Cardinality({}) = 0
+    BY FS_EmptySet
+  <1>3. QED BY <1>1, <1>2
+
+THEOREM ESE_TupleSetEmptyCardinality3 ==
+  ASSUME NEW S, NEW T, NEW U, S = {} \/ T = {} \/ U = {}
+  PROVE  Cardinality(S \X T \X U) = 0
+  <1>1. S \X T \X U = {}
+    BY ESE_TupleSetEmpty3
   <1>2. Cardinality({}) = 0
     BY FS_EmptySet
   <1>3. QED BY <1>1, <1>2
@@ -619,6 +666,13 @@ THEOREM ESE_SingletonRangeFinite ==
     BY ESE_SingletonRange
   <1>2. QED BY <1>1, FS_Singleton
 
+THEOREM ESE_SingletonRangeCardinality ==
+  ASSUME NEW S, NEW T, NEW w, T = {w}
+  PROVE  Cardinality([S -> T]) = 1
+  <1>1. [S -> T] = { [x \in S |-> w] }
+    BY ESE_SingletonRange
+  <1>2. QED BY <1>1, FS_Singleton
+
 LEMMA SingletonDomainBijection ==
   ASSUME NEW S, NEW T, NEW w, S = {w}
   PROVE  ExistsBijection(T, [S -> T])
@@ -650,6 +704,11 @@ LEMMA SingletonDomainBijection ==
 THEOREM ESE_SingletonDomainFinite ==
   ASSUME NEW S, NEW T, NEW w, S = {w}, IsFiniteSet(T)
   PROVE  IsFiniteSet([S -> T])
+  BY SingletonDomainBijection, FS_Bijection
+
+THEOREM ESE_SingletonDomainCardinality ==
+  ASSUME NEW S, NEW T, NEW w, S = {w}, IsFiniteSet(T)
+  PROVE  Cardinality([S -> T]) = Cardinality(T)
   BY SingletonDomainBijection, FS_Bijection
 
 THEOREM ESE_PairFinite ==

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqTheorems_proofs.tla
@@ -508,6 +508,19 @@ THEOREM ESE_RcdSetDiffTupleSet ==
   <1>3. QED BY <1>2
 
 (***************************************************************************)
+(* The domain of a one-field record beside the domain of a pair, i.e. the  *)
+(* two domains that a membership has to tell apart.                        *)
+(***************************************************************************)
+
+THEOREM ESE_TupleDomainDiffRcdDomain == 1..2 # {"n1"}
+  \* The cardinalities decide this, because TLA+ leaves 1 = "n1" open.
+  <1>1. Cardinality(1..2) = 2
+    BY FS_Interval
+  <1>2. Cardinality({"n1"}) = 1
+    BY FS_Singleton
+  <1>3. QED BY <1>1, <1>2
+
+(***************************************************************************)
 (* The cardinality of a set of functions that denotes {<<>>} and of an      *)
 (* empty set of each of the three constructors, i.e. the equalities above   *)
 (* read through Cardinality.                                                *)
@@ -750,9 +763,51 @@ THEOREM ESE_SeqEmptyFinite ==
 (* The operators that have to agree with the equalities above.              *)
 (***************************************************************************)
 
+THEOREM ESE_FcnSetMember ==
+  ASSUME NEW S, NEW T, NEW f
+  PROVE  f \in [S -> T] <=> /\ f = [x \in DOMAIN f |-> f[x]]
+                            /\ DOMAIN f = S
+                            /\ \A x \in S : f[x] \in T
+  OBVIOUS
+
+THEOREM ESE_RcdSetMember1 ==
+  ASSUME NEW S, NEW r
+  PROVE  r \in [n1 : S] <=> /\ r = [x \in DOMAIN r |-> r[x]]
+                            /\ DOMAIN r = {"n1"}
+                            /\ r.n1 \in S
+  OBVIOUS
+
+THEOREM ESE_RcdSetMember ==
+  ASSUME NEW S, NEW T, NEW r
+  PROVE  r \in [n1 : S, n2 : T] <=> /\ r = [x \in DOMAIN r |-> r[x]]
+                                    /\ DOMAIN r = {"n1", "n2"}
+                                    /\ r.n1 \in S
+                                    /\ r.n2 \in T
+  OBVIOUS
+
+THEOREM ESE_TupleSetMember ==
+  ASSUME NEW S, NEW T, NEW t
+  PROVE  t \in S \X T <=> /\ t = [x \in DOMAIN t |-> t[x]]
+                          /\ DOMAIN t = 1..2
+                          /\ t[1] \in S
+                          /\ t[2] \in T
+  OBVIOUS
+
+THEOREM ESE_EmptyNoMember ==
+  ASSUME NEW S, NEW e, S = {}
+  PROVE  e \notin S
+  OBVIOUS
+
 THEOREM ESE_UnitMember ==
   ASSUME NEW S, NEW T, S = {}
   PROVE  <<>> \in [S -> T]
+  <1>1. [S -> T] = { <<>> }
+    BY ESE_UnitDomain
+  <1>2. QED BY <1>1
+
+THEOREM ESE_UnitNonMember ==
+  ASSUME NEW S, NEW T, NEW e, S = {}, e # <<>>
+  PROVE  e \notin [S -> T]
   <1>1. [S -> T] = { <<>> }
     BY ESE_UnitDomain
   <1>2. QED BY <1>1

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/EmptySetEqAssumeTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/EmptySetEqAssumeTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class EmptySetEqAssumeTest extends ModelCheckerTestCase {
+
+	// A false assumption in test-model/EmptySetEqAssume.tla fails this test with
+	// EC.TLC_ASSUMPTION_FALSE, and one that TLC cannot evaluate with
+	// EC.TLC_ASSUMPTION_EVALUATION_ERROR.
+	public EmptySetEqAssumeTest() {
+		super("EmptySetEqAssume");
+	}
+
+	@Test
+	public void testSpec() {
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+		assertFalse(recorder.recorded(EC.TLC_ASSUMPTION_FALSE));
+		assertFalse(recorder.recorded(EC.TLC_ASSUMPTION_EVALUATION_ERROR));
+		assertFalse(recorder.recorded(EC.GENERAL));
+
+		// The config has no behavior spec and, therefore, no states.
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "0", "0", "0"));
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true; // not relevant for this test
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/EmptySetEqStatesRcdTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/EmptySetEqStatesRcdTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class EmptySetEqStatesRcdTest extends ModelCheckerTestCase {
+
+	// test-model/EmptySetEqStates.tla states what RcdSpec covers: a set of
+	// records and the set of functions that denotes it, which TLC has to
+	// fingerprint alike although it stores the one as a record and the other as
+	// a function.
+	public EmptySetEqStatesRcdTest() {
+		super("EmptySetEqStates", new String[] { "-config", "EmptySetEqStatesRcd.cfg" });
+	}
+
+	@Override
+	protected boolean checkDeadLock() {
+		return true;
+	}
+
+	@Test
+	public void testRcdSpec() {
+		assertFalse(recorder.recorded(EC.TLC_DEADLOCK_REACHED));
+		assertFalse(recorder.recorded(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR));
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		// [n1 : {"a"}] and [{"n1"} -> {"a"}] are one state, plus its successor.
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "3", "1", "0"));
+
+		assertZeroUncovered();
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true; // not relevant for this test
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/tool/EmptySetEqStatesTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/tool/EmptySetEqStatesTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.tool;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import tlc2.output.EC;
+import tlc2.tool.liveness.ModelCheckerTestCase;
+
+public class EmptySetEqStatesTest extends ModelCheckerTestCase {
+
+	// test-model/EmptySetEqStates.tla states what Spec covers. Its initial
+	// predicate ends up in Value#fingerPrint, its next-state relation in
+	// Value#equals.
+	public EmptySetEqStatesTest() {
+		super("EmptySetEqStates");
+	}
+
+	@Override
+	protected boolean checkDeadLock() {
+		// A spurious deadlock is one of the two symptoms this test is after, the
+		// number of distinct states the other.
+		return true;
+	}
+
+	@Test
+	public void testSpec() {
+		assertFalse(recorder.recorded(EC.TLC_DEADLOCK_REACHED));
+		assertFalse(recorder.recorded(EC.TLC_INVARIANT_VIOLATED_BEHAVIOR));
+		assertTrue(recorder.recorded(EC.TLC_FINISHED));
+
+		// The 34 sets of Forms fingerprint as the four values they denote, plus one
+		// successor per state.
+		assertTrue(recorder.recordedWithStringValues(EC.TLC_STATS, "38", "4", "0"));
+
+		assertZeroUncovered();
+	}
+
+	@Override
+	protected boolean noGenerateSpec() {
+		return true; // not relevant for this test
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/ValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/ValueTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2026 NVIDIA Corp. All rights reserved. 
+ *
+ * The MIT License (MIT)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy 
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software. 
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Contributors:
+ *   Markus Alexander Kuppe - initial API and implementation
+ ******************************************************************************/
+package tlc2.value.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import tlc2.module.AnySet;
+import tlc2.module.Integers;
+import tlc2.module.Naturals;
+import tlc2.module.Sequences;
+import tlc2.module.Strings;
+import util.Assert.TLCRuntimeException;
+import util.UniqueString;
+
+/**
+ * SetOfFcnsValue, SetOfRcdsValue, and SetOfTuplesValue short-circuit their
+ * equals on Value#isEmpty, so a wrong answer makes TLC report two distinct
+ * sets as equal. ValueTest.tla states what TLC must answer, proved with TLAPS.
+ *
+ * The values below are built in Java, rather than asserted in TLA+ as
+ * test-model/EmptySetEqCases.tla does, because TLC reduces a set expression to
+ * a SetEnumValue as soon as it can. An assumption reaches the \cup, the \, and
+ * the UNION branch of isEmpty only with an operand that TLC cannot enumerate,
+ * such as {"d1"} \cup Nat, and it never reaches the \cap branch: a \cap with
+ * one enumerable operand is intersected on the spot (Reducible#cap), and one
+ * without raises an error instead of answering.
+ *
+ * https://github.com/tlaplus/tlaplus/issues/1407
+ */
+public class ValueTest {
+
+	private static final Value ONE = IntValue.gen(1);
+	private static final Value TWO = IntValue.gen(2);
+
+	private static final SetEnumValue set() {
+		return new SetEnumValue();
+	}
+
+	private static final SetEnumValue set(final Value v) {
+		return new SetEnumValue(new Value[] { v }, true);
+	}
+
+	private static final SetOfRcdsValue rcds(final Value field) {
+		return new SetOfRcdsValue(new UniqueString[] { UniqueString.uniqueStringOf("n1") },
+				new Value[] { field }, false);
+	}
+
+	@Test
+	public void testIsEmpty() {
+		assertTrue("{}", set().isEmpty());
+		assertFalse("{1}", set(ONE).isEmpty());
+
+		assertTrue("1..0", new IntervalValue(1, 0).isEmpty());
+		assertFalse("1..1", new IntervalValue(1, 1).isEmpty());
+
+		assertTrue("{1} \\cap {2}", new SetCapValue(set(ONE), set(TWO)).isEmpty());
+		assertFalse("{1} \\cap {1}", new SetCapValue(set(ONE), set(ONE)).isEmpty());
+
+		assertTrue("{} \\cup {}", new SetCupValue(set(), set()).isEmpty());
+		assertFalse("{} \\cup {1}", new SetCupValue(set(), set(ONE)).isEmpty());
+
+		assertTrue("{1} \\ {1}", new SetDiffValue(set(ONE), set(ONE)).isEmpty());
+		assertFalse("{1} \\ {2}", new SetDiffValue(set(ONE), set(TWO)).isEmpty());
+
+		assertTrue("[{1} -> {}]", new SetOfFcnsValue(set(ONE), set()).isEmpty());
+		assertFalse("[{} -> {}] denotes {<<>>}", new SetOfFcnsValue(set(), set()).isEmpty());
+
+		assertTrue("[n1: {}]", rcds(set()).isEmpty());
+		assertFalse("[n1: {1}]", rcds(set(ONE)).isEmpty());
+
+		assertTrue("{} \\X {1}", new SetOfTuplesValue(set(), set(ONE)).isEmpty());
+		assertFalse("{1} \\X {1}", new SetOfTuplesValue(set(ONE), set(ONE)).isEmpty());
+
+		assertFalse("SUBSET {} denotes {{}}", new SubsetValue(set()).isEmpty());
+		assertFalse("SUBSET {1}", new SubsetValue(set(ONE)).isEmpty());
+
+		assertTrue("UNION {}", new UnionValue(set()).isEmpty());
+		assertTrue("UNION {{}}", new UnionValue(set(set())).isEmpty());
+		assertFalse("UNION {{1}}", new UnionValue(set(set(ONE))).isEmpty());
+
+		// SETPREDVALUE is missing, and no assumption covers it either: a
+		// SetPredValue needs the parsed predicate of a spec, which JUnit
+		// cannot easily supply.
+
+		// isEmpty refuses an overridden value until the commit that lets each
+		// module answer for itself, which uncomments the four assertions.
+//		assertFalse("Nat", Naturals.Nat().isEmpty());
+//		assertFalse("Int", Integers.Int().isEmpty());
+//		assertFalse("STRING", Strings.STRING().isEmpty());
+//		assertFalse("Seq({})", Sequences.Seq(set()).isEmpty());
+
+		try {
+			AnySet.ANY().isEmpty();
+			fail("isEmpty answered for ANY, whose elements TLA+ leaves unspecified");
+		} catch (TLCRuntimeException e) {
+			// Expected.
+		}
+
+		try {
+			ONE.isEmpty();
+			fail("isEmpty answered for 1, whose elements TLA+ leaves unspecified");
+		} catch (TLCRuntimeException e) {
+			// Expected.
+		}
+	}
+}

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/ValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/ValueTest.java
@@ -109,12 +109,10 @@ public class ValueTest {
 		// SetPredValue needs the parsed predicate of a spec, which JUnit
 		// cannot easily supply.
 
-		// isEmpty refuses an overridden value until the commit that lets each
-		// module answer for itself, which uncomments the four assertions.
-//		assertFalse("Nat", Naturals.Nat().isEmpty());
-//		assertFalse("Int", Integers.Int().isEmpty());
-//		assertFalse("STRING", Strings.STRING().isEmpty());
-//		assertFalse("Seq({})", Sequences.Seq(set()).isEmpty());
+		assertFalse("Nat", Naturals.Nat().isEmpty());
+		assertFalse("Int", Integers.Int().isEmpty());
+		assertFalse("STRING", Strings.STRING().isEmpty());
+		assertFalse("Seq({})", Sequences.Seq(set()).isEmpty());
 
 		try {
 			AnySet.ANY().isEmpty();

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/ValueTest.tla
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/ValueTest.tla
@@ -1,0 +1,67 @@
+------------------------------ MODULE ValueTest ------------------------------
+\* The TLA+ semantics that ValueTest.testIsEmpty expects Value#isEmpty to
+\* implement, proved with TLAPS and stated in the order of the test. TLC!Any
+\* and the number 1 have no theorem: both are sets, as every TLA+ value is,
+\* but TLA+ leaves their elements unspecified, so nothing decides whether
+\* either is empty and isEmpty refuses to answer.
+\*
+\* TLC does not parse this module. Check it from tlatools/org.lamport.tlatools
+\* with:
+\*   tlapm test/tlc2/value/impl/ValueTest.tla
+\*
+\* See https://github.com/tlaplus/tlaplus/issues/1407
+EXTENDS Integers, Sequences
+
+THEOREM SetEnumNonEmpty == {1} # {} OBVIOUS
+
+THEOREM IntervalEmpty == 1..0 = {} OBVIOUS
+THEOREM IntervalNonEmpty == 1..1 # {} OBVIOUS
+
+THEOREM CapEmpty == {1} \cap {2} = {} OBVIOUS
+THEOREM CapNonEmpty == {1} \cap {1} # {} OBVIOUS
+THEOREM CupEmpty == {} \cup {} = {} OBVIOUS
+THEOREM CupNonEmpty == {} \cup {1} # {} OBVIOUS
+THEOREM DiffEmpty == {1} \ {1} = {} OBVIOUS
+THEOREM DiffNonEmpty == {1} \ {2} # {} OBVIOUS
+
+\* An empty domain yields {<<>>} and not {}.
+THEOREM FcnSetEmptyRangeEmpty == [{1} -> {}] = {} OBVIOUS
+THEOREM FcnSetEmptyDomainNonEmpty == [{} -> {}] # {} OBVIOUS
+
+THEOREM RcdSetEmptyFieldEmpty == [n1 : {}] = {} OBVIOUS
+THEOREM RcdSetNonEmpty == [n1 : {1}] # {} OBVIOUS
+THEOREM TupleSetEmptyComponentEmpty == ({} \X {1}) = {} OBVIOUS
+THEOREM TupleSetNonEmpty == ({1} \X {1}) # {} OBVIOUS
+
+\* SUBSET S contains {} for every S, hence it is never empty.
+THEOREM SubsetOfEmptyNonEmpty == SUBSET {} # {} OBVIOUS
+THEOREM SubsetNonEmpty == SUBSET {1} # {} OBVIOUS
+
+THEOREM UnionOfEmptyEmpty == UNION {} = {} OBVIOUS
+THEOREM UnionOfEmptyElementEmpty == UNION {{}} = {} OBVIOUS
+THEOREM UnionNonEmpty == UNION {{1}} # {} OBVIOUS
+
+THEOREM NatNonEmpty == Nat # {}
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1
+
+THEOREM IntNonEmpty == Int # {}
+  <1>1. 0 \in Int
+    OBVIOUS
+  <1>2. QED BY <1>1
+
+THEOREM StringNonEmpty == STRING # {}
+  <1>1. "" \in STRING
+    OBVIOUS
+  <1>2. QED BY <1>1
+
+THEOREM SeqNonEmpty ==
+  ASSUME NEW S
+  PROVE  Seq(S) # {}
+  <1>1. <<>> \in Seq(S)
+    <2>1. <<>> \in [1..0 -> S]
+      OBVIOUS
+    <2>2. QED BY <2>1
+  <1>2. QED BY <1>1
+=============================================================================


### PR DESCRIPTION
### Test suite

- **TLA+ level, TLC as a black box, TLAPS as the oracle.** `EmptySetEqCases.tla` names the equalities, finiteness questions, and cardinalities of sets of functions `[S -> T]`, sets of records `[h : S]`, and Cartesian products `S \X T` built from empty, non-empty, and infinite sets (`Nat`, `Int`, `STRING`, `Seq(S)`). `EmptySetEqAssume.tla` assumes them, `EmptySetEqCases_proofs.tla` proves each of them from the rules of `EmptySetEqTheorems.tla`. Assumption and theorem share one definition, so the two cannot drift apart.
- **Answer correctly or refuse.** Most assumptions state a case, the rest pin an error with `TLCExt!AssertError`. Some of those errors are facts TLAPS proves, so they record a limitation instead of an acceptable refusal.
- **State and action level.** `EmptySetEqStates.tla` offers every enumerable set as an initial state, so TLC reaches `Value#fingerPrint`, and a wrong answer becomes an extra state, a deadlock, or a violated `Inv`.
- **JUnit where no expression reaches the code.** `ValueTest` builds such values in Java, e.g. for the `\cap` arm of `Value#isEmpty`; `ValueTest.tla` proves the formulas behind its assertions.

### Fix

Every set the suite names is `{<<>>}` or `{}`, so one empty argument decides the answer whatever the others contain. TLC read the others anyway, wherever it decided equality, finiteness, cardinality, or printing.

- **Equality.** `Value#isEmpty` decides `[S -> T]`, `[h : S]`, and `S \X T` structurally instead of by enumerating, and a standard module answers for itself through the new `UserObj#isEmpty`. `SetOfFcnsValue#equals` settles an empty domain or an empty range first, as `SetOfRcdsValue#equals` and `SetOfTuplesValue#equals` have since 075246eea of 2014-06-09.
- **Finiteness.** `IsFiniteSet([{} -> Nat])` answered `FALSE` although `[{} -> Nat] = {<<>>}`, and TLC denied `[Nat -> {}]`, `[n1 : {}, n2 : Nat]`, and `{} \X Nat` the same way. An empty argument decides, in either order. So does a singleton range, because `[S -> {w}]` is the one function `[x \in S |-> w]` for an infinite `S`, which settles `IsFiniteSet([Nat -> {"d1"}])`; and `Seq({})` is `{<<>>}` without a bound on the length, which settles `IsFiniteSet(Seq({}))`.
- **Cardinality.** `Cardinality([n1 : 1..50000, n2 : 1..50000, n3 : {}])` reported an overflow and `Cardinality([{} -> Nat])` refused, though the empty argument decides both. An empty field set, component, domain, or range decides the count, as does a singleton range, and `needBigInteger` short-circuits on the same ones, because the cardinality of `{}` needs no `BigInteger`.
- **Printing.** `ToString([n1 : 1..50000, n2 : 1..50000, n3 : {}])` printed the expression that denotes the set rather than the set, and `ToString([{} -> SUBSET (1..40)])` overflowed. TLC prints `{}` and `{<<>>}` whether or not the remaining sets can be counted.

### Accepted limitations

Each is pinned with `AssertError`, and proved where TLA+ decides the fact, so it is recorded rather than hidden.

- **Printing a set whose other argument TLC cannot handle.** Printing sizes the set and then enumerates it, so TLC gives up on `ToString([n1 : Nat, n2 : {}])`, `ToString([{} -> Nat])`, and `ToString([(1..50000) \X (1..50000) -> {}])`. `Cardinality([n1 : (Nat \ {0}), n2 : {}])` gives up in any position, because `Nat \ {0}` cannot be enumerated at all.
- **A set a standard module cannot count.** `IsFiniteSet([Nat -> Seq({})])` refuses, although `Seq({})` is `{<<>>}` and the set is the singleton `{[x \in Nat |-> <<>>]}`. Deciding it asks `Sequences` for `Cardinality(Seq({}))`, which the module does not answer.
- **A comparison of a set with itself.** TLC refuses `[1 -> 2] = [1 -> 2]` and the like, which TLA+ decides by congruence, because the guards `SetOfFcnsValue#equals` gains ask whether `1` is empty; `SetOfRcdsValue` and `SetOfTuplesValue` have refused theirs since 075246eea. Deciding them needs an emptiness test that may answer neither.
- **An argument whose emptiness TLA+ leaves open.** `IsFiniteSet([1 -> 2])`, `IsFiniteSet(1 \X {"d1"})`, `IsFiniteSet(Seq(1))`, and the like are open in TLA+, so refusing is the answer, and TLC refuses instead of returning `FALSE`.

Every commit is green: what TLC gets wrong is commented out where the suite lands, and uncommented by the commit that fixes it.

Addresses #1407
