### PR TITLE
Fix crash parsing long radix-prefixed numerals (\b, \o, \h)

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NumeralNode.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/semantic/NumeralNode.java
@@ -66,7 +66,7 @@ public class NumeralNode extends ExprNode {
     try {
       this.value = Integer.parseInt( num, radix );
     } catch ( NumberFormatException e ) {
-      this.bigValue = new BigInteger( s, radix );
+      this.bigValue = new BigInteger( num, radix );
     }
   }
 

--- a/tlatools/org.lamport.tlatools/test/tla2sany/semantic/IncrementalSemanticParseTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/semantic/IncrementalSemanticParseTests.java
@@ -25,6 +25,7 @@ package tla2sany.semantic;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -116,6 +117,33 @@ public class IncrementalSemanticParseTests {
     Assert.assertEquals(syntax, result.getTreeNode());
     Assert.assertEquals(LevelConstants.ConstantLevel, result.getLevel());
     Assert.assertEquals(NumeralNode.class, result.getClass());
+  }
+
+  /**
+   * Regression test for https://github.com/tlaplus/tlaplus/issues/1419 :
+   * radix-prefixed numerals (\b, \o, \h) that overflow a Java int must fall
+   * back to {@link java.math.BigInteger} correctly instead of throwing a
+   * {@link NumberFormatException}, which happened because the radix prefix
+   * was left attached to the string passed to the BigInteger constructor.
+   */
+  @Test
+  public void bigRadixNumeralTest() throws ParseException, AbortException {
+    bigRadixNumeralTest("\\b" + "1".repeat(32), 2);
+    bigRadixNumeralTest("\\o" + "7".repeat(12), 8);
+    bigRadixNumeralTest("\\h" + "f".repeat(9), 16);
+  }
+
+  private void bigRadixNumeralTest(String literal, int radix) throws ParseException, AbortException {
+    final SyntaxTreeNode syntax = IncrementalSyntaxParseTests.parser(literal).Expression();
+    final Errors log = new Errors();
+    final Generator semantic = new Generator(null, log);
+    final ExprNode result = semantic.generateExpression(syntax, new ModuleNode(null, null, null));
+    Assert.assertTrue(log.toString(), log.isSuccess());
+    Assert.assertEquals(NumeralNode.class, result.getClass());
+    final NumeralNode numeral = (NumeralNode)result;
+    Assert.assertFalse(numeral.useVal());
+    final BigInteger expected = new BigInteger(literal.substring(2), radix);
+    Assert.assertEquals(expected, numeral.bigVal());
   }
 
   @Test


### PR DESCRIPTION
NumeralNode fell back to BigInteger when a numeral overflowed a Java int, but passed the original string (still carrying the \b/\o/\h prefix) to the BigInteger constructor instead of the prefix-stripped string used for the initial Integer.parseInt attempt. BigInteger does not understand TLA+'s radix-prefix syntax, so this threw a NumberFormatException for any sufficiently long binary (>31 digits), octal (>11 digits), or hex (>8 digits) numeral, e.g. \h0123456789abcdef.

Fixes #1419.