### PR TITLE
Fix parsing of a named theorem following a submodule

### DIFF
--- a/tlatools/org.lamport.tlatools/javacc/tla+.jj
+++ b/tlatools/org.lamport.tlatools/javacc/tla+.jj
@@ -266,7 +266,9 @@ public class TLAplusParser implements tla2sany.st.SyntaxTreeConstants, ParseTree
            * date described below.                                         *
            ****************************************************************/
            && nextT.kind != ASSUMPTION 
-           && nextT.kind != END_MODULE) {
+           && nextT.kind != END_MODULE
+           && currentT.kind != THEOREM
+           && currentT.kind != PROPOSITION) {
       /*********************************************************************
       * As long as we have not yet reached the end of the stream or a      *
       * THEOREM, ASSUME, or END_MODULE token, move forward through the     *

--- a/tlatools/org.lamport.tlatools/src/tla2sany/parser/TLAplusParser.java
+++ b/tlatools/org.lamport.tlatools/src/tla2sany/parser/TLAplusParser.java
@@ -177,7 +177,9 @@ public class TLAplusParser implements tla2sany.st.SyntaxTreeConstants, ParseTree
            * date described below.                                         *
            ****************************************************************/
            && nextT.kind != ASSUMPTION
-           && nextT.kind != END_MODULE) {
+           && nextT.kind != END_MODULE
+           && currentT.kind != THEOREM
+           && currentT.kind != PROPOSITION) {
       /*********************************************************************
       * As long as we have not yet reached the end of the stream or a      *
       * THEOREM, ASSUME, or END_MODULE token, move forward through the     *

--- a/tlatools/org.lamport.tlatools/test/tla2sany/parser/TlaPlusSyntaxCorpusTests.java
+++ b/tlatools/org.lamport.tlatools/test/tla2sany/parser/TlaPlusSyntaxCorpusTests.java
@@ -88,9 +88,6 @@ public class TlaPlusSyntaxCorpusTests {
 				// Ref https://github.com/tlaplus/tlapm/issues/162
 				"Cartesian Product as Parameter",
 
-				// https://github.com/tlaplus/tlaplus/issues/430
-				"Named Theorem After Submodule (GH tlaplus/tlaplus #430)",
-
 				// https://github.com/tlaplus/tlaplus/issues/487
 				"Conjunct Inside Ambiguous Case (GH tlaplus/tlaplus #487)",
 				"Unicode Conjunct Inside Ambiguous Case (GH tlaplus/tlaplus #487)",


### PR DESCRIPTION
belchDEF() is invoked in Body() after a Module() definition to insert a DEFBREAK before the next "==", which OperatorOrFunctionDefinition() needs to recognize the start of a definition. Its scanning loop stopped only on nextT.kind, never on currentT.kind, so when the token immediately after a submodule was a THEOREM (or PROPOSITION/LEMMA/COROLLARY), the loop still stepped onto the theorem's name and "==" and inserted a DEFBREAK between the THEOREM keyword and its name. That corrupts the token stream and makes the Theorem() lookahead fail, so the theorem was never consumed as a body element and EndModule() failed with "Encountered THEOREM ... expecting ====" (https://github.com/tlaplus/tlaplus/issues/430).

The while condition now also stops when currentT itself is a THEOREM or PROPOSITION token, so a theorem following a submodule is left untouched for Theorem() to parse. Named theorems/propositions/lemmas/corollaries in plain modules and definitions following a submodule are unaffected.

TLAplusParser.java was regenerated, and the corresponding corpus test was removed from the expected-failures list.

Part of the work on the integration of the SANY backend in tlapm: https://github.com/tlaplus/tlapm/pull/275

[Bug][SANY][Changelog]