### PR TITLE
Enumerate { } and { <<>> } without enumerating their arguments.

### DIFF
--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EnumerableValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/EnumerableValue.java
@@ -66,6 +66,19 @@ public abstract class EnumerableValue extends Value implements Enumerable {
     	return ((SetEnumValue) this.toSetEnum()).getRandomSubset(kOutOfN);
 	}
 
+	protected static final ValueEnumeration EMPTY_ENUMERATION = new ValueEnumeration() {
+
+		@Override
+		public void reset() {
+			// Nothing to reset because nextElement never yields an element.
+		}
+
+		@Override
+		public Value nextElement() {
+			return null;
+		}
+	};
+
 	@Override
 	public ValueEnumeration elements(final Ordering ordering) {
 		if (ordering == Ordering.NORMALIZED) {

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfFcnsValue.java
@@ -458,6 +458,12 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   public final ValueEnumeration elements() {
     try {
       if (this.fcnSet == null || this.fcnSet == SetEnumValue.DummyEnum) {
+        // [S -> T] = {} <=> S # {} /\ T = {}, which decides emptiness without the
+        // enumeration of S that the enumerators below need. They answer the other
+        // rule, [{} -> T] = { <<>> }.
+        if (this.isEmpty()) {
+          return EMPTY_ENUMERATION;
+        }
     	  if (this.domain instanceof IntervalValue) {
     		  return new DomIVEnumerator();
     	  }
@@ -479,25 +485,23 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
 	public DomIVEnumerator() {
       this.isDone = false;
       int sz = domain.size();
-      if (range instanceof Enumerable) {
-        this.enums = new ValueEnumeration[sz];
-        this.currentElems = new Value[sz];
-        // SZ Feb 24, 2009: never read locally
-        // ValueEnumeration enumeration = ((Enumerable)domSet).elements();
-        for (int i = 0; i < sz; i++) {
-          this.enums[i] = ((Enumerable)range).elements();
-          this.currentElems[i] = this.enums[i].nextElement();
-          if (this.currentElems[i] == null) {
-            this.enums = null;
-            this.isDone = true;
-            break;
-          }
-        }
-      }
-      else {
+      // [S -> T] needs one enumeration of T per element of S, and
+      // [{} -> T] = { <<>> } whatever T is.
+      if (sz > 0 && !(range instanceof Enumerable)) {
         Assert.fail("Attempted to enumerate a set of the form [D -> R]," +
               "but the range R:\n" + Values.ppr(range.toString()) +
               "\ncannot be enumerated.", getSource());
+      }
+      this.enums = new ValueEnumeration[sz];
+      this.currentElems = new Value[sz];
+      for (int i = 0; i < sz; i++) {
+        this.enums[i] = ((Enumerable)range).elements();
+        this.currentElems[i] = this.enums[i].nextElement();
+        if (this.currentElems[i] == null) {
+          this.enums = null;
+          this.isDone = true;
+          break;
+        }
       }
 	}
 
@@ -564,27 +568,25 @@ public class SetOfFcnsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
       domSet.normalize();
       ValueVec elems = domSet.elems;
       int sz = elems.size();
-      if (range instanceof Enumerable) {
-        this.dom = new Value[sz];
-        this.enums = new ValueEnumeration[sz];
-        this.currentElems = new Value[sz];
-        // SZ Feb 24, 2009: never read locally
-        // ValueEnumeration enumeration = ((Enumerable)domSet).elements();
-        for (int i = 0; i < sz; i++) {
-          this.dom[i] = elems.elementAt(i);
-          this.enums[i] = ((Enumerable)range).elements();
-          this.currentElems[i] = this.enums[i].nextElement();
-          if (this.currentElems[i] == null) {
-            this.enums = null;
-            this.isDone = true;
-            break;
-          }
-        }
-      }
-      else {
+      // [S -> T] needs one enumeration of T per element of S, and
+      // [{} -> T] = { <<>> } whatever T is.
+      if (sz > 0 && !(range instanceof Enumerable)) {
         Assert.fail("Attempted to enumerate a set of the form [D -> R]," +
               "but the range R:\n" + Values.ppr(range.toString()) +
               "\ncannot be enumerated.", getSource());
+      }
+      this.dom = new Value[sz];
+      this.enums = new ValueEnumeration[sz];
+      this.currentElems = new Value[sz];
+      for (int i = 0; i < sz; i++) {
+        this.dom[i] = elems.elementAt(i);
+        this.enums[i] = ((Enumerable)range).elements();
+        this.currentElems[i] = this.enums[i].nextElement();
+        if (this.currentElems[i] == null) {
+          this.enums = null;
+          this.isDone = true;
+          break;
+        }
       }
     }
 

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfRcdsValue.java
@@ -450,6 +450,11 @@ public class SetOfRcdsValue extends SetOfFcnsOrRcdsValue implements Enumerable {
   public final ValueEnumeration elements() {
     try {
       if (this.rcdSet == null || this.rcdSet == SetEnumValue.DummyEnum) {
+        // [l1 : v1, ..., ln : vn] = {} <=> \E i : vi = {}, which decides emptiness
+        // without the enumeration of v1..vi that Enumerator below needs.
+        if (this.isEmpty()) {
+          return EMPTY_ENUMERATION;
+        }
         return new Enumerator();
       }
       return this.rcdSet.elements();

--- a/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
+++ b/tlatools/org.lamport.tlatools/src/tlc2/value/impl/SetOfTuplesValue.java
@@ -434,6 +434,11 @@ public class SetOfTuplesValue extends EnumerableValue implements Enumerable {
   public final ValueEnumeration elements() {
     try {
       if (this.tupleSet == null || this.tupleSet == SetEnumValue.DummyEnum) {
+        // s1 \X s2 ... \X sn = {} <=> \E i : si = {}, which decides emptiness
+        // without the enumeration of s1..si that Enumerator below needs.
+        if (this.isEmpty()) {
+          return EMPTY_ENUMERATION;
+        }
         return new Enumerator();
       }
       return this.tupleSet.elements();

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -6,11 +6,6 @@
 \* TLA+ fact; the ones that do have a proof say so, i.e. they record a
 \* limitation.
 \*
-\* TLC does not yet answer every assumption below. The commented out ones are
-\* the enumerations it refuses, marked "refused", and the commit that fixes
-\* TLC uncomments them and drops the AssertError assumptions that state the
-\* same refusals.
-\*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 
@@ -23,12 +18,12 @@ ASSUME UnitSingletonRangeEnum
 ASSUME UnitSingletonRangeSym
 ASSUME UnitTripleRangeEnum
 ASSUME UnitTripleRangeSym
-\* ASSUME UnitNatRangeEnum          \* refused
+ASSUME UnitNatRangeEnum
 ASSUME UnitNatRangeSym
 
 ASSUME UnitIntervalEnum
 ASSUME UnitIntervalSym
-\* ASSUME UnitIntervalNatEnum       \* refused
+ASSUME UnitIntervalNatEnum
 ASSUME UnitIntervalNatSym
 
 ASSUME UnitCapEnum
@@ -46,21 +41,21 @@ ASSUME UnitFilterSym
 
 ASSUME UnitRcdFieldEnum
 ASSUME UnitRcdFieldSym
-\* ASSUME UnitRcdNatFieldEnum       \* refused
+ASSUME UnitRcdNatFieldEnum
 ASSUME UnitRcdNatFieldSym
 ASSUME UnitRcdFieldNatSym
 
 ASSUME UnitTupleEnum
 ASSUME UnitTupleSym
-\* ASSUME UnitTupleNatFirstEnum     \* refused
+ASSUME UnitTupleNatFirstEnum
 ASSUME UnitTupleNatFirstSym
 ASSUME UnitTupleNatSecondSym
 ASSUME UnitTupleStrFirstSym
 
-\* ASSUME UnitFcnSetEnum            \* refused
+ASSUME UnitFcnSetEnum
 ASSUME UnitFcnSetSym
 ASSUME UnitFcnSetNestedSym
-\* ASSUME UnitFcnSetNatRangeEnum    \* refused
+ASSUME UnitFcnSetNatRangeEnum
 ASSUME UnitDiffNestedUnitEnum
 ASSUME UnitDiffNestedUnitSym
 
@@ -92,24 +87,24 @@ ASSUME EmptyFilterSym
 
 ASSUME EmptySubsetEmptyEnum
 ASSUME EmptySubsetEmptySym
-\* ASSUME EmptySubsetNatEnum        \* refused
+ASSUME EmptySubsetNatEnum
 ASSUME EmptySubsetNatSym
 
 ASSUME EmptyRcdEnum
 ASSUME EmptyRcdSym
-\* ASSUME EmptyRcdNatEnum           \* refused
+ASSUME EmptyRcdNatEnum
 ASSUME EmptyRcdNatSym
 
 ASSUME EmptyTupleEnum
 ASSUME EmptyTupleSym
-\* ASSUME EmptyTupleNatEnum         \* refused
+ASSUME EmptyTupleNatEnum
 ASSUME EmptyTupleNatSym
 
-\* ASSUME EmptyNatEnum              \* refused
+ASSUME EmptyNatEnum
 ASSUME EmptyNatSym
-\* ASSUME EmptyIntEnum              \* refused
+ASSUME EmptyIntEnum
 ASSUME EmptyIntSym
-\* ASSUME EmptySeqEnum              \* refused
+ASSUME EmptySeqEnum
 ASSUME EmptySeqSym
 ASSUME EmptyStrSym
 
@@ -119,7 +114,7 @@ ASSUME EmptyRcdFcnSetRangeSym
 ASSUME EmptyTupleFcnSetRangeSym
 ASSUME EmptyFcnSetRangeSym
 
-\* ASSUME EmptyFcnSetEnum           \* refused
+ASSUME EmptyFcnSetEnum
 ASSUME EmptyFcnSetSym
 
 -----------------------------------------------------------------------------
@@ -132,7 +127,7 @@ ASSUME RcdEmptyArityEnum
 ASSUME RcdEmptyAritySym
 ASSUME RcdEmptyIntervalEnum
 ASSUME RcdEmptyIntervalSym
-\* ASSUME RcdEmptyNatFieldEnum      \* refused
+ASSUME RcdEmptyNatFieldEnum
 ASSUME RcdEmptyNatFieldSym
 ASSUME RcdEmptyFieldNatSym
 ASSUME RcdEmptySeqFieldSym
@@ -153,7 +148,7 @@ ASSUME TupEmptyArityEnum
 ASSUME TupEmptyAritySym
 ASSUME TupEmptyIntervalEnum
 ASSUME TupEmptyIntervalSym
-\* ASSUME TupEmptyNatFirstEnum      \* refused
+ASSUME TupEmptyNatFirstEnum
 ASSUME TupEmptyNatFirstSym
 ASSUME TupEmptyNatSecondSym
 ASSUME TupEmptySeqFirstSym
@@ -168,9 +163,9 @@ ASSUME TupEmptyThenDiffSym
 \* Two sets of different constructors.
 
 ASSUME FcnSetEqRcdSetEmpty
-\* ASSUME FcnSetEqRcdSetNat         \* refused
+ASSUME FcnSetEqRcdSetNat
 ASSUME FcnSetEqTupleSetEmpty
-\* ASSUME FcnSetEqTupleSetNat       \* refused
+ASSUME FcnSetEqTupleSetNat
 ASSUME RcdSetEqTupleSetEmpty
 ASSUME UnitDiffRcdSetEmpty
 ASSUME UnitDiffTupleSetEmpty
@@ -187,17 +182,17 @@ ASSUME TupleSetIsFcnSet3
 ASSUME UnitEmptyRangeRev
 ASSUME UnitSingletonRangeRev
 ASSUME EmptySingletonRev
-\* ASSUME EmptyNatRev               \* refused
+ASSUME EmptyNatRev
 ASSUME RcdEmptyFieldRev
 ASSUME RcdEmptyArityRev
 ASSUME TupEmptyComponentRev
 ASSUME TupEmptyArityRev
 
 ASSUME RcdSetEqFcnSetEmptyRev
-\* ASSUME RcdSetEqFcnSetNatRev      \* refused
+ASSUME RcdSetEqFcnSetNatRev
 ASSUME TupleSetEqFcnSetEmptyRev
 ASSUME TupleSetEqRcdSetEmptyRev
-\* ASSUME TupleSetEqRcdSetNatRev    \* refused
+ASSUME TupleSetEqRcdSetNatRev
 ASSUME RcdSetIsFcnSetRev
 ASSUME TupleSetIsFcnSetRev
 
@@ -391,19 +386,19 @@ ASSUME InUnitFilter
 
 ASSUME InUnitRcdField
 ASSUME InUnitRcdFieldNat
-\* ASSUME InUnitRcdNatField         \* refused
+ASSUME InUnitRcdNatField
 ASSUME InUnitTuple
 ASSUME InUnitTupleNatSecond
-\* ASSUME InUnitTupleNatFirst       \* refused
-\* ASSUME InUnitTupleStrFirst       \* refused
+ASSUME InUnitTupleNatFirst
+ASSUME InUnitTupleStrFirst
 ASSUME InUnitFcnSet
-\* ASSUME InUnitFcnSetNat           \* refused
-\* ASSUME InUnitFcnSetNested        \* refused
+ASSUME InUnitFcnSetNat
+ASSUME InUnitFcnSetNested
 
-\* ASSUME InUnitRcdFcnSet           \* refused
+ASSUME InUnitRcdFcnSet
 ASSUME InUnitRcdRcd
 ASSUME InUnitRcdTuple
-\* ASSUME InUnitTupleFcnSet         \* refused
+ASSUME InUnitTupleFcnSet
 ASSUME InUnitTupleRcd
 ASSUME InUnitTupleTuple
 
@@ -470,9 +465,9 @@ ASSUME InFcnSetNatRange
 \* The remaining operator that has to agree with the comparisons above.
 
 ASSUME SubsetUnitRanges
-\* ASSUME SubsetUnitNatRange        \* refused
+ASSUME SubsetUnitNatRange
 ASSUME SubsetEmptyDomain
-\* ASSUME SubsetEmptyNatDomain      \* refused
+ASSUME SubsetEmptyNatDomain
 
 -----------------------------------------------------------------------------
 \* The rendering that TLC prints for the same sets, which has to agree with
@@ -495,14 +490,15 @@ ASSUME ToString([n1 : 1..50000, n2 : 1..50000, n3 : {}]) = "{}"
 ASSUME ToString((1..50000) \X (1..50000) \X {})          = "{}"
 ASSUME ToString([{} -> (SUBSET (1..40))])                = "{<<>>}"
 ASSUME ToString([{} -> ((1..50000) \X (1..50000))])      = "{<<>>}"
-\* ASSUME ToString([{} -> Nat])                          = "{<<>>}"  \* refused
+ASSUME ToString([{} -> Nat])                             = "{<<>>}"
 
 ASSUME ToString([n1 : 1..50000, n2 : 1..50000]) = "[n1: 1..50000, n2: 1..50000]"
 
 -----------------------------------------------------------------------------
 \* The comparisons that TLC refuses to answer. Giving up is acceptable for
-\* these sets, whereas a wrong answer is not, except for the last two
-\* assumptions of this section, which TLA+ does decide.
+\* these sets, whereas a wrong answer is not. The groups at the end of this
+\* section say where a refusal records a limitation instead, i.e. where TLA+
+\* does decide the comparison.
 
 \* A domain or a co-domain that TLC cannot enumerate.
 ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
@@ -543,18 +539,6 @@ ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerabl
                    [ref : {}] # [n1 : (Nat \ Nat)])
 ASSUME AssertError("Attempted to enumerate S \\ T when S:\nNat\nis not enumerable.",
                    ({"ref"} \X {}) # ((Nat \ Nat) \X {"d1"}))
-
-\* Two sets of different constructors, where TLC enumerates both instead of
-\* taking the emptiness rules. FcnSetEqRcdSetEmpty and the cases next to it
-\* are the same comparisons on sets that TLC does enumerate.
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   [Nat -> {}] = [n1 : {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   [n1 : {}] = [Nat -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   [Nat -> {}] = ({} \X {"r1"}))
-ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
-                   ({} \X {"r1"}) = [n1 : Nat, n2 : {}])
 
 \* A record and a tuple, which differ because their domains differ
 \* (ESE_RcdSetDiffTupleSet of EmptySetEqTheorems.tla), and which TLC refuses
@@ -602,41 +586,11 @@ ASSUME AssertError("Shouldn't call isEmpty() on value ANY",
                    ({"ref"} \X {}) = (Any \X {}))
 
 \* An operator other than = that gives up where = decides: [Nat -> {}] is
-\* empty and [{} -> Nat] denotes {<<>>} above, so \notin and \subseteq have an
-\* answer that TLC does not give. ESE_EmptyNonMember, ESE_EmptySubset, and
-\* ESE_UnitSubset of EmptySetEqTheorems.tla state the three answers.
+\* empty, so \notin has an answer that TLC does not give. ESE_EmptyNonMember
+\* of EmptySetEqTheorems.tla states it, and SubsetEmptyNatDomain is the
+\* \subseteq that TLC does answer on the same set.
 ASSUME AssertError("Attempted to check equality of the set {} with the value:\nNat",
                    NotInEmptyNatDomain)
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   [Nat -> {}] \subseteq [{"r1"} -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
-                   [{} -> Nat] \subseteq [{} -> {"d1"}])
-
-\* The reduced form { } or { <<>> } for an input that TLC cannot enumerate.
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   { } = [Nat -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   [Nat -> {}] = { })
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nInt\ncannot be enumerated.",
-                   { } = [Int -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nSeq({\"d1\"})\ncannot be enumerated.",
-                   { } = [Seq({"d1"}) -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
-                   { <<>> } = [{} -> Nat])
-ASSUME AssertError("Attempted to compute the number of elements in the overridden value Nat.",
-                   { } = [(SUBSET Nat) -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
-                   { } = [[n1 : Nat] -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
-                   { } = [(Nat \X {"d1"}) -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
-                   { } = [n1 : Nat, n2 : {}])
-ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
-                   { } = (Nat \X {}))
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   { } = [[Nat -> {"d1"}] -> {}])
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   { <<>> } = [[Nat -> {}] -> {"d2"}])
 
 \* The finiteness of a set built from a value whose emptiness TLA+ leaves
 \* open, which TLA+ leaves open in turn: [1 -> 2] is { <<>> } if 1 = {} and
@@ -691,10 +645,10 @@ ASSUME AssertError("Shouldn't call isEmpty() on value 1", TupIntReflexive)
 \* ESE_FcnSetEmpty: a set of functions is empty only for an empty co-domain,
 \* and 0 \in Nat rules that out whatever the domain is.
 \*
-\* These two stay refused past the commit that fixes the ones above, because
-\* TLC answers by enumerating rather than by reading the co-domain, and a
-\* domain that has an element asks for one enumeration of the co-domain per
-\* element, which is what TLC cannot do for Nat.
+\* TLC reads the co-domain the other way round, by enumerating it once per
+\* element of the domain, which is what it cannot do for Nat. An empty domain
+\* asks for no enumeration at all, so UnitNatRangeEnum and
+\* UnitIntervalNatEnum are the same two enumerators answering.
 ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
                    EmptyDiffNatRangeEnum)
 ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
@@ -711,8 +665,6 @@ ASSUME AssertError("Attempted to apply the operator overridden by the Java metho
 
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to compute the number of elements in the overridden value Nat.",
                    ToString([n1 : Nat, n2 : {}]) = "{}")
-ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nAttempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
-                   ToString([{} -> Nat]) = "{<<>>}")
 ASSUME AssertError("Attempted to apply the operator overridden by the Java method\npublic static tlc2.value.impl.Value tlc2.module.TLC.ToString(tlc2.value.impl.Value),\nbut it produced the following error:\nOverflow when computing the number of elements in (1..50000 \\X 1..50000)",
                    ToString([((1..50000) \X (1..50000)) -> {}]) = "{}")
 
@@ -724,22 +676,6 @@ ASSUME AssertError("Attempted to apply the operator overridden by the Java metho
 \* components one by one. An argument that TLC can neither compare nor read
 \* therefore refuses a membership that an empty domain, co-domain, field
 \* set, or component decides.
-
-\* An empty domain, i.e. the set is { <<>> } and <<>> is its member.
-ASSUME AssertError("Attempted to enumerate a set of the form [l1 : v1, ..., ln : vn],\nbut can't enumerate the value of the `n1' field:\nNat",
-                   InUnitRcdNatField)
-ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nNat",
-                   InUnitTupleNatFirst)
-ASSUME AssertError("Attempted to enumerate a set of the form s1 \\X s2 ... \\X sn,\nbut can't enumerate s0:\nSTRING",
-                   InUnitTupleStrFirst)
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   InUnitFcnSetNat)
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   InUnitFcnSetNested)
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   InUnitRcdFcnSet)
-ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the domain D:\nNat\ncannot be enumerated.",
-                   InUnitTupleFcnSet)
 
 \* An empty co-domain, i.e. the set is { } and nothing is its member, where
 \* the domain is the argument that TLC gives up on.

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqAssume.tla
@@ -6,6 +6,11 @@
 \* TLA+ fact; the ones that do have a proof say so, i.e. they record a
 \* limitation.
 \*
+\* TLC does not yet answer every assumption below. The commented out ones are
+\* the enumerations it refuses, marked "refused", and the commit that fixes
+\* TLC uncomments them and drops the AssertError assumptions that state the
+\* same refusals.
+\*
 \* See https://github.com/tlaplus/tlaplus/issues/1407
 EXTENDS FiniteSets, Integers, Sequences, TLC, TLCExt, EmptySetEqCases
 
@@ -18,10 +23,12 @@ ASSUME UnitSingletonRangeEnum
 ASSUME UnitSingletonRangeSym
 ASSUME UnitTripleRangeEnum
 ASSUME UnitTripleRangeSym
+\* ASSUME UnitNatRangeEnum          \* refused
 ASSUME UnitNatRangeSym
 
 ASSUME UnitIntervalEnum
 ASSUME UnitIntervalSym
+\* ASSUME UnitIntervalNatEnum       \* refused
 ASSUME UnitIntervalNatSym
 
 ASSUME UnitCapEnum
@@ -39,17 +46,21 @@ ASSUME UnitFilterSym
 
 ASSUME UnitRcdFieldEnum
 ASSUME UnitRcdFieldSym
+\* ASSUME UnitRcdNatFieldEnum       \* refused
 ASSUME UnitRcdNatFieldSym
 ASSUME UnitRcdFieldNatSym
 
 ASSUME UnitTupleEnum
 ASSUME UnitTupleSym
+\* ASSUME UnitTupleNatFirstEnum     \* refused
 ASSUME UnitTupleNatFirstSym
 ASSUME UnitTupleNatSecondSym
 ASSUME UnitTupleStrFirstSym
 
+\* ASSUME UnitFcnSetEnum            \* refused
 ASSUME UnitFcnSetSym
 ASSUME UnitFcnSetNestedSym
+\* ASSUME UnitFcnSetNatRangeEnum    \* refused
 ASSUME UnitDiffNestedUnitEnum
 ASSUME UnitDiffNestedUnitSym
 
@@ -81,18 +92,24 @@ ASSUME EmptyFilterSym
 
 ASSUME EmptySubsetEmptyEnum
 ASSUME EmptySubsetEmptySym
+\* ASSUME EmptySubsetNatEnum        \* refused
 ASSUME EmptySubsetNatSym
 
 ASSUME EmptyRcdEnum
 ASSUME EmptyRcdSym
+\* ASSUME EmptyRcdNatEnum           \* refused
 ASSUME EmptyRcdNatSym
 
 ASSUME EmptyTupleEnum
 ASSUME EmptyTupleSym
+\* ASSUME EmptyTupleNatEnum         \* refused
 ASSUME EmptyTupleNatSym
 
+\* ASSUME EmptyNatEnum              \* refused
 ASSUME EmptyNatSym
+\* ASSUME EmptyIntEnum              \* refused
 ASSUME EmptyIntSym
+\* ASSUME EmptySeqEnum              \* refused
 ASSUME EmptySeqSym
 ASSUME EmptyStrSym
 
@@ -102,6 +119,7 @@ ASSUME EmptyRcdFcnSetRangeSym
 ASSUME EmptyTupleFcnSetRangeSym
 ASSUME EmptyFcnSetRangeSym
 
+\* ASSUME EmptyFcnSetEnum           \* refused
 ASSUME EmptyFcnSetSym
 
 -----------------------------------------------------------------------------
@@ -114,6 +132,7 @@ ASSUME RcdEmptyArityEnum
 ASSUME RcdEmptyAritySym
 ASSUME RcdEmptyIntervalEnum
 ASSUME RcdEmptyIntervalSym
+\* ASSUME RcdEmptyNatFieldEnum      \* refused
 ASSUME RcdEmptyNatFieldSym
 ASSUME RcdEmptyFieldNatSym
 ASSUME RcdEmptySeqFieldSym
@@ -134,6 +153,7 @@ ASSUME TupEmptyArityEnum
 ASSUME TupEmptyAritySym
 ASSUME TupEmptyIntervalEnum
 ASSUME TupEmptyIntervalSym
+\* ASSUME TupEmptyNatFirstEnum      \* refused
 ASSUME TupEmptyNatFirstSym
 ASSUME TupEmptyNatSecondSym
 ASSUME TupEmptySeqFirstSym
@@ -148,7 +168,9 @@ ASSUME TupEmptyThenDiffSym
 \* Two sets of different constructors.
 
 ASSUME FcnSetEqRcdSetEmpty
+\* ASSUME FcnSetEqRcdSetNat         \* refused
 ASSUME FcnSetEqTupleSetEmpty
+\* ASSUME FcnSetEqTupleSetNat       \* refused
 ASSUME RcdSetEqTupleSetEmpty
 ASSUME UnitDiffRcdSetEmpty
 ASSUME UnitDiffTupleSetEmpty
@@ -165,14 +187,17 @@ ASSUME TupleSetIsFcnSet3
 ASSUME UnitEmptyRangeRev
 ASSUME UnitSingletonRangeRev
 ASSUME EmptySingletonRev
+\* ASSUME EmptyNatRev               \* refused
 ASSUME RcdEmptyFieldRev
 ASSUME RcdEmptyArityRev
 ASSUME TupEmptyComponentRev
 ASSUME TupEmptyArityRev
 
 ASSUME RcdSetEqFcnSetEmptyRev
+\* ASSUME RcdSetEqFcnSetNatRev      \* refused
 ASSUME TupleSetEqFcnSetEmptyRev
 ASSUME TupleSetEqRcdSetEmptyRev
+\* ASSUME TupleSetEqRcdSetNatRev    \* refused
 ASSUME RcdSetIsFcnSetRev
 ASSUME TupleSetIsFcnSetRev
 
@@ -366,12 +391,19 @@ ASSUME InUnitFilter
 
 ASSUME InUnitRcdField
 ASSUME InUnitRcdFieldNat
+\* ASSUME InUnitRcdNatField         \* refused
 ASSUME InUnitTuple
 ASSUME InUnitTupleNatSecond
+\* ASSUME InUnitTupleNatFirst       \* refused
+\* ASSUME InUnitTupleStrFirst       \* refused
 ASSUME InUnitFcnSet
+\* ASSUME InUnitFcnSetNat           \* refused
+\* ASSUME InUnitFcnSetNested        \* refused
 
+\* ASSUME InUnitRcdFcnSet           \* refused
 ASSUME InUnitRcdRcd
 ASSUME InUnitRcdTuple
+\* ASSUME InUnitTupleFcnSet         \* refused
 ASSUME InUnitTupleRcd
 ASSUME InUnitTupleTuple
 
@@ -438,7 +470,9 @@ ASSUME InFcnSetNatRange
 \* The remaining operator that has to agree with the comparisons above.
 
 ASSUME SubsetUnitRanges
+\* ASSUME SubsetUnitNatRange        \* refused
 ASSUME SubsetEmptyDomain
+\* ASSUME SubsetEmptyNatDomain      \* refused
 
 -----------------------------------------------------------------------------
 \* The rendering that TLC prints for the same sets, which has to agree with
@@ -461,6 +495,7 @@ ASSUME ToString([n1 : 1..50000, n2 : 1..50000, n3 : {}]) = "{}"
 ASSUME ToString((1..50000) \X (1..50000) \X {})          = "{}"
 ASSUME ToString([{} -> (SUBSET (1..40))])                = "{<<>>}"
 ASSUME ToString([{} -> ((1..50000) \X (1..50000))])      = "{<<>>}"
+\* ASSUME ToString([{} -> Nat])                          = "{<<>>}"  \* refused
 
 ASSUME ToString([n1 : 1..50000, n2 : 1..50000]) = "[n1: 1..50000, n2: 1..50000]"
 
@@ -650,6 +685,20 @@ ASSUME AssertError("Shouldn't call isEmpty() on value \"s\"", FcnStrLitReflexive
 ASSUME AssertError("Shouldn't call isEmpty() on value <<1>>", FcnTupleReflexive)
 ASSUME AssertError("Shouldn't call isEmpty() on value 1", RcdIntReflexive)
 ASSUME AssertError("Shouldn't call isEmpty() on value 1", TupIntReflexive)
+
+\* Two comparisons of { } with a set of functions that is not empty, which
+\* record a limitation as well. EmptySetEqCases_proofs.tla derives both from
+\* ESE_FcnSetEmpty: a set of functions is empty only for an empty co-domain,
+\* and 0 \in Nat rules that out whatever the domain is.
+\*
+\* These two stay refused past the commit that fixes the ones above, because
+\* TLC answers by enumerating rather than by reading the co-domain, and a
+\* domain that has an element asks for one enumeration of the co-domain per
+\* element, which is what TLC cannot do for Nat.
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
+                   EmptyDiffNatRangeEnum)
+ASSUME AssertError("Attempted to enumerate a set of the form [D -> R],but the range R:\nNat\ncannot be enumerated.",
+                   EmptyDiffIntervalNatEnum)
 
 \* The cardinality that records a limitation as well.
 \*

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -14,8 +14,10 @@
 \* the Sym suffix the form that compares it with the most reduced form of the
 \* input's own constructor: [{} -> {"ref"}] and [{"ref"} -> {}] for a set of
 \* functions, [ref : {}] for a set of records, and {"ref"} \X {} for a
-\* Cartesian product. An input that TLC cannot enumerate has the Sym form
-\* only. The Rev suffix names the form whose operands are swapped, i.e. the
+\* Cartesian product. An input whose constructor makes it { } or { <<>> } has
+\* both forms even where TLC cannot enumerate the arguments of that
+\* constructor, because the enumeration is then the reduced form itself.
+\* The Rev suffix names the form whose operands are swapped, i.e. the
 \* exception to the order above, for the reason given in the section carrying
 \* it.
 \*
@@ -32,10 +34,12 @@ UnitSingletonRangeEnum == { <<>> }        = [{} -> {"d1"}]
 UnitSingletonRangeSym  == [{} -> {"ref"}] = [{} -> {"d1"}]
 UnitTripleRangeEnum    == { <<>> }        = [{} -> {"a", "b", "c"}]
 UnitTripleRangeSym     == [{} -> {"ref"}] = [{} -> {"a", "b", "c"}]
+UnitNatRangeEnum       == { <<>> }        = [{} -> Nat]
 UnitNatRangeSym        == [{} -> {"ref"}] = [{} -> Nat]
 
 UnitIntervalEnum       == { <<>> }        = [1..0 -> {"d1"}]
 UnitIntervalSym        == [{} -> {"ref"}] = [1..0 -> {"d1"}]
+UnitIntervalNatEnum    == { <<>> }        = [1..0 -> Nat]
 UnitIntervalNatSym     == [{} -> {"ref"}] = [1..0 -> Nat]
 
 UnitCapEnum            == { <<>> }        = [({"d1"} \cap {"d2"}) -> {"e1"}]
@@ -54,19 +58,24 @@ UnitFilterSym          == [{} -> {"ref"}] = [{d \in {"d1"} : FALSE} -> {"e1"}]
 \* The domain is a set of records.
 UnitRcdFieldEnum       == { <<>> }        = [[n1 : {}] -> {"e1"}]
 UnitRcdFieldSym        == [{} -> {"ref"}] = [[n1 : {}] -> {"e1"}]
+UnitRcdNatFieldEnum    == { <<>> }        = [[n1 : Nat, n2 : {}] -> {"d1"}]
 UnitRcdNatFieldSym     == [{} -> {"ref"}] = [[n1 : Nat, n2 : {}] -> {"d1"}]
 UnitRcdFieldNatSym     == [{} -> {"ref"}] = [[n1 : {}, n2 : Nat] -> {"d1"}]
 
 \* The domain is a Cartesian product.
 UnitTupleEnum          == { <<>> }        = [({"d1"} \X {}) -> {"e1"}]
 UnitTupleSym           == [{} -> {"ref"}] = [({"d1"} \X {}) -> {"e1"}]
+UnitTupleNatFirstEnum  == { <<>> }        = [(Nat \X {}) -> {"d1"}]
 UnitTupleNatFirstSym   == [{} -> {"ref"}] = [(Nat \X {}) -> {"d1"}]
 UnitTupleNatSecondSym  == [{} -> {"ref"}] = [({} \X Nat) -> {"d1"}]
 UnitTupleStrFirstSym   == [{} -> {"ref"}] = [(STRING \X {}) -> {"d1"}]
 
 \* The domain is a set of functions that is itself empty.
+UnitFcnSetEnum         == { <<>> }        = [[Nat -> {}] -> {"d2"}]
 UnitFcnSetSym          == [{} -> {"ref"}] = [[Nat -> {}] -> {"d2"}]
 UnitFcnSetNestedSym    == [{} -> {"ref"}] = [[[Nat -> {"d1"}] -> {}] -> {"d2"}]
+
+UnitFcnSetNatRangeEnum == { <<>> }        = [[Nat -> {}] -> Nat]
 
 \* The domain is a set of functions that denotes { <<>> } instead of {}, i.e.
 \* it is a singleton, which is what makes these sets differ.
@@ -105,18 +114,24 @@ EmptyFilterSym           == [{"ref"} -> {}] = [{d \in {"d1"} : TRUE} -> {}]
 \* SUBSET S contains {} for every S, i.e. it is never empty.
 EmptySubsetEmptyEnum     == { }             = [(SUBSET {}) -> {}]
 EmptySubsetEmptySym      == [{"ref"} -> {}] = [(SUBSET {}) -> {}]
+EmptySubsetNatEnum       == { }             = [(SUBSET Nat) -> {}]
 EmptySubsetNatSym        == [{"ref"} -> {}] = [(SUBSET Nat) -> {}]
 
 EmptyRcdEnum             == { }             = [[n1 : {"d1"}] -> {}]
 EmptyRcdSym              == [{"ref"} -> {}] = [[n1 : {"d1"}] -> {}]
+EmptyRcdNatEnum          == { }             = [[n1 : Nat] -> {}]
 EmptyRcdNatSym           == [{"ref"} -> {}] = [[n1 : Nat] -> {}]
 
 EmptyTupleEnum           == { }             = [({"d1"} \X {"d1"}) -> {}]
 EmptyTupleSym            == [{"ref"} -> {}] = [({"d1"} \X {"d1"}) -> {}]
+EmptyTupleNatEnum        == { }             = [(Nat \X {"d1"}) -> {}]
 EmptyTupleNatSym         == [{"ref"} -> {}] = [(Nat \X {"d1"}) -> {}]
 
+EmptyNatEnum             == { }             = [Nat -> {}]
 EmptyNatSym              == [{"ref"} -> {}] = [Nat -> {}]
+EmptyIntEnum             == { }             = [Int -> {}]
 EmptyIntSym              == [{"ref"} -> {}] = [Int -> {}]
+EmptySeqEnum             == { }             = [Seq({"d1"}) -> {}]
 EmptySeqSym              == [{"ref"} -> {}] = [Seq({"d1"}) -> {}]
 EmptyStrSym              == [{"ref"} -> {}] = [STRING -> {}]
 
@@ -128,6 +143,7 @@ EmptyTupleFcnSetRangeSym == [{"ref"} -> {}] = [{"d1"} -> ({"d1"} \X [Nat -> {}])
 EmptyFcnSetRangeSym      == [{"ref"} -> {}] = [{"x1"} -> [{"y"} -> [Nat -> {}]]]
 
 \* The domain is a set of functions that is non-empty.
+EmptyFcnSetEnum          == { }             = [[Nat -> {"d1"}] -> {}]
 EmptyFcnSetSym           == [{"ref"} -> {}] = [[Nat -> {"d1"}] -> {}]
 
 -----------------------------------------------------------------------------
@@ -141,6 +157,7 @@ RcdEmptyArityEnum    == { }        = [n1 : {}, n2 : {"r1"}]
 RcdEmptyAritySym     == [ref : {}] = [n1 : {}, n2 : {"r1"}]
 RcdEmptyIntervalEnum == { }        = [n1 : 1..0, n2 : {"r1"}]
 RcdEmptyIntervalSym  == [ref : {}] = [n1 : 1..0, n2 : {"r1"}]
+RcdEmptyNatFieldEnum == { }        = [n1 : Nat, n2 : {}]
 RcdEmptyNatFieldSym  == [ref : {}] = [n1 : Nat, n2 : {}]
 RcdEmptyFieldNatSym  == [ref : {}] = [n1 : {}, n2 : Nat]
 RcdEmptySeqFieldSym  == [ref : {}] = [n1 : Seq({"d1"}), n2 : {}]
@@ -169,6 +186,7 @@ TupEmptyArityEnum     == { }             = ({} \X {"r1"} \X {"r2"})
 TupEmptyAritySym      == ({"ref"} \X {}) = ({} \X {"r1"} \X {"r2"})
 TupEmptyIntervalEnum  == { }             = ((1..0) \X {"r1"})
 TupEmptyIntervalSym   == ({"ref"} \X {}) = ((1..0) \X {"r1"})
+TupEmptyNatFirstEnum  == { }             = (Nat \X {})
 TupEmptyNatFirstSym   == ({"ref"} \X {}) = (Nat \X {})
 TupEmptyNatSecondSym  == ({"ref"} \X {}) = ({} \X Nat)
 TupEmptySeqFirstSym   == ({"ref"} \X {}) = (Seq({"d1"}) \X {})
@@ -185,12 +203,16 @@ TupEmptyTupleSym      == ({"ref"} \X {}) = (({"d1"} \X {}) \X {"d1"})
 TupEmptyThenDiffSym   == ({"ref"} \X {}) = ({} \X (Nat \ {0}))
 
 -----------------------------------------------------------------------------
-\* Two sets of different constructors. TLC enumerates both instead of taking
-\* the emptiness rules, so only the enumerable ones are here and the rest are
-\* AssertError assumptions of EmptySetEqAssume.tla.
+\* Two sets of different constructors, which TLC decides by enumerating both
+\* instead of taking the emptiness rules. An empty argument makes that
+\* enumeration empty, so the ones whose arguments TLC cannot enumerate are
+\* refused assumptions of EmptySetEqAssume.tla until the commit that has TLC
+\* read that rule.
 
 FcnSetEqRcdSetEmpty   == [{"ref"} -> {}] = [n1 : {}]
+FcnSetEqRcdSetNat     == [Nat -> {}]     = [n1 : {}]
 FcnSetEqTupleSetEmpty == [{"ref"} -> {}] = ({} \X {"r1"})
+FcnSetEqTupleSetNat   == [Nat -> {}]     = ({} \X {"r1"})
 RcdSetEqTupleSetEmpty == [ref : {}]      = ({} \X {"r1"})
 UnitDiffRcdSetEmpty   == [{} -> {"ref"}] # [n1 : {}]
 UnitDiffTupleSetEmpty == [{} -> {"ref"}] # ({} \X {"r1"})
@@ -213,6 +235,7 @@ TupleSetIsFcnSet3 == [1..3 -> {"a"}]      = ({"a"} \X {"a"} \X {"a"})
 UnitEmptyRangeRev     == [{} -> {}]               = { <<>> }
 UnitSingletonRangeRev == [{} -> {"d1"}]           = { <<>> }
 EmptySingletonRev     == [{"r1"} -> {}]           = { }
+EmptyNatRev           == [Nat -> {}]              = { }
 RcdEmptyFieldRev      == [n1 : {}]                = { }
 RcdEmptyArityRev      == [n1 : {}, n2 : {"r1"}]   = { }
 TupEmptyComponentRev  == ({} \X {"r1"})           = { }
@@ -221,8 +244,10 @@ TupEmptyArityRev      == ({} \X {"r1"} \X {"r2"}) = { }
 \* Two sets of different constructors, with the one that the section above
 \* keeps on the right on the left instead.
 RcdSetEqFcnSetEmptyRev   == [n1 : {}]      = [{"ref"} -> {}]
+RcdSetEqFcnSetNatRev     == [n1 : {}]      = [Nat -> {}]
 TupleSetEqFcnSetEmptyRev == ({} \X {"r1"}) = [{"ref"} -> {}]
 TupleSetEqRcdSetEmptyRev == ({} \X {"r1"}) = [ref : {}]
+TupleSetEqRcdSetNatRev   == ({} \X {"r1"}) = [n1 : Nat, n2 : {}]
 RcdSetIsFcnSetRev        == [n1 : {"a"}]   = [{"n1"} -> {"a"}]
 TupleSetIsFcnSetRev      == ({"a", "b"} \X {"a", "b"}) = [1..2 -> {"a", "b"}]
 
@@ -458,6 +483,12 @@ TupNatReflexive == (Nat \X {"d1"}) = (Nat \X {"d1"})
 TupNatIntDiffer == (Nat \X {"d1"}) # (Int \X {"d1"})
 TupStrReflexive == (STRING \X {"d1"}) = (STRING \X {"d1"})
 
+\* The same sets against { }, which the co-domain alone decides: a set of
+\* functions is empty only for an empty co-domain, and 0 \in Nat rules that
+\* out whatever the domain is.
+EmptyDiffNatRangeEnum    == { } # [{"d1"} -> Nat]
+EmptyDiffIntervalNatEnum == { } # [1..2 -> Nat]
+
 -----------------------------------------------------------------------------
 \* Sets built from a value whose emptiness TLA+ leaves open, i.e. congruence
 \* is the only means left to decide these. Every TLA+ value is a set, but
@@ -637,5 +668,7 @@ InFcnSetNatRange == [d \in {"d1"} |-> 0] \in [{"d1"} -> Nat]
 \* The same sets read through \subseteq, which has to agree as well.
 
 SubsetUnitRanges     == [{} -> {"d1"}] \subseteq [{} -> Nat]
+SubsetUnitNatRange   == [{} -> Nat]    \subseteq [{} -> {"d1"}]
 SubsetEmptyDomain    == [{"r1"} -> {}] \subseteq [Nat -> {}]
+SubsetEmptyNatDomain == [Nat -> {}]    \subseteq [{"r1"} -> {}]
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases.tla
@@ -205,9 +205,7 @@ TupEmptyThenDiffSym   == ({"ref"} \X {}) = ({} \X (Nat \ {0}))
 -----------------------------------------------------------------------------
 \* Two sets of different constructors, which TLC decides by enumerating both
 \* instead of taking the emptiness rules. An empty argument makes that
-\* enumeration empty, so the ones whose arguments TLC cannot enumerate are
-\* refused assumptions of EmptySetEqAssume.tla until the commit that has TLC
-\* read that rule.
+\* enumeration empty, so an argument that TLC cannot enumerate is no obstacle.
 
 FcnSetEqRcdSetEmpty   == [{"ref"} -> {}] = [n1 : {}]
 FcnSetEqRcdSetNat     == [Nat -> {}]     = [n1 : {}]

--- a/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
+++ b/tlatools/org.lamport.tlatools/test-model/EmptySetEqCases_proofs.tla
@@ -58,6 +58,9 @@ THEOREM UnitTripleRangeEnum
 THEOREM UnitTripleRangeSym
   BY RefUnit, ESE_UnitDomain DEF UnitTripleRangeSym
 
+THEOREM UnitNatRangeEnum
+  BY ESE_UnitDomain DEF UnitNatRangeEnum
+
 THEOREM UnitNatRangeSym
   BY RefUnit, ESE_UnitDomain DEF UnitNatRangeSym
 
@@ -70,6 +73,11 @@ THEOREM UnitIntervalSym
   <1>1. 1..0 = {}
     OBVIOUS
   <1>2. QED BY <1>1, RefUnit, ESE_UnitDomain DEF UnitIntervalSym
+
+THEOREM UnitIntervalNatEnum
+  <1>1. 1..0 = {}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomain DEF UnitIntervalNatEnum
 
 THEOREM UnitIntervalNatSym
   <1>1. 1..0 = {}
@@ -144,6 +152,9 @@ THEOREM UnitRcdFieldEnum
 THEOREM UnitRcdFieldSym
   BY RefUnit, ESE_UnitDomainRcd1 DEF UnitRcdFieldSym
 
+THEOREM UnitRcdNatFieldEnum
+  BY ESE_UnitDomainRcd DEF UnitRcdNatFieldEnum
+
 THEOREM UnitRcdNatFieldSym
   BY RefUnit, ESE_UnitDomainRcd DEF UnitRcdNatFieldSym
 
@@ -158,6 +169,9 @@ THEOREM UnitTupleEnum
 THEOREM UnitTupleSym
   BY RefUnit, ESE_UnitDomainTuple DEF UnitTupleSym
 
+THEOREM UnitTupleNatFirstEnum
+  BY ESE_UnitDomainTuple DEF UnitTupleNatFirstEnum
+
 THEOREM UnitTupleNatFirstSym
   BY RefUnit, ESE_UnitDomainTuple DEF UnitTupleNatFirstSym
 
@@ -169,6 +183,11 @@ THEOREM UnitTupleStrFirstSym
 
 \* The domain is a set of functions that is itself empty.
 
+THEOREM UnitFcnSetEnum
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomainFcnSet DEF UnitFcnSetEnum
+
 THEOREM UnitFcnSetSym
   <1>1. 0 \in Nat
     OBVIOUS
@@ -178,6 +197,11 @@ THEOREM UnitFcnSetNestedSym
   <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
     OBVIOUS
   <1>2. QED BY <1>1, RefUnit, ESE_UnitDomainFcnSet DEF UnitFcnSetNestedSym
+
+THEOREM UnitFcnSetNatRangeEnum
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_UnitDomainFcnSet DEF UnitFcnSetNatRangeEnum
 
 \* The domain is a set of functions that denotes { <<>> }, i.e. the domains of
 \* the two sets are { <<>> } and {}, which ESE_DomainDecides tells apart.
@@ -318,6 +342,11 @@ THEOREM EmptySubsetEmptySym
     OBVIOUS
   <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptySubsetEmptySym
 
+THEOREM EmptySubsetNatEnum
+  <1>1. {} \in SUBSET Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptySubsetNatEnum
+
 THEOREM EmptySubsetNatSym
   <1>1. {} \in SUBSET Nat
     OBVIOUS
@@ -332,6 +361,11 @@ THEOREM EmptyRcdSym
   <1>1. [n1 |-> "d1"] \in [n1 : {"d1"}]
     OBVIOUS
   <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyRcdSym
+
+THEOREM EmptyRcdNatEnum
+  <1>1. [n1 |-> 0] \in [n1 : Nat]
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyRcdNatEnum
 
 THEOREM EmptyRcdNatSym
   <1>1. [n1 |-> 0] \in [n1 : Nat]
@@ -348,18 +382,38 @@ THEOREM EmptyTupleSym
     OBVIOUS
   <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyTupleSym
 
+THEOREM EmptyTupleNatEnum
+  <1>1. <<0, "d1">> \in Nat \X {"d1"}
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyTupleNatEnum
+
 THEOREM EmptyTupleNatSym
   <1>1. <<0, "d1">> \in Nat \X {"d1"}
     OBVIOUS
   <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyTupleNatSym
 
+THEOREM EmptyNatEnum
+  BY NatToEmpty DEF EmptyNatEnum
+
 THEOREM EmptyNatSym
   BY NatToEmpty, RefEmpty DEF EmptyNatSym
+
+THEOREM EmptyIntEnum
+  <1>1. 0 \in Int
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyIntEnum
 
 THEOREM EmptyIntSym
   <1>1. 0 \in Int
     OBVIOUS
   <1>2. QED BY <1>1, RefEmpty, ESE_EmptyRange DEF EmptyIntSym
+
+THEOREM EmptySeqEnum
+  <1>1. <<>> \in Seq({"d1"})
+    <2>1. <<>> \in [1..0 -> {"d1"}]
+      OBVIOUS
+    <2>2. QED BY <2>1
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptySeqEnum
 
 THEOREM EmptySeqSym
   <1>1. <<>> \in Seq({"d1"})
@@ -415,6 +469,11 @@ THEOREM EmptyFcnSetRangeSym
 
 \* The domain is a set of functions that is non-empty.
 
+THEOREM EmptyFcnSetEnum
+  <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptyFcnSetEnum
+
 THEOREM EmptyFcnSetSym
   <1>1. [n \in Nat |-> "d1"] \in [Nat -> {"d1"}]
     OBVIOUS
@@ -449,6 +508,9 @@ THEOREM RcdEmptyIntervalSym
   <1>1. 1..0 = {}
     OBVIOUS
   <1>2. QED BY <1>1, RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyIntervalSym
+
+THEOREM RcdEmptyNatFieldEnum
+  BY ESE_RcdSetEmpty DEF RcdEmptyNatFieldEnum
 
 THEOREM RcdEmptyNatFieldSym
   BY RefRcdEmpty, ESE_RcdSetEmpty DEF RcdEmptyNatFieldSym
@@ -509,6 +571,9 @@ THEOREM TupEmptyIntervalSym
     OBVIOUS
   <1>2. QED BY <1>1, RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyIntervalSym
 
+THEOREM TupEmptyNatFirstEnum
+  BY ESE_TupleSetEmpty DEF TupEmptyNatFirstEnum
+
 THEOREM TupEmptyNatFirstSym
   BY RefTupEmpty, ESE_TupleSetEmpty DEF TupEmptyNatFirstSym
 
@@ -546,8 +611,14 @@ THEOREM TupEmptyThenDiffSym
 THEOREM FcnSetEqRcdSetEmpty
   BY RefEmpty, ESE_RcdSetEmpty1 DEF FcnSetEqRcdSetEmpty
 
+THEOREM FcnSetEqRcdSetNat
+  BY NatToEmpty, ESE_RcdSetEmpty1 DEF FcnSetEqRcdSetNat
+
 THEOREM FcnSetEqTupleSetEmpty
   BY RefEmpty, ESE_TupleSetEmpty DEF FcnSetEqTupleSetEmpty
+
+THEOREM FcnSetEqTupleSetNat
+  BY NatToEmpty, ESE_TupleSetEmpty DEF FcnSetEqTupleSetNat
 
 THEOREM RcdSetEqTupleSetEmpty
   BY RefRcdEmpty, ESE_TupleSetEmpty DEF RcdSetEqTupleSetEmpty
@@ -590,6 +661,9 @@ THEOREM EmptySingletonRev
     OBVIOUS
   <1>2. QED BY <1>1, ESE_EmptyRange DEF EmptySingletonRev
 
+THEOREM EmptyNatRev
+  BY NatToEmpty DEF EmptyNatRev
+
 THEOREM RcdEmptyFieldRev
   BY ESE_RcdSetEmpty1 DEF RcdEmptyFieldRev
 
@@ -605,11 +679,17 @@ THEOREM TupEmptyArityRev
 THEOREM RcdSetEqFcnSetEmptyRev
   BY RefEmpty, ESE_RcdSetEmpty1 DEF RcdSetEqFcnSetEmptyRev
 
+THEOREM RcdSetEqFcnSetNatRev
+  BY NatToEmpty, ESE_RcdSetEmpty1 DEF RcdSetEqFcnSetNatRev
+
 THEOREM TupleSetEqFcnSetEmptyRev
   BY RefEmpty, ESE_TupleSetEmpty DEF TupleSetEqFcnSetEmptyRev
 
 THEOREM TupleSetEqRcdSetEmptyRev
   BY RefRcdEmpty, ESE_TupleSetEmpty DEF TupleSetEqRcdSetEmptyRev
+
+THEOREM TupleSetEqRcdSetNatRev
+  BY ESE_RcdSetEmpty, ESE_TupleSetEmpty DEF TupleSetEqRcdSetNatRev
 
 THEOREM RcdSetIsFcnSetRev
   BY ESE_RcdSetIsFcnSet DEF RcdSetIsFcnSetRev
@@ -1270,6 +1350,19 @@ THEOREM TupNatIntDiffer
 THEOREM TupStrReflexive
   BY DEF TupStrReflexive
 
+\* ESE_FcnSetEmpty makes [S -> T] empty only for an empty T, so a witness in
+\* the co-domain settles both of these without a look at the domain.
+
+THEOREM EmptyDiffNatRangeEnum
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_FcnSetEmpty DEF EmptyDiffNatRangeEnum
+
+THEOREM EmptyDiffIntervalNatEnum
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_FcnSetEmpty DEF EmptyDiffIntervalNatEnum
+
 -----------------------------------------------------------------------------
 \* Sets built from a value whose emptiness TLA+ leaves open, where the
 \* congruence rules are all that is left. No witness w \in 1 exists to
@@ -1834,8 +1927,16 @@ THEOREM InFcnSetNatRange
 THEOREM SubsetUnitRanges
   BY ESE_UnitSubset DEF SubsetUnitRanges
 
+THEOREM SubsetUnitNatRange
+  BY ESE_UnitSubset DEF SubsetUnitNatRange
+
 THEOREM SubsetEmptyDomain
   <1>1. "r1" \in {"r1"}
     OBVIOUS
   <1>2. QED BY <1>1, ESE_EmptySubset DEF SubsetEmptyDomain
+
+THEOREM SubsetEmptyNatDomain
+  <1>1. 0 \in Nat
+    OBVIOUS
+  <1>2. QED BY <1>1, ESE_EmptySubset DEF SubsetEmptyNatDomain
 =============================================================================

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/SetOfFcnsValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/SetOfFcnsValueTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,6 +41,7 @@ import java.util.stream.IntStream;
 
 import org.junit.Test;
 
+import tlc2.module.Naturals;
 import tlc2.util.FP64;
 import tlc2.value.impl.SetOfFcnsValue.SubsetEnumerator;
 import util.Assert.TLCRuntimeException;
@@ -388,5 +390,66 @@ public class SetOfFcnsValueTest {
 				fail();
 			}
 		});
+	}
+
+	// [Nat -> {}] = {}, so there is no element to enumerate, whereas enumerating
+	// the domain Nat is what TLC cannot do.
+	@Test
+	public void testEmptyNonEnumerableDomain() {
+		final SetOfFcnsValue fcns = new SetOfFcnsValue(Naturals.Nat(), new SetEnumValue());
+
+		assertEquals(0, fcns.elements().all().size());
+	}
+
+	// [{} -> Nat] = {<<>>}, i.e. the empty domain says which functions there are
+	// without the co-domain Nat enumerated.
+	@Test
+	public void testUnitNonEnumerableRange() {
+		final SetOfFcnsValue fcns = new SetOfFcnsValue(new SetEnumValue(), Naturals.Nat());
+
+		assertEquals(Collections.singletonList(FcnRcdValue.EmptyFcn), fcns.elements().all());
+	}
+
+	// The same set written with an interval as its domain, which elements()
+	// answers with DomIVEnumerator instead of Enumerator.
+	@Test
+	public void testUnitNonEnumerableRangeInterval() {
+		final SetOfFcnsValue fcns = new SetOfFcnsValue(new IntervalValue(1, 0), Naturals.Nat());
+
+		assertEquals(Collections.singletonList(FcnRcdValue.EmptyFcn), fcns.elements().all());
+	}
+
+	// A domain with an element asks for one enumeration of the co-domain per
+	// element, so Nat is an obstacle here where the empty domains above ask for
+	// none. Both enumerators have to say so rather than fail on the cast of a
+	// co-domain that is not Enumerable.
+	@Test
+	public void testNonEnumerableRange() {
+		final SetOfFcnsValue fcns = new SetOfFcnsValue(new SetEnumValue(getValue("d1"), true),
+				Naturals.Nat());
+
+		try {
+			fcns.elements();
+		} catch (TLCRuntimeException e) {
+			assertEquals("Attempted to enumerate a set of the form [D -> R],"
+					+ "but the range R:\nNat\ncannot be enumerated.", e.getMessage());
+			return;
+		}
+		fail();
+	}
+
+	// The same co-domain under DomIVEnumerator instead of Enumerator.
+	@Test
+	public void testNonEnumerableRangeInterval() {
+		final SetOfFcnsValue fcns = new SetOfFcnsValue(new IntervalValue(1, 2), Naturals.Nat());
+
+		try {
+			fcns.elements();
+		} catch (TLCRuntimeException e) {
+			assertEquals("Attempted to enumerate a set of the form [D -> R],"
+					+ "but the range R:\nNat\ncannot be enumerated.", e.getMessage());
+			return;
+		}
+		fail();
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/SetOfRcrdValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/SetOfRcrdValueTest.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import tlc2.module.Naturals;
 import tlc2.util.FP64;
 import tlc2.value.impl.SetOfRcdsValue.SubsetEnumerator;
 import util.UniqueString;
@@ -192,5 +193,15 @@ public class SetOfRcrdValueTest {
 		}
 
 		assertEquals(k, randomsubsetValues.size());
+	}
+
+	// [N0 : Nat, N1 : {}] = {}, so there is no element to enumerate, whereas
+	// enumerating Nat is what TLC cannot do.
+	@Test
+	public void testEmptyNonEnumerableField() {
+		final SetOfRcdsValue rcds = new SetOfRcdsValue(getNames(2),
+				new Value[] { Naturals.Nat(), new SetEnumValue() }, false);
+
+		assertEquals(0, rcds.elements().all().size());
 	}
 }

--- a/tlatools/org.lamport.tlatools/test/tlc2/value/impl/SetOfTuplesValueTest.java
+++ b/tlatools/org.lamport.tlatools/test/tlc2/value/impl/SetOfTuplesValueTest.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import tlc2.TLCGlobals;
+import tlc2.module.Naturals;
 import tlc2.value.impl.IntervalValue;
 import tlc2.value.impl.SetOfTuplesValue;
 
@@ -46,5 +47,15 @@ public class SetOfTuplesValueTest {
 		final SetOfTuplesValue outter = new SetOfTuplesValue(inner, inner);
 		assertTrue(outter.toString().contains("\\X"));
 		assertEquals("((1..2 \\X 1..2) \\X (1..2 \\X 1..2))", outter.toString());
+	}
+
+	// Nat \X {} = {}, so there is no element to enumerate, whereas enumerating Nat
+	// is what TLC cannot do.
+	@Test
+	public void testEmptyNonEnumerableComponent() {
+		final SetOfTuplesValue product = new SetOfTuplesValue(
+				new Value[] { Naturals.Nat(), new SetEnumValue() });
+
+		assertEquals(0, product.elements().all().size());
 	}
 }


### PR DESCRIPTION
NT