### PR TITLE
Skip Apalache models in the examples integration tests.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -228,12 +228,9 @@ jobs:
           # https://github.com/tlaplus/tlaplus/issues/1353
           "specifications/EinsteinRiddle/Einstein.cfg"
         )
-        # Apalache does not yet support Unicode specs:
-        # https://github.com/apalache-mc/apalache/issues/2995
-        APALACHE_FLAG=()
-        if [ "${{ matrix.unicode }}" = "true" ]; then
-          APALACHE_FLAG+=("--skip_apalache")
-        fi
+        # Symbolic models are checked by Apalache, whose releases target a
+        # newer Java than the one this workflow builds TLC with. Apalache is
+        # exercised against the nightly build by tlaplus/examples' own CI.
         python "$SCRIPT_DIR/check_small_models.py"                        \
           --verbose                                                       \
           --tools_jar_path "$DIST_DIR/tla2tools.jar"                      \
@@ -243,7 +240,7 @@ jobs:
           --examples_root "$EXAMPLES_DIR"                                 \
           --enable_assertions                                             \
           --skip "${SKIP[@]}"                                             \
-          "${APALACHE_FLAG[@]}"
+          --skip_apalache
     - name: Smoke-test large tlaplus/examples models
       run: |
         # SimKnuthYao requires certain number of states to have been generated
@@ -257,7 +254,8 @@ jobs:
           --community_modules_jar_path "$DEPS_DIR/community/modules.jar"  \
           --examples_root "$EXAMPLES_DIR"                                 \
           --enable_assertions                                             \
-          --skip "specifications/KnuthYao/SimKnuthYao.cfg"
+          --skip "specifications/KnuthYao/SimKnuthYao.cfg"                \
+          --skip_apalache
     - name: Run formatter TLAPS-dependent tests
       if: ${{ !matrix.unicode }}
       run: |


### PR DESCRIPTION
Apalache requires Java 21, while TLC continues to require Java 17. This workflow installs Java 17 for TLC, causing every symbolic model to fail with UnsupportedClassVersionError.

[Build]